### PR TITLE
Organize dependencies & some clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,24 +45,36 @@
    pip3 install -e .
    ```
 
+   You can also install the requirements for individual workloads, e.g. via
+
+   ```bash
+   pip3 install -e '.[librispeech]'
+   ```
+
+   or all workloads at once via
+
+   ```bash
+   pip3 install -e '.[full]'
+   ```
+
    Depending on the framework you want to use (e.g. `JAX` or `PyTorch`) you need to install them as well. You could either do this manually or by adding the corresponding options:
 
    **JAX (GPU)**
 
    ```bash
-   pip3 install -e .[jax-gpu] -f 'https://storage.googleapis.com/jax-releases/jax_releases.html'
+   pip3 install -e '.[jax_gpu]' -f 'https://storage.googleapis.com/jax-releases/jax_releases.html'
    ```
 
    **JAX (CPU)**
 
    ```bash
-   pip3 install -e .[jax-cpu]
+   pip3 install -e '.[jax_cpu]'
    ```
 
    **PyTorch**
 
    ```bash
-   pip3 install -e .[pytorch] -f 'https://download.pytorch.org/whl/torch_stable.html'
+   pip3 install -e '.[pytorch]' -f 'https://download.pytorch.org/whl/torch_stable.html'
    ```
 
    **Development**
@@ -70,8 +82,10 @@
    To use the development tools such as `pytest` or `pylint` use the `dev` option:
 
    ```bash
-   pip3 install -e .[dev]
+   pip3 install -e '.[dev]'
    ```
+
+   To get an installation with the requirements for all workloads and development, use the argument `[full_dev]`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ Docker is the easiest way to enable PyTorch/JAX GPU support on Linux since only 
 ### JAX
 
 ```bash
-python3 algorithmic_efficiency/submission_runner.py --framework=jax --workload=mnist_jax --submission_path=baselines/mnist/mnist_jax/submission.py --tuning_search_space=baselines/mnist/tuning_search_space.json
+python3 algorithmic_efficiency/submission_runner.py --framework=jax --workload=mnist--submission_path=baselines/mnist/mnist_jax/submission.py --tuning_search_space=baselines/mnist/tuning_search_space.json
 ```
 
 ### PyTorch
 
 ```bash
