### PR TITLE
Adding a pure numpy impl of PRNG split/fold so we don't require jax installs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/*
+__pycache__
 *egg-info
 .vscode/
 env/

--- a/random_utils.py
+++ b/random_utils.py
@@ -1,4 +1,17 @@
+from absl import flags
+from absl import logging
 import numpy as np
+
+try:
+  import jax.random as jax_rng
+except (ImportError, ModuleNotFoundError):
+  logging.warning(
+      'Could not import jax.random for the submission runner, falling back to '
+      'numpy random_utils.')
+  jax_rng = None
+
+FLAGS = flags.FLAGS
+
 
 # Annoyingly, RandomState(seed) requires seed to be in [0, 2 ** 32 - 1] (an
 # unsigned int), while RandomState.randint only accepts and returns signed ints.
@@ -15,16 +28,47 @@ def _signed_to_unsigned(seed):
     return np.array([s + 2 ** 32 if s < 0 else s for s in seed.tolist()])
 
 
-def fold_in(seed, data):
+def _fold_in(seed, data):
   rng = np.random.RandomState(seed=_signed_to_unsigned(seed))
   new_seed = rng.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
   return [new_seed, data]
 
 
-def split(seed, num=2):
+def _split(seed, num=2):
   rng = np.random.RandomState(seed=_signed_to_unsigned(seed))
   return rng.randint(MIN_INT32, MAX_INT32, dtype=np.int32, size=[num, 2])
 
 
-def PRNGKey(seed: int):
+def _PRNGKey(seed: int):
   return split(seed, num=2)[0]
+
+
+# It is usually bad practice to use FLAGS outside of the main() function, but
+# the alternative is having to pipe use_jax_rng to all functions that may need
+# it, which seems unnecessarily cumbersome.
+def _check_jax_install():
+  if jax_rng is None:
+    raise ValueError(
+      'Must install jax to use the jax RNG library, or pass '
+      '--use_jax_rng=false to use the Numpy version instead.')
+
+
+def fold_in(seed, data):
+  if FLAGS.use_jax_rng:
+    _check_jax_install()
+    return jax_rng.fold_in(seed, data)
+  return _fold_in(seed, data)
+
+
+def split(seed, num=2):
+  if FLAGS.use_jax_rng:
+    _check_jax_install()
+    return jax_rng.split(seed, num)
+  return _split(seed, num)
+
+
+def PRNGKey(seed):
+  if FLAGS.use_jax_rng:
+    _check_jax_install()
+    return jax_rng.PRNGKey(seed)
+  return _PRNGKey(seed)

