### PR TITLE
renaming ParameterTree to ParameterContainer as per previous discussions

### DIFF
--- a/spec.py
+++ b/spec.py
@@ -52,7 +52,7 @@ ParameterShapeTree = Dict[str, Dict[str, Shape]]
 # structure, to get an iterator over pairs of leaves.
 ParameterKey = str
 # Dicts can be arbitrarily nested.
-ParameterTree = Dict[ParameterKey, Dict[ParameterKey, Tensor]]
+ParameterContainer = Dict[ParameterKey, Dict[ParameterKey, Tensor]]
 ParameterTypeTree = Dict[ParameterKey, Dict[ParameterKey, ParameterType]]
 
 RandomState = Any  # Union[jax.random.PRNGKey, int, bytes, ...]
@@ -64,17 +64,17 @@ Steps = int
 
 # BN EMAs.
 ModelAuxiliaryState = Any
-ModelInitState = Tuple[ParameterTree, ModelAuxiliaryState]
+ModelInitState = Tuple[ParameterContainer, ModelAuxiliaryState]
 
 
 UpdateReturn = Tuple[
-    OptimizerState, ParameterTree, ModelAuxiliaryState]
+    OptimizerState, ParameterContainer, ModelAuxiliaryState]
 InitOptimizerFn = Callable[
     [ParameterShapeTree, Hyperparamters, RandomState],
     OptimizerState]
 UpdateParamsFn = Callable[
     [
-        ParameterTree,
+        ParameterContainer,
         ParameterTypeTree,
         ModelAuxiliaryState,
         Hyperparamters,
@@ -91,7 +91,7 @@ DataSelectionFn = Callable[
     [
         Iterator[Tuple[Tensor, Tensor]],
         OptimizerState,
-        ParameterTree,
+        ParameterContainer,
         LossType,
         Hyperparamters,
         int,
@@ -148,7 +148,7 @@ class Workload(metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def is_output_params(self, param_key: ParameterKey) -> bool:
-    """Whether or not a key in ParameterTree is the output layer parameters."""
+    """Whether or not a key in ParameterContainer is the output layer parameters."""
 
   @abc.abstractmethod
   def preprocess_for_train(
@@ -169,19 +169,19 @@ class Workload(metaclass=abc.ABCMeta):
     """return preprocessed_input_batch"""
 
   # InitModelFn = Callable[
-  #     Tuple[ParameterShapeTree, RandomState], ParameterTree]
+  #     Tuple[ParameterShapeTree, RandomState], ParameterContainer]
   @abc.abstractmethod
   def init_model_fn(
-      self, rng: RandomState) -> Tuple[ParameterTree, ModelAuxiliaryState]:
+      self, rng: RandomState) -> Tuple[ParameterContainer, ModelAuxiliaryState]:
     """return initial_params, initial_model_state"""
 
   # ModelFn = Callable[
-  #     Tuple[ParameterTree, Tensor, ForwardPassMode, RandomState, bool],
+  #     Tuple[ParameterContainer, Tensor, ForwardPassMode, RandomState, bool],
   #     Tensor]
   @abc.abstractmethod
   def model_fn(
       self,
-      params: ParameterTree,
+      params: ParameterContainer,
       augmented_and_preprocessed_input_batch: Tensor,
       model_state: ModelAuxiliaryState,
       mode: ForwardPassMode,
@@ -216,7 +216,7 @@ class Workload(metaclass=abc.ABCMeta):
   @abc.abstractmethod
   def eval_model(
       self,
-      params: ParameterTree,
+      params: ParameterContainer,
       model_state: ModelAuxiliaryState,
       rng: RandomState):
     """Run a full evaluation of the model."""
@@ -232,7 +232,7 @@ class TrainingCompleteError(Exception):
 
 def init_optimizer_state(
     workload: Workload,
-    model_params: ParameterTree,
+    model_params: ParameterContainer,
     model_state: ModelAuxiliaryState,
     hyperparameters: Hyperparamters,
     rng: RandomState) -> OptimizerState:
@@ -241,7 +241,7 @@ def init_optimizer_state(
 
 
 _UpdateReturn = Tuple[
-    OptimizerState, ParameterTree, ModelAuxiliaryState]
+    OptimizerState, ParameterContainer, ModelAuxiliaryState]
 # Each call to this function is considered a "step".
 # Can raise a TrainingCompleteError if it believe it has achieved the goal and
 # wants to end the run and receive a final free eval. It will not be restarted,
@@ -250,7 +250,7 @@ _UpdateReturn = Tuple[
 # wait until the next free eval and not use this functionality.
 def update_params(
     workload: Workload,
-    current_params: ParameterTree,
+    current_param_container: ParameterContainer,
     current_params_types: ParameterTypeTree,
     model_state: ModelAuxiliaryState,
     hyperparameters: Hyperparamters,
@@ -272,7 +272,7 @@ def data_selection(
     workload: Workload,
     input_queue: Iterator[Tuple[Tensor, Tensor]],
     optimizer_state: OptimizerState,
-    current_params: ParameterTree,
+    current_param_container: ParameterContainer,
     hyperparameters: Hyperparamters,
     global_step: int,
     rng: RandomState) -> Tuple[Tensor, Tensor]:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -176,7 +176,7 @@ def train_once(
     try:
       optimizer_state, model_params, model_state = update_params(
           workload=workload,
-          current_params=model_params,
+          current_param_container=model_params,
           current_params_types=workload.model_params_types,
           model_state=model_state,
           hyperparameters=hyperparameters,

--- a/workloads/mnist/mnist_jax/workload.py
+++ b/workloads/mnist/mnist_jax/workload.py
@@ -73,7 +73,7 @@ class MnistWorkload(Mnist):
   def model_params_types(self):
     pass
 
-  # Return whether or not a key in spec.ParameterTree is the output layer
+  # Return whether or not a key in spec.ParameterContainer is the output layer
   # parameters.
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     pass
@@ -107,7 +107,7 @@ class MnistWorkload(Mnist):
 
   def model_fn(
       self,
-      params: spec.ParameterTree,
+      params: spec.ParameterContainer,
       augmented_and_preprocessed_input_batch: spec.Tensor,
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,

--- a/workloads/mnist/mnist_pytorch/submission.py
+++ b/workloads/mnist/mnist_pytorch/submission.py
@@ -14,7 +14,7 @@ def get_batch_size(workload_name):
 
 def init_optimizer_state(
     workload: spec.Workload,
-    model_params: spec.ParameterTree,
+    model_params: spec.ParameterContainer,
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparamters,
     rng: spec.RandomState) -> spec.OptimizerState:
@@ -31,7 +31,7 @@ def init_optimizer_state(
 
 def update_params(
     workload: spec.Workload,
-    current_params: spec.ParameterTree,
+    current_param_container: spec.ParameterContainer,
     current_params_types: spec.ParameterTypeTree,
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparamters,
@@ -48,8 +48,8 @@ def update_params(
   del eval_results
   del global_step
 
-  current_model = current_params
-  current_params.train()
+  current_model = current_param_container
+  current_param_container.train()
 
   input_batch = augmented_and_preprocessed_input_batch
   optimizer_state['optimizer'].zero_grad()
@@ -69,7 +69,7 @@ def update_params(
   loss.backward()
   optimizer_state['optimizer'].step()
 
-  return (optimizer_state, current_params, new_model_state)
+  return (optimizer_state, current_param_container, new_model_state)
 
 
 # Not allowed to update the model parameters, hyperparameters, global step, or
@@ -78,7 +78,7 @@ def data_selection(
     workload: spec.Workload,
     input_queue: Iterator[Tuple[spec.Tensor, spec.Tensor]],
     optimizer_state: spec.OptimizerState,
-    current_params: spec.ParameterTree,
+    current_param_container: spec.ParameterContainer,
     hyperparameters: spec.Hyperparamters,
     global_step: int,
     rng: spec.RandomState) -> Tuple[spec.Tensor, spec.Tensor]:
@@ -92,7 +92,7 @@ def data_selection(
   Return a tuple of input label batches.
   """
   del optimizer_state
-  del current_params
+  del current_param_container
   del global_step
   del rng
   return next(input_queue)

--- a/workloads/mnist/mnist_pytorch/workload.py
+++ b/workloads/mnist/mnist_pytorch/workload.py
@@ -82,7 +82,7 @@ class MnistWorkload(Mnist):
   def model_params_types(self):
     pass
 
-  # Return whether or not a key in spec.ParameterTree is the output layer
+  # Return whether or not a key in spec.ParameterContainer is the output layer
   # parameters.
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     pass
@@ -117,7 +117,7 @@ class MnistWorkload(Mnist):
 
   def model_fn(
       self,
-      params: spec.ParameterTree,
+      params: spec.ParameterContainer,
       augmented_and_preprocessed_input_batch: spec.Tensor,
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,

--- a/workloads/mnist/workload.py
+++ b/workloads/mnist/workload.py
@@ -32,7 +32,7 @@ class Mnist(spec.Workload):
 
   def eval_model(
       self,
-      params: spec.ParameterTree,
+      params: spec.ParameterContainer,
       model_state: spec.ModelAuxiliaryState,
       rng: spec.RandomState,
       data_dir: str):


### PR DESCRIPTION
ParameterContainer will be a Union of a model param pytree (used in Jax) or a PyTorch model