-python3 algorithmic_efficiency/submission_runner.py --framework=pytorch --workload=mnist_pytorch --submission_path=baselines/mnist/mnist_pytorch/submission.py --tuning_search_space=baselines/mnist/tuning_search_space.json
+python3 algorithmic_efficiency/submission_runner.py --framework=pytorch --workload=mnist --submission_path=baselines/mnist/mnist_pytorch/submission.py --tuning_search_space=baselines/mnist/tuning_search_space.json
 ```
 
 ## Rules

--- a/algorithmic_efficiency/workloads/imagenet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet/imagenet_jax/workload.py
@@ -1,8 +1,8 @@
 """ImageNet workload implemented in Jax.
 
 python3 submission_runner.py \
-    --workload=imagenet_jax \
-    --submission_path=workloads/imagenet/imagenet_jax/submission.py \
+    --workload=imagenet \
+    --submission_path=baselines/imagenet/imagenet_jax/submission.py \
     --num_tuning_trials=1
 """
 import functools

--- a/baselines/imagenet/imagenet_jax/submission.py
+++ b/baselines/imagenet/imagenet_jax/submission.py
@@ -94,7 +94,7 @@ def pmapped_train_step(workload, opt_update_fn, model_state, optimizer_state,
   grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
   aux, grad = grad_fn(current_param_container)
   grad = lax.pmean(grad, axis_name='batch')
-  new_model_state, logits = aux[1]
+  new_model_state, _ = aux[1]
   updates, new_optimizer_state = opt_update_fn(grad, optimizer_state,
                                                current_param_container)
   updated_params = optax.apply_updates(current_param_container, updates)

--- a/baselines/imagenet/imagenet_pytorch/submission.py
+++ b/baselines/imagenet/imagenet_pytorch/submission.py
@@ -11,7 +11,7 @@ from baselines.mnist.mnist_pytorch.submission import data_selection
 
 
 def get_batch_size(workload_name):
-  batch_sizes = {'imagenet_pytorch': 128}
+  batch_sizes = {'imagenet': 128}
   return batch_sizes[workload_name]
 
 
@@ -24,8 +24,7 @@ def init_optimizer_state(workload: spec.Workload,
   del model_state
   del rng
 
-  base_lr = hyperparameters.learning_rate * get_batch_size(
-      'imagenet_pytorch') / 256.
+  base_lr = hyperparameters.learning_rate * get_batch_size('imagenet') / 256.
   optimizer_state = {
       'optimizer':
           torch.optim.SGD(
@@ -93,8 +92,7 @@ def update_params(
   loss.backward()
   optimizer_state['optimizer'].step()
 
-  steps_per_epoch = workload.num_train_examples // get_batch_size(
-      'imagenet_pytorch')
+  steps_per_epoch = workload.num_train_examples // get_batch_size('imagenet')
   if (global_step + 1) % steps_per_epoch == 0:
     optimizer_state['scheduler'].step()
 

--- a/baselines/imagenet/imagenet_pytorch/submission.py
+++ b/baselines/imagenet/imagenet_pytorch/submission.py
@@ -1,5 +1,5 @@
 """Training algorithm track submission functions for ImageNet."""
-from typing import List, Tuple
+from typing import Iterator, List, Tuple
 
 import torch
 from torch.optim.lr_scheduler import CosineAnnealingLR
@@ -7,7 +7,6 @@ from torch.optim.lr_scheduler import LinearLR
 from torch.optim.lr_scheduler import SequentialLR
 
 from algorithmic_efficiency import spec
-from baselines.mnist.mnist_pytorch.submission import data_selection
 
 
 def get_batch_size(workload_name):
@@ -97,3 +96,27 @@ def update_params(
     optimizer_state['scheduler'].step()
 
   return (optimizer_state, current_param_container, new_model_state)
+
+
+# Not allowed to update the model parameters, hyperparameters, global step, or
+# optimzier state.
+def data_selection(workload: spec.Workload,
+                   input_queue: Iterator[Tuple[spec.Tensor, spec.Tensor]],
+                   optimizer_state: spec.OptimizerState,
+                   current_param_container: spec.ParameterContainer,
+                   hyperparameters: spec.Hyperparamters, global_step: int,
+                   rng: spec.RandomState) -> Tuple[spec.Tensor, spec.Tensor]:
+  """Select data from the infinitely repeating, pre-shuffled input queue.
+
+  Each element of the queue is a single training example and label.
+
+  We left out `current_params_types` because we do not believe that it would
+  # be necessary for this function.
+
+  Return a tuple of input label batches.
+  """
+  del optimizer_state
+  del current_param_container
+  del global_step
+  del rng
+  return next(input_queue)

--- a/baselines/librispeech/librispeech_pytorch/submission.py
+++ b/baselines/librispeech/librispeech_pytorch/submission.py
@@ -10,7 +10,7 @@ ctc_loss = torch.nn.CTCLoss(blank=0, reduction="none")
 
 
 def get_batch_size(workload_name):
-  batch_sizes = {"librispeech_pytorch": 8}
+  batch_sizes = {"librispeech": 8}
   return batch_sizes[workload_name]
 
 

--- a/baselines/mnist/mnist_jax/submission.py
+++ b/baselines/mnist/mnist_jax/submission.py
@@ -12,7 +12,7 @@ from algorithmic_efficiency import spec
 
 
 def get_batch_size(workload_name):
-  batch_sizes = {'mnist_jax': 1024}
+  batch_sizes = {'mnist': 1024}
   return batch_sizes[workload_name]
 
 

--- a/baselines/mnist/mnist_pytorch/submission.py
+++ b/baselines/mnist/mnist_pytorch/submission.py
@@ -10,7 +10,7 @@ DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 
 def get_batch_size(workload_name):
-  batch_sizes = {'mnist_pytorch': 1024}
+  batch_sizes = {'mnist': 1024}
   return batch_sizes[workload_name]
 
 

--- a/baselines/wmt/wmt_jax/submission.py
+++ b/baselines/wmt/wmt_jax/submission.py
@@ -72,7 +72,7 @@ def create_learning_rate_scheduler(
         ret *= jnp.maximum(0.0,
                            0.5 * (1.0 + jnp.cos(jnp.pi * (progress % 1.0))))
       else:
-        raise ValueError("Unknown factor %s." % name)
+        raise ValueError(f"Unknown factor {name}.")
     return jnp.asarray(ret, dtype=jnp.float32)
 
   return step_fn

--- a/baselines/wmt/wmt_jax/submission.py
+++ b/baselines/wmt/wmt_jax/submission.py
@@ -16,7 +16,7 @@ from algorithmic_efficiency.workloads.wmt.wmt_jax import models
 
 
 def get_batch_size(workload_name):
-  batch_sizes = {"wmt_jax": 16}
+  batch_sizes = {"wmt": 16}
   return batch_sizes[workload_name]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,6 @@ setup_requires =
 # Dependencies of the project:
 install_requires =
   absl-py==0.14.0
-  # ctcdecode>=1.0.3
-  levenshtein>=0.12.0
-  librosa>=0.8.1
   numpy>=1.19.2
   pandas>=1.3.1
   six>=1.15.0
@@ -55,12 +52,34 @@ python_requires = >=3.7
 # Use as `pip install -e '.[jax-gpu]' -f https://storage.googleapis.com/jax-releases/jax_releases.html`
 # or `pip install -e '.[dev]'`
 
