### PR TITLE
Add workload properties with number of training/eval examples

### DIFF
--- a/spec.py
+++ b/spec.py
@@ -126,6 +126,10 @@ class Workload(metaclass=abc.ABCMeta):
     """The types of the parameters in the workload model."""
 
   @abc.abstractproperty
+  def target_value(self):
+    """The target value to reach."""
+
+  @abc.abstractproperty
   def loss_type(self):
     """The type of loss function."""
 

--- a/spec.py
+++ b/spec.py
@@ -134,6 +134,14 @@ class Workload(metaclass=abc.ABCMeta):
     """The type of loss function."""
 
   @abc.abstractproperty
+  def num_train_examples(self):
+    """The size of the training set."""
+
+  @abc.abstractproperty
+  def num_eval_examples(self):
+    """The size of the evaluation set."""
+
+  @abc.abstractproperty
   def train_mean(self):
     """The mean of the training data."""
 

--- a/workloads/imagenet/imagenet_jax/workload.py
+++ b/workloads/imagenet/imagenet_jax/workload.py
@@ -42,7 +42,11 @@ class ImagenetWorkload(spec.Workload):
     self.num_classes = 10
 
   def has_reached_goal(self, eval_result: float) -> bool:
-    return eval_result['accuracy'] > 0.76
+    return eval_result['accuracy'] > self.target_value
+
+  @property
+  def target_value(self):
+    return 0.76
 
   @property
   def loss_type(self):

--- a/workloads/mnist/workload.py
+++ b/workloads/mnist/workload.py
@@ -6,7 +6,11 @@ import spec
 class Mnist(spec.Workload):
 
   def has_reached_goal(self, eval_result: float) -> bool:
-    return eval_result['accuracy'] > 0.9
+    return eval_result['accuracy'] > self.target_value
+
+  @property
+  def target_value(self):
+    return 0.9
 
   @property
   def loss_type(self):

--- a/workloads/mnist/workload.py
+++ b/workloads/mnist/workload.py
@@ -17,6 +17,14 @@ class Mnist(spec.Workload):
     return spec.LossType.SOFTMAX_CROSS_ENTROPY
 
   @property
+  def num_train_examples(self):
+    return 60000
+
+  @property
+  def num_eval_examples(self):
+    return 10000
+
+  @property
   def train_mean(self):
     return 0.1307
 
@@ -45,7 +53,7 @@ class Mnist(spec.Workload):
     """Run a full evaluation of the model."""
     data_rng, model_rng = prng.split(rng, 2)
     eval_batch_size = 2000
-    num_batches = 10000 // eval_batch_size
+    num_batches = self.num_eval_examples // eval_batch_size
     self._eval_ds = self.build_input_queue(
         data_rng, 'test', data_dir, batch_size=eval_batch_size)
 


### PR DESCRIPTION
This fixes #20 and allows submissions to do epoch-related calculations.

The properties are defined as part of the specs and will then be specified in each workload (but across frameworks).

