### PR TITLE
Small fix for mnist eval ds iterator

### DIFF
--- a/workloads/mnist/workload.py
+++ b/workloads/mnist/workload.py
@@ -1,5 +1,5 @@
-import spec
 import jax
+import spec
 
 class Mnist(spec.Workload):
 
@@ -40,9 +40,8 @@ class Mnist(spec.Workload):
     data_rng, model_rng = jax.random.split(rng, 2)
     eval_batch_size = 2000
     num_batches = 10000 // eval_batch_size
-    if self._eval_ds is None:
-      self._eval_ds = self.build_input_queue(
-          data_rng, 'test', data_dir, batch_size=eval_batch_size)
+    self._eval_ds = self.build_input_queue(
+        data_rng, 'test', data_dir, batch_size=eval_batch_size)
 
     total_metrics = {
         'accuracy': 0.,


### PR DESCRIPTION
It is simpler for the MNIST case to remake the eval dataset each time we eval, because we need to repeat the eval iterator. For larger datasets we may want to repeat the eval dataset more intelligently, being careful to handle final partial batches properly.