### PR TITLE
Adding a required framework flag so that the user can specify which framework to use.

### DIFF
--- a/random_utils.py
+++ b/random_utils.py
@@ -1,3 +1,4 @@
+"""Proxy functions in front of the Jax RNG API or a compatible Numpy RNG API."""
 from absl import flags
 from absl import logging
 import numpy as np
@@ -44,31 +45,31 @@ def _PRNGKey(seed: int):
 
 
 # It is usually bad practice to use FLAGS outside of the main() function, but
-# the alternative is having to pipe use_jax_rng to all functions that may need
-# it, which seems unnecessarily cumbersome.
+# the alternative is having to pipe the framework flag to all functions that may
+# need it, which seems unnecessarily cumbersome.
 def _check_jax_install():
   if jax_rng is None:
     raise ValueError(
-      'Must install jax to use the jax RNG library, or pass '
-      '--use_jax_rng=false to use the Numpy version instead.')
+      'Must install jax to use the jax RNG library, or use PyTorch and pass '
+      '--framework=pytorch to use the Numpy version instead.')
 
 
 def fold_in(seed, data):
-  if FLAGS.use_jax_rng:
+  if FLAGS.framework == 'jax':
     _check_jax_install()
     return jax_rng.fold_in(seed, data)
   return _fold_in(seed, data)
 
 
 def split(seed, num=2):
-  if FLAGS.use_jax_rng:
+  if FLAGS.framework == 'jax':
     _check_jax_install()
     return jax_rng.split(seed, num)
   return _split(seed, num)
 
 
 def PRNGKey(seed):
-  if FLAGS.use_jax_rng:
+  if FLAGS.framework == 'jax':
     _check_jax_install()
     return jax_rng.PRNGKey(seed)
   return _PRNGKey(seed)


### PR DESCRIPTION
Generalizes the previous `use_jax_rng` flag.