+# Bundled installs #
+
+# All workloads
+full =
+  %(librispeech)s
+
+# All workloads plus development dependencies
+full-dev =
+  %(full)s
+  %(dev)s
+
 # Dependencies for developing the package
 dev =
   isort
   pylint
   pytest
   yapf
+
+
+# Workloads #
+
+librispeech = 
+  ctcdecode>=1.0.2
+  levenshtein>=0.12.0
+  librosa>=0.8.1
+
+
+# Frameworks #
 
 # JAX Core
 jax_core_deps =

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ full =
   %(librispeech)s
 
 # All workloads plus development dependencies
-full-dev =
+full_dev =
   %(full)s
   %(dev)s
 
@@ -89,13 +89,13 @@ jax_core_deps =
   tensorflow_datasets==4.4.0
 
 # JAX CPU
-jax-cpu =
+jax_cpu =
   %(jax_core_deps)s
   jax==0.2.28
   jaxlib==0.1.76
 
 # JAX GPU
-jax-gpu =
+jax_gpu =
   %(jax_core_deps)s
   jax[cuda]==0.2.28
   jaxlib==0.1.76+cuda11.cudnn82

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
-# MLCommons Algorithmic Efficiency.
+###############################################################################
+#                      MLCommons Algorithmic Efficiency.                      #
+###############################################################################
 
 [metadata]
 name = algorithmic_efficiency
@@ -42,8 +44,14 @@ install_requires =
   six>=1.15.0
 python_requires = >=3.7
 
+
+###############################################################################
+#                           Additional Dependencies                           #
+###############################################################################
+
 [options.extras_require]
-# Add extra dependencies, e.g. to run tests or for the different frameworks.
+# Add extra dependencies for individual workloads
+# or developement (linting or testing)
 # Use as `pip install -e '.[jax-gpu]' -f https://storage.googleapis.com/jax-releases/jax_releases.html`
 # or `pip install -e '.[dev]'`
 
@@ -57,88 +65,74 @@ dev =
 # JAX Core
 jax_core_deps =
   flax==0.3.5
-  jax==0.2.17
   optax==0.0.9
   tensorflow-cpu==2.5.0
   tensorflow_datasets==4.4.0
 
 # JAX CPU
-jax_cpu =
+jax-cpu =
   %(jax_core_deps)s
-  jaxlib==0.1.71
+  jax==0.2.28
+  jaxlib==0.1.76
 
 # JAX GPU
-jax_gpu =
+jax-gpu =
   %(jax_core_deps)s
-  jaxlib==0.1.71+cuda111
+  jax[cuda]==0.2.28
+  jaxlib==0.1.76+cuda11.cudnn82
 
 # PyTorch
 pytorch =
   torch==1.9.1+cu111
   torchvision==0.10.1+cu111
 