--- a/random_utils.py
+++ b/random_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+# Annoyingly, RandomState(seed) requires seed to be in [0, 2 ** 32 - 1] (an
+# unsigned int), while RandomState.randint only accepts and returns signed ints.
+MAX_INT32 = 2 ** 31
+MIN_INT32 = -MAX_INT32
+
+
+def _signed_to_unsigned(seed):
+  if isinstance(seed, int):
+    return seed + 2 ** 32 if seed < 0 else seed
+  if isinstance(seed, list):
+    return [s + 2 ** 32 if s < 0 else s for s in seed]
+  if isinstance(seed, np.ndarray):
+    return np.array([s + 2 ** 32 if s < 0 else s for s in seed.tolist()])
+
+
+def fold_in(seed, data):
+  rng = np.random.RandomState(seed=_signed_to_unsigned(seed))
+  new_seed = rng.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
+  return [new_seed, data]
+
+
+def split(seed, num=2):
+  rng = np.random.RandomState(seed=_signed_to_unsigned(seed))
+  return rng.randint(MIN_INT32, MAX_INT32, dtype=np.int32, size=[num, 2])
+
+
+def PRNGKey(seed: int):
+  return split(seed, num=2)[0]

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import setup
 
 
 jax_core_deps = [
+    'jax',
     'flax',
     'optax',
     'tensorflow-cpu',
@@ -26,7 +27,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'absl-py',
-        'jax',  # We use Jax for RNG key manipulation.
+        'numpy',
     ],
     extras_require={
         'jax-cpu': jax_core_deps + ['jaxlib'],

--- a/spec.py
+++ b/spec.py
@@ -5,7 +5,6 @@ import time
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
 import abc
-import jax
 
 
 class LossType(enum.Enum):
@@ -192,16 +191,12 @@ class Workload(metaclass=abc.ABCMeta):
 
   # Keep this separate from the loss function in order to support optimizers
   # that use the logits.
+  @abc.abstractmethod
   def output_activation_fn(
       self,
       logits_batch: Tensor,
       loss_type: LossType) -> Tensor:
-    if loss_type == LossType.SOFTMAX_CROSS_ENTROPY:
-      return jax.nn.softmax(logits_batch, axis=-1)
-    if loss_type == LossType.SIGMOID_CROSS_ENTROPY:
-      return jax.nn.sigmoid(logits_batch)
-    if loss_type == LossType.MEAN_SQUARED_ERROR:
-      return logits_batch
+    """Return the final activations of the model."""
 
   # LossFn = Callable[Tuple[Tensor, Tensor], Tensor]
   # Does NOT apply regularization, which is left to the submitter to do in

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -64,7 +64,10 @@ flags.DEFINE_string(
 flags.DEFINE_boolean(
     'use_jax_rng',
     False,
-    'Whether to use the Jax or Numpy RNG library.')
+    'Whether to use the Jax or Numpy RNG library. For PyTorch users, this flag '
+    'should be set to false (the default) so that Jax is not required for the '
+    'run; in addition to adding another dependency, Jax can be aggressive and '
+    'reserve all GPU memory, causing OOMs).')
 
 FLAGS = flags.FLAGS
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -23,12 +23,6 @@ import time
 
 import halton
 import random_utils as prng
-try:
-  import jax.random as prng
-except (ImportError, ModuleNotFoundError):
-  logging.warning(
-      'Could not import jax.random for the submission runner, falling back to '
-      'numpy random_utils.')
 import spec
 
 
@@ -66,8 +60,11 @@ flags.DEFINE_integer(
 flags.DEFINE_string(
     'data_dir',
     '~/',
-    'Dataset location'
-)
+    'Dataset location')
+flags.DEFINE_boolean(
+    'use_jax_rng',
+    False,
+    'Whether to use the Jax or Numpy RNG library.')
 
 FLAGS = flags.FLAGS
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -66,8 +66,8 @@ flags.DEFINE_boolean(
     False,
     'Whether to use the Jax or Numpy RNG library. For PyTorch users, this flag '
     'should be set to false (the default) so that Jax is not required for the '
-    'run; in addition to adding another dependency, Jax can be aggressive and '
-    'reserve all GPU memory, causing OOMs).')
+    'run; in addition to adding another dependency, Jax can default to '
+    'reserving all GPU memory, causing OOMs).')
 
 FLAGS = flags.FLAGS
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -21,8 +21,14 @@ import os
 import struct
 import time
 
-import jax
 import halton
+import random_utils as prng
+try:
+  import jax.random as prng
+except (ImportError, ModuleNotFoundError):
+  logging.warning(
+      'Could not import jax.random for the submission runner, falling back to '
+      'numpy random_utils.')
 import spec
 
 
@@ -128,9 +134,9 @@ def train_once(
     init_optimizer_state: spec.InitOptimizerFn,
     update_params: spec.UpdateParamsFn,
     data_selection: spec.DataSelectionFn,
-    hyperparameters: spec.Hyperparamters,
+    hyperparameters: Optional[spec.Hyperparamters],
     rng: spec.RandomState) -> Tuple[spec.Timing, spec.Steps]:
