### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
+
+RUN apt-get update && \
+    apt-get install -y bash \
+                   build-essential \
+                   git \
+                   curl \
+                   ca-certificates \
+                   python3 \
+                   python3-pip && \
+    rm -rf /var/lib/apt/lists
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+
+# add user
+RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1001 ubuntu
+USER ubuntu
+
+# set working directory
+WORKDIR /home/ubuntu/algorithmic-efficiency
+
+# setup path
+ENV PATH="/home/ubuntu/.local/bin:${PATH}" 
+
+# add requirements
+COPY ./requirements.txt /tmp/requirements.txt
+
+# install requirements
+RUN pip3 install -r /tmp/requirements.txt
+
+# bash
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 1. Create new environment, e.g. via `conda` or `virtualenv`:
 
+   Python minimum requirement >= 3.7 
    ```bash
     sudo apt-get install python3-venv
     python3 -m venv env
@@ -55,8 +56,37 @@
    **PyTorch**
 
    ```bash
-   pip3 install -e .[pytorch]
+   pip3 install -e .[pytorch] -f 'https://download.pytorch.org/whl/torch_stable.html'
    ```
+
+### Docker
+
+Docker is the easiest way to enable PyTorch/JAX GPU support on Linux since only the [NVIDIA® GPU driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver) is required on the host machine (the NVIDIA® CUDA® Toolkit does not need to be installed). 
+
+#### Docker requirements
+
+-  Install [Docker](https://docs.docker.com/get-docker/) on your local host machine.
+
+- For GPU support on Linux, [install NVIDIA Docker support](https://github.com/NVIDIA/nvidia-docker).
+   - Take note of your Docker version with docker -v. Versions earlier than 19.03 require nvidia-docker2 and the --runtime=nvidia flag. On versions including and after 19.03, you will use the nvidia-container-toolkit package and the --gpus all flag. Both options are documented on the page linked above.
+
+#### Setup
+
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/mlcommons/algorithmic-efficiency.git
+   ```
+
+2. Build Docker
+   ```bash
+   cd algorithmic-efficiency/ && sudo docker build -t algorithmic-efficiency .
+   ```
+
+3. Run Docker
+   ```bash
+   sudo docker run --gpus all -it --rm -v $PWD:/home/ubuntu/algorithmic-efficiency --ipc=host algorithmic-efficiency
+   ```
+   Currently docker method installs both PyTorch and JAX
 
    </details>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+numpy>=1.19.2
+absl-py==0.14.0
+# pytorch
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.9.1+cu111
+torchvision==0.10.1+cu111
+# jax
+jax==0.2.17
+-f https://storage.googleapis.com/jax-releases/jax_releases.html
+jaxlib==0.1.71+cuda111
+flax==0.3.5
+optax==0.0.9
+tensorflow-datasets==4.4.0
+tensorflow-cpu==2.5.0

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ from setuptools import setup
 
 
 jax_core_deps = [
-    'jax',
-    'flax',
-    'optax',
-    'tensorflow-cpu',
-    'tensorflow_datasets',
+    'jax==0.2.17',
+    'flax==0.3.5',
+    'optax==0.0.9',
+    'tensorflow_datasets==4.4.0',
+    'tensorflow-cpu==2.5.0',
 ]
 
 
@@ -24,19 +24,20 @@ setup(
     author_email='algorithms@mlcommons.org',
     url='https://github.com/mlcommons/algorithmic-efficiency',
     license='Apache 2.0',
+    python_requires=">=3.7",
     packages=find_packages(),
     install_requires=[
-        'absl-py',
-        'numpy',
+        'absl-py==0.14.0',
+        'numpy>=1.19.2',
     ],
     extras_require={
-        'jax-cpu': jax_core_deps + ['jaxlib'],
+        'jax-cpu': jax_core_deps + ['jaxlib==0.1.71'],
         # Note for GPU support the installer must be run with
         # `-f 'https://storage.googleapis.com/jax-releases/jax_releases.html'`.
-        'jax-gpu': jax_core_deps + ['jaxlib==0.1.65+cuda110'],
+        'jax-gpu': jax_core_deps + ['jaxlib==0.1.71+cuda111'],
         'pytorch': [
-            'torch',
-            'torchvision',
+            'torch==1.9.1+cu111',
+            'torchvision==0.10.1+cu111',
         ],
     },
     classifiers=[


### PR DESCRIPTION
1) adc850f
    - Added docker with Nvidia base image `CUDA11.1` + requirements with pinned versions.

2) 0880251
     - Updated setup.py: pkgs pinned to specific versions
     - Especially all JAX libs are getting frequent releases with breaking changes, it is better to use pinned version for development.
     - Now both PyTorch and JAX is will run using CUDA 11.1 
     - Updated minimum required python to 3.7. python 3.6 contextlib don't have  `nullcontext` https://stackoverflow.com/questions/45187286/how-do-i-write-a-null-no-op-contextmanager-in-python
       jaxlib build for CUDA 11.1 onwards not available in py36.

 3) f513174
     - updated readme with docker instructions
     