-# Linting configuration #
+
+###############################################################################
+#                           Linting Configurations                            #
+###############################################################################
 
 # yapf configuration
 [yapf]
 based_on_style = yapf
 
+
 # isort configuration
 [isort]
 profile=google
 
+
 # pylint configuration
 [pylint.MASTER]
-
-# Pickle collected data for later comparisons.
-persistent=no
-
-# Set the cache size for astng objects.
-cache-size=500
-
+persistent=no  # Pickle collected data for later comparisons.
+cache-size=500  # Set the cache size for astng objects.
 # Ignore Py3 files
 ignore=get_references_web.py,get_references_web_single_group.py
-
-
 [pylint.REPORTS]
-
 # Set the output format.
 # output-format=sorted-text
-
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be
 # written in a file name "pylint_global.[txt|html]".
 files-output=no
-
 # Tells whether to display a full report or only the messages.
 reports=no
-
 # Disable the report(s) with the given id(s).
 disable-report=R0001,R0002,R0003,R0004,R0101,R0102,R0201,R0202,R0220,R0401,R0402,R0701,R0801,R0901,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915,R0921,R0922,R0923
-
 # Error message template (continued on second line)
 msg-template={msg_id}:{line:3} {obj}: {msg} [{symbol}]
-
-
 [pylint.'MESSAGES CONTROL']
 # List of checkers and warnings to enable.
 enable=indexing-exception,old-raise-syntax
-
 # List of checkers and warnings to disable.
 disable=abstract-method,access-member-before-definition,arguments-differ,assignment-from-no-return,attribute-defined-outside-init,bad-mcs-classmethod-argument,bad-option-value,c-extension-no-member,consider-merging-isinstance,consider-using-dict-comprehension,consider-using-enumerate,consider-using-in,consider-using-set-comprehension,consider-using-ternary,deprecated-method,design,file-ignored,fixme,global-statement,import-error,inconsistent-return-statements,invalid-unary-operand-type,len-as-condition,locally-disabled,locally-enabled,misplaced-comparison-constant,missing-docstring,multiple-imports,no-else-return,no-member,no-name-in-module,no-self-use,no-value-for-parameter,not-an-iterable,not-context-manager,pointless-except,protected-access,redefined-argument-from-local,signature-differs,similarities,simplifiable-if-expression,star-args,super-init-not-called,suppressed-message,too-many-function-args,trailing-comma-tuple,trailing-newlines,ungrouped-imports,unnecessary-pass,unsubscriptable-object,unused-argument,useless-object-inheritance,useless-return,useless-suppression,wrong-import-order,wrong-import-position,unneeded-not,unexpected-keyword-arg,redundant-keyword-arg
-
 [pylint.BASIC]
-
 # Required attributes for module, separated by a comma
 required-attributes=
-
 # Regular expression which should only match the name
 # of functions or classes which do not require a docstring.
 no-docstring-rgx=(__.*__|main)
-
 # Min length in lines of a function that requires a docstring.
 docstring-min-length=10
-
 # Regular expression which should only match correct module names. The
 # leading underscore is sanctioned for private modules by Google's style
 # guide.
@@ -146,22 +140,16 @@ docstring-min-length=10
 # There are exceptions to the basic rule (_?[a-z][a-z0-9_]*) to cover
 # requirements of Python's module system.
 module-rgx=^(_?[a-z][a-z0-9_]*)|__init__$
-
 # Regular expression which should only match correct module level names
 const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
-
 # Regular expression which should only match correct class attribute
 class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
-
 # Regular expression which should only match correct class names
 class-rgx=^_?[A-Z][a-zA-Z0-9]*$
-
 # Regular expression which should only match correct function names.
 # 'camel_case' and 'snake_case' group names are used for consistency of naming
 # styles across functions and methods.
 function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
-
-
 # Regular expression which should only match correct method names.
 # 'camel_case' and 'snake_case' group names are used for consistency of naming
 # styles across functions and methods. 'exempt' indicates a name which is
