### PR TITLE
Make target value a property

### DIFF
--- a/spec.py
+++ b/spec.py
@@ -126,6 +126,10 @@ class Workload(metaclass=abc.ABCMeta):
     """The types of the parameters in the workload model."""
 
   @abc.abstractproperty
+  def target_value(self):
+    """The target value to reach."""
+
+  @abc.abstractproperty
   def loss_type(self):
     """The type of loss function."""
 

--- a/workloads/imagenet/imagenet_jax/workload.py
+++ b/workloads/imagenet/imagenet_jax/workload.py
@@ -42,7 +42,11 @@ class ImagenetWorkload(spec.Workload):
     self.num_classes = 10
 
   def has_reached_goal(self, eval_result: float) -> bool:
-    return eval_result['accuracy'] > 0.76
+    return eval_result['accuracy'] > self.target_value
+
+  @property
+  def target_value(self):
+    return 0.76
 
   @property
   def loss_type(self):

--- a/workloads/mnist/workload.py
+++ b/workloads/mnist/workload.py
@@ -6,7 +6,11 @@ import spec
 class Mnist(spec.Workload):
 
   def has_reached_goal(self, eval_result: float) -> bool:
-    return eval_result['accuracy'] > 0.9
+    return eval_result['accuracy'] > self.target_value
+
+  @property
+  def target_value(self):
+    return 0.9
 
   @property
   def loss_type(self):


### PR DESCRIPTION
Fixes #18.

The specs now define an abstract property called `target_value` for the `workload` class.

https://github.com/fsschneider/algorithmic-efficiency/blob/948c5a02336a51749069c2ecd81b343d82393a11/spec.py#L128-L130

The individual workloads specify this value individually but framework-independent:

https://github.com/fsschneider/algorithmic-efficiency/blob/948c5a02336a51749069c2ecd81b343d82393a11/workloads/mnist/workload.py#L11-L13