-  data_rng, opt_init_rng, model_init_rng, rng = jax.random.split(rng, 4)
+  data_rng, opt_init_rng, model_init_rng, rng = prng.split(rng, 4)
 
   # Workload setup.
   input_queue = workload.build_input_queue(
@@ -154,8 +160,8 @@ def train_once(
   global_start_time = time.time()
 
   while (is_time_remaining and not goal_reached and not training_complete):
-    step_rng = jax.random.fold_in(rng, global_step)
-    data_select_rng, preprocess_rng, update_rng, eval_rng = jax.random.split(
+    step_rng = prng.fold_in(rng, global_step)
+    data_select_rng, preprocess_rng, update_rng, eval_rng = prng.split(
         step_rng, 4)
     start_time = time.time()
     selected_train_input_batch, selected_train_label_batch = data_selection(
@@ -243,17 +249,15 @@ def score_submission_on_workload(
     all_metrics = []
     for hi, hyperparameters in enumerate(tuning_search_space):
       # Generate a new seed from hardware sources of randomness for each trial.
-      rng_seed = struct.unpack('q', os.urandom(8))[0]
-      rng = jax.random.PRNGKey(rng_seed)
-      # Each returned rng is actually 2 32 bit ints. Because of the way that Jax
-      # initializes its PRNKeys, if the provided seed is only 32 bits (or
-      # truncated to 32 bits because Jax support for 64 bit arithmetic is not
-      # enabled!), then rng[0] is all zeros, which means this could lead to
-      # unintentionally reusing the same seed of only rng[0] were ever used. By
-      # splitting the JAX PRNGKey into 2, we mix the lower and upper 32 bit
-      # ints, ensuring we can safely use either rng[0] or rng[1] as a random
+      rng_seed = struct.unpack('I', os.urandom(4))[0]
+      rng = prng.PRNGKey(rng_seed)
+      # Because we initialize the PRNGKey with only a single 32 bit int, in the
+      # Jax implementation this means that rng[0] is all zeros, which means this
+      # could lead to unintentionally reusing the same seed of only rng[0] were
+      # ever used. By splitting the rng into 2, we mix the lower and upper 32
+      # bit ints, ensuring we can safely use either rng[0] or rng[1] as a random
       # number.
-      rng, _ = jax.random.split(rng, 2)
+      rng, _ = prng.split(rng, 2)
       logging.info(f'--- Tuning run {hi + 1}/{num_tuning_trials} ---')
       timing, metrics = train_once(
           workload,
@@ -274,6 +278,8 @@ def score_submission_on_workload(
       logging.info('Timing: %s', all_timings[ti])
       logging.info('=' * 20)
   else:
+    rng_seed = struct.unpack('q', os.urandom(8))[0]
+    rng = prng.PRNGKey(rng_seed)
     # If the submission is responsible for tuning itself, we only need to run it
     # once and return the total time.
     score, _ = train_once(
@@ -282,7 +288,7 @@ def score_submission_on_workload(
         init_optimizer_state,
         update_params,
         data_selection,
-        hyperparameters,
+        None,
         rng)
   # TODO(znado): record and return other information (number of steps).
   return score
@@ -291,9 +297,9 @@ def score_submission_on_workload(
 def main(_):
   for workload_name, workload in WORKLOADS.items():
     _import_workload(
-      workload_path=workload['workload_path'],
-      workload_registry_name=workload_name,
-      workload_class_name=workload['workload_class_name']
+        workload_path=workload['workload_path'],
+        workload_registry_name=workload_name,
+        workload_class_name=workload['workload_class_name']
     )
 
   score = score_submission_on_workload(

--- a/workloads/mnist/mnist_jax/workload.py
+++ b/workloads/mnist/mnist_jax/workload.py
@@ -45,7 +45,7 @@ class MnistWorkload(Mnist):
       split: str,
       data_dir: str,
       batch_size):
-    ds = tfds.load('mnist', split=split, try_gcs=True)
+    ds = tfds.load('mnist', split=split)
     ds = ds.cache()
     ds = ds.map(lambda x: (self._normalize(x['image']), x['label']))
     if split == 'train':
@@ -104,6 +104,19 @@ class MnistWorkload(Mnist):
     self._param_shapes = jax.tree_map(
         lambda x: spec.ShapeTuple(x.shape), initial_params)
     return initial_params, None
+
+  # Keep this separate from the loss function in order to support optimizers
+  # that use the logits.
+  def output_activation_fn(
+      self,
+      logits_batch: spec.Tensor,
+      loss_type: spec.LossType) -> spec.Tensor:
+    if loss_type == spec.LossType.SOFTMAX_CROSS_ENTROPY:
+      return jax.nn.softmax(logits_batch, axis=-1)
+    if loss_type == spec.LossType.SIGMOID_CROSS_ENTROPY:
+      return jax.nn.sigmoid(logits_batch)
+    if loss_type == spec.LossType.MEAN_SQUARED_ERROR:
+      return logits_batch
 
   def model_fn(
       self,

--- a/workloads/mnist/mnist_pytorch/workload.py
+++ b/workloads/mnist/mnist_pytorch/workload.py
@@ -142,6 +142,15 @@ class MnistWorkload(Mnist):
 
     return logits_batch, None
 
+  # TODO(znado): Implement.
+  # Keep this separate from the loss function in order to support optimizers
+  # that use the logits.
+  def output_activation_fn(
+      self,
+      logits_batch: spec.Tensor,
+      loss_type: spec.LossType) -> spec.Tensor:
+    raise NotImplementedError
+
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
   def loss_fn(

--- a/workloads/mnist/workload.py
+++ b/workloads/mnist/workload.py
@@ -1,11 +1,5 @@
 from absl import logging
 import random_utils as prng
-try:
-  import jax.random as prng
-except (ImportError, ModuleNotFoundError):
-  logging.warning(
-      'Could not import jax.random for MNIST workload, falling back to numpy '
-      'random_utils.')
 
 import spec
 

--- a/workloads/mnist/workload.py
+++ b/workloads/mnist/workload.py
@@ -1,5 +1,13 @@
+from absl import logging
+import random_utils as prng
+try:
+  import jax.random as prng
+except (ImportError, ModuleNotFoundError):
+  logging.warning(
+      'Could not import jax.random for MNIST workload, falling back to numpy '
+      'random_utils.')
+
 import spec
-import jax
 
 class Mnist(spec.Workload):
 
@@ -37,12 +45,11 @@ class Mnist(spec.Workload):
       rng: spec.RandomState,
       data_dir: str):
     """Run a full evaluation of the model."""
-    data_rng, model_rng = jax.random.split(rng, 2)
+    data_rng, model_rng = prng.split(rng, 2)
     eval_batch_size = 2000
     num_batches = 10000 // eval_batch_size
-    if self._eval_ds is None:
-      self._eval_ds = self.build_input_queue(
-          data_rng, 'test', data_dir, batch_size=eval_batch_size)
+    self._eval_ds = self.build_input_queue(
+        data_rng, 'test', data_dir, batch_size=eval_batch_size)
 
     total_metrics = {
         'accuracy': 0.,


### PR DESCRIPTION
Also making a small fix for the Jax MNIST submission where `try_gcs=True` was slowing down our tfds reading.

Tested that can run the PyTorch MNIST example without `jax` installed, and that the Jax MNIST example still runs.

The general strategy is to import a seed manipulation module like:
```
import random_utils as prng
try:
  import jax.random as prng
except (ImportError, ModuleNotFoundError):
  logging.warning(
      'Could not import jax.random for the submission runner, falling back to '
      'numpy random_utils.')
```

And then call `prng.split`, `prng.fold_in`, `prng.PRNGKey`.

I'm open to suggestions if people prefer a different strategy for switching which implementation to use (`FLAGS`, etc.)!