### PR TITLE
(Almost) fix MNIST example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Docker is the easiest way to enable PyTorch/JAX GPU support on Linux since only 
 ### JAX
 
 ```bash
-python3 algorithmic_efficiency/submission_runner.py \
+python3 submission_runner.py \
     --framework=jax \
     --workload=mnist |\
     --submission_path=baselines/mnist/mnist_jax/submission.py \
@@ -138,7 +138,7 @@ python3 algorithmic_efficiency/submission_runner.py \
 ### PyTorch
 
 ```bash
-python3 algorithmic_efficiency/submission_runner.py \
+python3 submission_runner.py \
     --framework=pytorch \
     --workload=mnist \
     --submission_path=baselines/mnist/mnist_pytorch/submission.py \

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -76,7 +76,14 @@ class MnistWorkload(BaseMnistWorkload):
     """
     TODO: return type tuples from model as a tree
     """
-    raise NotImplementedError
+    return None
+
+  @property
+  def param_shapes(self):
+    """
+    TODO: return param shapes from model as a tree
+    """
+    return None
 
   # Return whether or not a key in spec.ParameterContainer is the output layer
   # parameters.

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -22,8 +22,16 @@ class BaseMnistWorkload(spec.Workload):
     return 60000
 
   @property
-  def num_eval_examples(self):
+  def num_eval_train_examples(self):
     return 10000
+
+  @property
+  def num_validation_examples(self):
+    return 10000
+
+  @property
+  def num_test_examples(self):
+    return None
 
   @property
   def train_mean(self):


### PR DESCRIPTION
Addresses the bugs described in issue #62.

This should, however, be seen as a hotfix, not as a proper solution.

We currently don't consistently use the `num_X_examples` property for evaluating the model. I would say, ideally, all models should follow the same protocol during `eval_model`, e.g. evaluate on the train set, validation set, and test set.
This would use the `num_X_examples` property, but currently, we are not doing this for most models.

Similarly, we wanted to provide both the `param_shapes` and the `model_params_types` as properties for submitters, but in most workloads, they are not implemented. Ideally, they would be defined in the framework-agnostic base class of each workload.

Lastly, there is the issue that PR #58 introduced an additional `_mask_batch` argument in a couple of places. This is, for example, prominent in the `submission_runner`, which now expects the `data_selection` (a submission function) to also return a `selected_train_mask_batch` variable:

https://github.com/mlcommons/algorithmic-efficiency/blob/c36557c7d8f2411fc316ea33449d0a93640b1252/submission_runner.py#L174-L182

This currently breaks the MNIST example.

We could fix this, by modifying the `data_selection` function of the MNIST submission 
```diff
-return next(input_queue)
+return next(input_queue) + [None]
```
but I am not convinced this is the most elegant solution (a full fix requires a few additional but similar changes).

@znado perhaps you could chip in, but I believe the introduction of the `_mask_batch` arguments currently is also not in line with the API specification we present in the rules: https://github.com/mlcommons/algorithmic-efficiency/blob/main/RULES.md#specification