@@ -172,83 +160,51 @@ method-rgx=(?x)
          |(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)
      |(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)
      |(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
-
-
 # Regular expression which should only match correct instance attribute names
 attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
-
 # Regular expression which should only match correct argument names
 argument-rgx=^[a-z][a-z0-9_]*$
-
 # Regular expression which should only match correct variable names
 variable-rgx=^[a-z][a-z0-9_]*$
-
 # Regular expression which should only match correct list comprehension /
 # generator expression variable names
 inlinevar-rgx=^[a-z][a-z0-9_]*$
-
 # Good variable names which should always be accepted, separated by a comma
 good-names=main,_
-
 # Bad variable names which should always be refused, separated by a comma
 bad-names=
-
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=input,apply,reduce
-
 # List of decorators that define properties, such as abc.abstractproperty.
 property-classes=abc.abstractproperty
-
-
 [pylint.TYPECHECK]
-
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).
 ignore-mixin-members=yes
-
 # List of decorators that create context managers from functions, such as
 # contextlib.contextmanager.
 contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
-
-
 [pylint.VARIABLES]
-
 # Tells whether we should check for unused import in __init__ files.
 init-import=no
-
 # A regular expression matching names used for dummy variables (i.e. not used).
 dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
-
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
 additional-builtins=
-
-
 [pylint.CLASSES]
-
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp
-
 # "class_" is also a valid for the first argument to a class method.
 valid-classmethod-first-arg=cls,class_
-
-
 [pylint.EXCEPTIONS]
-
 overgeneral-exceptions=StandardError,Exception,BaseException
-
-
 [pylint.IMPORTS]
-
 # Deprecated modules which should not be used, separated by a comma
 deprecated-modules=regsub,TERMIOS,Bastion,rexec,sets
-
-
 [pylint.FORMAT]
-
 # Maximum number of characters on a single line.
 max-line-length=80
-
 # Regexp for a line that is allowed to be longer than the limit.
 # This "ignore" regex is today composed of several independent parts:
 # (1) Long import lines
@@ -263,44 +219,28 @@ ignore-long-lines=(?x)
    |^\s*(\#\ )?<?(https?|ftp):\/\/[^\s\/$.?#].[^\s]*>?$
    |^[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*("[^"]\S+"|'[^']\S+')
    )
-
 # Maximum number of lines in a module
 max-module-lines=99999
-
 # String used as indentation unit. We differ from PEP8's normal 4 spaces.
 indent-string='  '
-
 # Do not warn about multiple statements on a single line for constructs like
 #   if test: stmt
 single-line-if-stmt=y
-
 # Make sure : in dicts and trailing commas are checked for whitespace.
 no-space-check=
-
-
 [pylint.LOGGING]
-
 # Add logging modules.
 logging-modules=logging,absl.logging
-
-
 [pylint.MISCELLANEOUS]
-
-
 # Maximum line length for lambdas
 short-func-length=1
-
 # List of module members that should be marked as deprecated.
 # All of the string functions are listed in 4.1.4 Deprecated string functions
 # in the Python 2.4 docs.
 deprecated-members=string.atof,string.atoi,string.atol,string.capitalize,string.expandtabs,string.find,string.rfind,string.index,string.rindex,string.count,string.lower,string.split,string.rsplit,string.splitfields,string.join,string.joinfields,string.lstrip,string.rstrip,string.strip,string.swapcase,string.translate,string.upper,string.ljust,string.rjust,string.center,string.zfill,string.replace,sys.exitfunc,sys.maxint
-
-
 # List of exceptions that do not need to be mentioned in the Raises section of
 # a docstring.
 ignore-exceptions=AssertionError,NotImplementedError,StopIteration,TypeError
-
-
 # Number of spaces of indent required when the last token on the preceding line
 # is an open (, [, or {.
 indent-after-paren=4


### PR DESCRIPTION
This PR performs some general cleanup and allows workload-specific dependencies:

- Fixes JAX install according to #52.
- Introduces workload-specific dependencies which can be installed e.g. via `pip install -e '.[librispeech]'`. There is also the option to use `[full]` to install dependencies for all workloads.
- Workloads are now defined without appending the framework, e.g. `--workload=mnist_jax` should now be `--workload=mnist`. It automatically combines the `workload` and `framework` arguments. This provides a clearer interface as previously one could run with the options `--framework=jax --workload=mnist_pytorch` as discussed in #19. This PR closes #19.
- Fixes some `pylint` errors in `baselines/` directory.