### PR TITLE
feat(librispeech): add working jax code

### DIFF
--- a/submission_runner.py
+++ b/submission_runner.py
@@ -48,6 +48,10 @@ WORKLOADS = {
   'librispeech_pytorch': {
     'workload_path': 'workloads/librispeech/librispeech_pytorch/workload.py',
     'workload_class_name': 'LibriSpeechWorkload'
+  },
+  'librispeech_jax': {
+    'workload_path': 'workloads/librispeech/librispeech_jax/workload.py',
+    'workload_class_name': 'LibriSpeechWorkload'
   }
 }
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -230,7 +230,7 @@ def train_once(
         latest_eval_result = workload.eval_model(
             model_params, model_state, eval_rng, data_dir)
         log(writer, "EvalResult", latest_eval_result, global_step)
-        log(writer, "StepsPerSecond", (current_time - global_start_time) / global_step, global_step)
+        log(writer, "Seconds Per Step", (current_time - global_start_time) / global_step, global_step)
         logging.info(
             f'{current_time - global_start_time:.2f}s\t{global_step}'
             f'\t{latest_eval_result}')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -161,7 +161,7 @@ def train_once(
       def log(self:log_writer, name:str, value, step:int) -> None:
            log_writer.add_scalar(self, name, value, step)
   elif FLAGS.logging_backend == 'none':
-      from contextlib import nullcontext
+      from contextlib import nullcontext as log_writer
       def log(*args, **kwargs):
           return
   # Workload setup.

--- a/workloads/librispeech/librispeech_jax/README.md
+++ b/workloads/librispeech/librispeech_jax/README.md
@@ -1,11 +1,12 @@
-To run an experiment on TPU, you need to install the dependencies and execute the submission runnion
+To run an experiment on TPU, you need to install the dependencies and execute the submission runner
 
 ```BASH
 sudo apt update
 sudo apt install libsndfile-dev -y
 python3 -m pip install --upgrade pip
+sudo python3 -m pip uninstall -y tf-nightly tb-nightly
 python3 -m pip install --upgrade "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-python3 -m pip install --upgrade flax optax git+https://github.com/parlance/ctcdecode Levenshtein pandas librosa sndfile
+python3 -m pip install --upgrade flax optax git+https://github.com/parlance/ctcdecode Levenshtein pandas librosa sndfile tensorflow tensorboard
 
 git clone https://github.com/ClashLuke/algorithmic-efficiency/
 cd algorithmic-efficiency

--- a/workloads/librispeech/librispeech_jax/README.md
+++ b/workloads/librispeech/librispeech_jax/README.md
@@ -1,0 +1,22 @@
+To run an experiment on TPU, you need to install the dependencies and execute the submission runnion
+
+```BASH
+sudo apt update
+sudo apt install libsndfile -y
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+python3 -m pip install --upgrade flax optax git+https://github.com/parlance/ctcdecode Levenshtein pandas librosa sndfile
+
+git clone https://github.com/ClashLuke/algorithmic-efficiency/
+cd algorithmic-efficiency
+git checkout librispeech-jax
+cd workloads/librispeech/librispeech_jax
+mkdir data
+cd data
+bash ../../download_data.sh
+cd LibriSpeech
+python3 ../../../prepare_data.py . jax
+
+cd ../../../../..
+python3 submission_runner.py --workload=librispeech_jax --submission_path=workloads/librispeech/librispeech_jax/submission.py tuning_search_space=baselines/librispeech/tuning_search_space.json --data_dir=`pwd`/workloads/librispeech/librispeech_jax/data/LibriSpeech/data
+```

--- a/workloads/librispeech/librispeech_jax/README.md
+++ b/workloads/librispeech/librispeech_jax/README.md
@@ -19,5 +19,5 @@ cd LibriSpeech
 python3 ../../../prepare_data.py . jax
 
 cd ../../../../..
-python3 submission_runner.py --workload=librispeech_jax --submission_path=workloads/librispeech/librispeech_jax/submission.py tuning_search_space=baselines/librispeech/tuning_search_space.json --data_dir=`pwd`/workloads/librispeech/librispeech_jax/data/LibriSpeech/data
+python3 submission_runner.py --workload=librispeech_jax --submission_path=workloads/librispeech/librispeech_jax/submission.py tuning_search_space=baselines/librispeech/tuning_search_space.json --data_dir=`pwd`/workloads/librispeech/librispeech_jax/data/LibriSpeech/data --logging_backend tensorboard
 ```

--- a/workloads/librispeech/librispeech_jax/README.md
+++ b/workloads/librispeech/librispeech_jax/README.md
@@ -2,7 +2,7 @@ To run an experiment on TPU, you need to install the dependencies and execute th
 
 ```BASH
 sudo apt update
-sudo apt install libsndfile -y
+sudo apt install libsndfile-dev -y
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 python3 -m pip install --upgrade flax optax git+https://github.com/parlance/ctcdecode Levenshtein pandas librosa sndfile

--- a/workloads/librispeech/librispeech_jax/input_pipeline.py
+++ b/workloads/librispeech/librispeech_jax/input_pipeline.py
@@ -22,8 +22,8 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
 
     def __getitem__(self, idx):
         idx *= self.batch_size
-        max_input_len = 256  # 142 to 3496
-        max_target_len = 16  # 11 to 586
+        max_input_len = -1  # 142 to 3496
+        max_target_len = -1  # 11 to 586
 
         for i in range(self.batch_size):
             sample = self.df.iloc[idx + i]
@@ -31,8 +31,9 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
             max_input_len = max(max_input_len, feature.shape[0])
             max_target_len = max(max_target_len, len(trn))
 
-        max_input_len = int(2 ** math.ceil(math.log2(max_input_len)))
-        max_target_len = int(2 ** math.ceil(math.log2(max_target_len)))
+        # same as pytorch code except for the padding (128 vs 1)
+        max_input_len = max_input_len + (-max_input_len) % 128  
+        max_target_len = max_target_len + (-max_target_len) % 128
         samples = []
 
         for i in range(self.batch_size):

--- a/workloads/librispeech/librispeech_jax/input_pipeline.py
+++ b/workloads/librispeech/librispeech_jax/input_pipeline.py
@@ -27,8 +27,9 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
     return self.sample_size
 
   def pad_collate(self, batch):
-    max_input_len = 2453
-    max_target_len = 405
+    max_input_len = 4096  # It has to be >3300 due to the eval dataset and 4096 is the next power of 2 above it
+    max_target_len = 512  # It has to be above 405 and 512 is the next power of 2 above it
+    # You can probably reduce max_input_len to 3328 (3072 + 256) for optimal performance on GPU
 
     for i, elem in enumerate(batch):
       index, f, trn = elem

--- a/workloads/librispeech/librispeech_jax/input_pipeline.py
+++ b/workloads/librispeech/librispeech_jax/input_pipeline.py
@@ -1,6 +1,7 @@
 """Data pipeline for LibriSpeech dataset modified from https://github.com/lsari/librispeech_100/blob/main/dataset.py."""
 
 import json
+import math
 
 import jax.numpy as jnp
 import numpy as np
@@ -9,48 +10,53 @@ import torch
 
 
 class LibriSpeechDataset(torch.utils.data.Dataset):
+    def __init__(self, feat_csv):
+        self.df = pd.read_csv(feat_csv)
+        self.df["features"] = self.df["features"].apply(np.load)
+        self.df["trans_ids"] = self.df["trans_ids"].apply(json.loads)
+        self.df["len"] = self.df["features"].apply(len)
+        self.df.sort_values("len", inplace=True)
+        self.sample_size = len(self.df)
+        self.df["id"] = list(range(self.sample_size))
 
-  def __init__(self, feat_csv):
-    self.df = pd.read_csv(feat_csv)
-    self.sample_size = len(self.df)
-    self.df["id"] = list(range(self.sample_size))
+    def __getitem__(self, idx):
+        sample = self.df.iloc[idx]
+        return sample["id"], sample["features"], sample["trans_ids"]
 
-  def __getitem__(self, idx):
-    sample = self.df.iloc[idx]
-    trn_ids = json.loads(sample["trans_ids"])
+    def __len__(self):
+        return self.sample_size
 
-    feature = np.load(sample["features"])
-    index = sample["id"]
-    return index, feature, trn_ids
+    def pad_collate(self, batch):
+        max_input_len = 128
+        max_target_len = 128
 
-  def __len__(self):
-    return self.sample_size
+        for elem in batch:
+            index, feature, trn = elem
+            max_input_len = max(max_input_len, feature.shape[0])
+            max_target_len = max(max_target_len, len(trn))
 
-  def pad_collate(self, batch):
-    max_input_len = 4096  # It has to be >3300 due to the eval dataset and 4096 is the next power of 2 above it
-    max_target_len = 1024  # 512 < max_length < 1024, so 1024 works
-    # You can probably reduce max_input_len to 3328 (3072 + 256) for optimal performance on GPU
+        max_input_len = int(2 ** math.ceil(math.log2(max_input_len)))
+        max_target_len = int(2 ** math.ceil(math.log2(max_target_len)))
 
-    for i, elem in enumerate(batch):
-      index, f, trn = elem
-      input_length = np.array(f.shape[0])
-      input_dim = f.shape[1]
-      feature = np.zeros((max_input_len, input_dim), dtype=np.float)
-      feature[:f.shape[0], :f.shape[1]] = f
-      target_len = len(trn)
-      target_padding = np.zeros(max_target_len)
-      target_padding[target_len:] = 1 
-      trn = np.pad(
-          trn, (0, max_target_len - len(trn)), "constant", constant_values=0)
+        for i, elem in enumerate(batch):
+            index, f, trn = elem
+            input_length = np.array(f.shape[0])
+            input_dim = f.shape[1]
+            feature = np.zeros((max_input_len, input_dim), dtype=np.float)
+            feature[:f.shape[0], :f.shape[1]] = f
+            target_len = len(trn)
+            target_padding = np.zeros(max_target_len)
+            target_padding[target_len:] = 1
+            trn = np.pad(trn, (0, max_target_len - len(trn)), "constant", constant_values=0)
 
-      batch[i] = (int(index), feature, trn, input_length, target_padding)
+            batch[i] = (int(index), feature, trn, input_length, target_padding)
 
-    batch.sort(key=lambda x: x[3], reverse=True)
+        batch.sort(key=lambda x: x[3], reverse=True)
 
-    index = np.array([x[0] for x in batch], dtype=jnp.int32)
-    feature = np.array([x[1] for x in batch], dtype=jnp.float32)
-    trn = np.array([x[2] for x in batch], dtype=jnp.int32)
-    input_length = np.array([x[3] for x in batch], dtype=jnp.int32)
-    target_padding = np.array([x[4] for x in batch], dtype=jnp.int32)
+        index = np.array([x[0] for x in batch], dtype=jnp.int32)
+        feature = np.array([x[1] for x in batch], dtype=jnp.float32)
+        trn = np.array([x[2] for x in batch], dtype=jnp.int32)
+        input_length = np.array([x[3] for x in batch], dtype=jnp.int32)
+        target_padding = np.array([x[4] for x in batch], dtype=jnp.int32)
 
-    return index, feature, trn, input_length, target_padding
+        return index, feature, trn, input_length, target_padding, max_input_len, max_target_len

--- a/workloads/librispeech/librispeech_jax/input_pipeline.py
+++ b/workloads/librispeech/librispeech_jax/input_pipeline.py
@@ -33,10 +33,11 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
 
         max_input_len = int(2 ** math.ceil(math.log2(max_input_len)))
         max_target_len = int(2 ** math.ceil(math.log2(max_target_len)))
+        samples = []
 
         for i in range(self.batch_size):
             sample = self.df.iloc[idx + i]
-            index, feature, trn = sample["id"], sample["features"], sample["trans_ids"]
+            index, f, trn = sample["id"], sample["features"], sample["trans_ids"]
             input_length = np.array(f.shape[0])
             input_dim = f.shape[1]
             feature = np.zeros((max_input_len, input_dim), dtype=np.float)
@@ -46,15 +47,13 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
             target_padding[target_len:] = 1
             trn = np.pad(trn, (0, max_target_len - len(trn)), "constant", constant_values=0)
 
-            batch[i] = (int(index), feature, trn, input_length, target_padding)
+            samples.append((int(index), feature, trn, input_length, target_padding))
 
-        batch.sort(key=lambda x: x[3], reverse=True)
-
-        index = np.array([x[0] for x in batch], dtype=jnp.int32)
-        feature = np.array([x[1] for x in batch], dtype=jnp.float32)
-        trn = np.array([x[2] for x in batch], dtype=jnp.int32)
-        input_length = np.array([x[3] for x in batch], dtype=jnp.int32)
-        target_padding = np.array([x[4] for x in batch], dtype=jnp.int32)
+        index = np.array([x[0] for x in samples], dtype=jnp.int32)
+        feature = np.array([x[1] for x in samples], dtype=jnp.float32)
+        trn = np.array([x[2] for x in samples], dtype=jnp.int32)
+        input_length = np.array([x[3] for x in samples], dtype=jnp.int32)
+        target_padding = np.array([x[4] for x in samples], dtype=jnp.int32)
 
         return index, feature, trn, input_length, target_padding, max_input_len, max_target_len
 

--- a/workloads/librispeech/librispeech_jax/input_pipeline.py
+++ b/workloads/librispeech/librispeech_jax/input_pipeline.py
@@ -1,0 +1,57 @@
+"""Data pipeline for LibriSpeech dataset modified from https://github.com/lsari/librispeech_100/blob/main/dataset.py."""
+
+import json
+
+import jax.numpy as jnp
+import numpy as np
+import pandas as pd
+import torch
+
+
+class LibriSpeechDataset(torch.utils.data.Dataset):
+
+  def __init__(self, feat_csv):
+    self.df = pd.read_csv(feat_csv)
+    self.sample_size = len(self.df)
+    self.df["id"] = list(range(self.sample_size))
+
+  def __getitem__(self, idx):
+    sample = self.df.iloc[idx]
+    trn_ids = json.loads(sample["trans_ids"])
+
+    feature = np.load(sample["features"])
+    index = sample["id"]
+    return index, feature, trn_ids
+
+  def __len__(self):
+    return self.sample_size
+
+  def pad_collate(self, batch):
+    max_input_len = 2453
+    max_target_len = 405
+
+    for elem in batch:
+      index, feature, trn = elem
+      max_input_len = max_input_len if max_input_len > feature.shape[
+          0] else feature.shape[0]
+      max_target_len = max_target_len if max_target_len > len(trn) else len(trn)
+
+    for i, elem in enumerate(batch):
+      index, f, trn = elem
+      input_length = np.array(f.shape[0])
+      input_dim = f.shape[1]
+      feature = np.zeros((max_input_len, input_dim), dtype=np.float)
+      feature[:f.shape[0], :f.shape[1]] = f
+      trn = np.pad(
+          trn, (0, max_target_len - len(trn)), "constant", constant_values=0)
+
+      batch[i] = (int(index), feature, trn, input_length)
+
+    batch.sort(key=lambda x: x[3], reverse=True)
+
+    index = np.array([x[0] for x in batch], dtype=jnp.int32)
+    feature = np.array([x[1] for x in batch], dtype=jnp.float32)
+    trn = np.array([x[2] for x in batch], dtype=jnp.float32)
+    input_length = np.array([x[3] for x in batch], dtype=jnp.int32)
+
+    return index, feature, trn, input_length

--- a/workloads/librispeech/librispeech_jax/input_pipeline.py
+++ b/workloads/librispeech/librispeech_jax/input_pipeline.py
@@ -28,7 +28,7 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
 
   def pad_collate(self, batch):
     max_input_len = 4096  # It has to be >3300 due to the eval dataset and 4096 is the next power of 2 above it
-    max_target_len = 512  # It has to be above 405 and 512 is the next power of 2 above it
+    max_target_len = 1024  # 512 < max_length < 1024, so 1024 works
     # You can probably reduce max_input_len to 3328 (3072 + 256) for optimal performance on GPU
 
     for i, elem in enumerate(batch):

--- a/workloads/librispeech/librispeech_jax/input_pipeline.py
+++ b/workloads/librispeech/librispeech_jax/input_pipeline.py
@@ -30,28 +30,26 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
     max_input_len = 2453
     max_target_len = 405
 
-    for elem in batch:
-      index, feature, trn = elem
-      max_input_len = max_input_len if max_input_len > feature.shape[
-          0] else feature.shape[0]
-      max_target_len = max_target_len if max_target_len > len(trn) else len(trn)
-
     for i, elem in enumerate(batch):
       index, f, trn = elem
       input_length = np.array(f.shape[0])
       input_dim = f.shape[1]
       feature = np.zeros((max_input_len, input_dim), dtype=np.float)
       feature[:f.shape[0], :f.shape[1]] = f
+      target_len = len(trn)
+      target_padding = np.zeros(max_target_len)
+      target_padding[target_len:] = 1 
       trn = np.pad(
           trn, (0, max_target_len - len(trn)), "constant", constant_values=0)
 
-      batch[i] = (int(index), feature, trn, input_length)
+      batch[i] = (int(index), feature, trn, input_length, target_padding)
 
     batch.sort(key=lambda x: x[3], reverse=True)
 
     index = np.array([x[0] for x in batch], dtype=jnp.int32)
     feature = np.array([x[1] for x in batch], dtype=jnp.float32)
-    trn = np.array([x[2] for x in batch], dtype=jnp.float32)
+    trn = np.array([x[2] for x in batch], dtype=jnp.int32)
     input_length = np.array([x[3] for x in batch], dtype=jnp.int32)
+    target_padding = np.array([x[4] for x in batch], dtype=jnp.int32)
 
-    return index, feature, trn, input_length
+    return index, feature, trn, input_length, target_padding

--- a/workloads/librispeech/librispeech_jax/input_pipeline.py
+++ b/workloads/librispeech/librispeech_jax/input_pipeline.py
@@ -14,7 +14,7 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
         self.df = pd.read_csv(feat_csv)
         self.df["features"] = self.df["features"].apply(np.load)
         self.df["trans_ids"] = self.df["trans_ids"].apply(json.loads)
-        self.df["len"] = self.df["features"].apply(len)
+        self.df["len"] = self.df["trans_ids"].apply(len)
         self.df.sort_values("len", inplace=True)
         self.sample_size = len(self.df)
         self.df["id"] = list(range(self.sample_size))
@@ -27,8 +27,8 @@ class LibriSpeechDataset(torch.utils.data.Dataset):
         return self.sample_size
 
     def pad_collate(self, batch):
-        max_input_len = 128
-        max_target_len = 128
+        max_input_len = 256  # 142 to 3496
+        max_target_len = 16  # 11 to 586
 
         for elem in batch:
             index, feature, trn = elem

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -261,7 +261,7 @@ class CNNLSTM(nn.Module):
                 strides=(2, 2),
                 padding=((20, 20), (5, 5)),
             ),
-            nn.BatchNorm(),
+            BatchNorm(),
             functools.partial(hard_tanh, min_value=0, max_value=20),
             nn.Conv(
                 features=32,
@@ -269,7 +269,7 @@ class CNNLSTM(nn.Module):
                 strides=(2, 1),
                 padding=((10, 10), (5, 5)),
             ),
-            nn.BatchNorm(),
+            BatchNorm(),
             functools.partial(hard_tanh, min_value=0, max_value=20),
         ]
         self.conv = MaskConv(sequential)
@@ -284,7 +284,7 @@ class CNNLSTM(nn.Module):
         rnns.extend([BatchRNN(input_size=self.hidden_size, hidden_size=self.hidden_size)
                      for _ in range(self.hidden_layers - 1)])
         self.rnns = rnns
-        self.out_norm = SequenceWise(nn.BatchNorm())
+        self.out_norm = SequenceWise(BatchNorm())
         self.fc = nn.Dense(self.num_classes, use_bias=False)
 
     def __call__(self, inputs, lengths, training=False):

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -173,7 +173,7 @@ def flip_sequences(inputs, lengths):
     # a single example.
     max_length = inputs.shape[0]
     flipped = jnp.flip(jnp.roll(inputs, max_length - lengths, axis=0), axis=0)
-    mask = jnp.arange(max_length) < lengths
+    mask = jnp.arange(max_length).reshape(-1, 1) < lengths
     return flipped * mask
 
 

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -166,7 +166,7 @@ class BatchRNN(nn.Module):
 
 
 def hard_tanh(x, min_value=-1., max_value=1.):
-    return jnp.where(x > max_value, max_value, jnp.where(x < min_value, min_value, x))
+    return jnp.clip(x, min_value, max_value)
 
 
 def get_seq_lens(input_length, conv_seq_module):

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -295,7 +295,7 @@ class CNNLSTM(nn.Module):
         x = x.reshape(sizes[0], sizes[1] * sizes[2], sizes[3])  # Collapse feature dimension
         x = x.transpose(2, 0, 1)  # [Batch, Feature, Seq] -> [Seq, Batch, Feature]
 
-        mask = jnp.arange(x.shape[0]).reshape(-1, 1, 1) < lengths.reshape(-1, 1, 1)
+        mask = jnp.arange(x.shape[0]).reshape(-1, 1, 1) < lengths.reshape(1, -1, 1)
         for rnn in self.rnns:
             x = rnn(x, output_lengths, mask, training=training)
         x = self.out_norm(x, mask, training=training)

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -299,7 +299,7 @@ class CNNLSTM(nn.Module):
 
         for rnn in self.rnns:
             x = rnn(x, output_lengths, mask, training=training)
-        x = self.out_norm(x, mask, not training)
+        x = self.out_norm(x, mask, training=training)
         x = self.fc(x)
         log_probs = jax.nn.log_softmax(x, axis=-1)
         log_probs = log_probs.transpose(1, 0, 2)  # [Seq, Batch, Feature] -> [Batch, Seq, Feature]

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -9,161 +9,166 @@ import jax.numpy as jnp
 from flax import linen as nn
 
 
-class Sequential(nn.Module):
-  layers: Sequence[nn.Module]
 
-  def __call__(self, x):
-    for layer in self.layers:
-      x = layer(x)
-    return x
+
+class Sequential(nn.Module):
+    layers: Sequence[nn.Module]
+
+    def __call__(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
 
 
 class SequenceWise(nn.Module):
-  """Collapses input of dim T*N*H to (T*N)*H, and applies to a module.
+    """Collapses input of dim T*N*H to (T*N)*H, and applies to a module.
 
-    Allows handling of variable sequence lengths and minibatch sizes.
-    Args:
-      module: Module to apply input to.
-    """
-  module: nn.Module
+      Allows handling of variable sequence lengths and minibatch sizes.
+      Args:
+        module: Module to apply input to.
+      """
+    module: nn.Module
 
-  def __call__(self, x, training=False):
-    t, n = x.shape[0], x.shape[1]
-    x = jnp.reshape(x, (t * n, -1))
-    x = self.module(x)
-    x = jnp.reshape(x, (t, n, -1))
-    return x
+    def __call__(self, x, training=False):
+        # [Seq, Batch, Feature]
+        t, n = x.shape[0], x.shape[1]
+        x = jnp.reshape(x, (t * n, -1))  # [Seq, Batch, Feature] -> [Seq * Batch, Feature]
+        x = self.module(x)
+        x = jnp.reshape(x, (t, n, -1))  # [Seq, Batch, Feature] -> [Seq, Batch, Feature]
+        return x
+
 
 class MaskConv(nn.Module):
-  """Adds padding to the output of the module based on the given lengths.
-    This is to ensure that the results of the model do not change when batch
-    sizes change during inference. Input needs to be in the shape of (BxCxDxT)
-    Args:
-      seq_module: The sequential module containing the conv stack.
-    """
-  seq_module: Sequence[nn.Module]
+    """Adds padding to the output of the module based on the given lengths.
+      This is to ensure that the results of the model do not change when batch
+      sizes change during inference. Input needs to be in the shape of (BxCxDxT)
+      Args:
+        seq_module: The sequential module containing the conv stack.
+      """
+    seq_module: Sequence[nn.Module]
 
-  def __call__(self, x, lengths):
-    """Forward pass.
-    Args:
-      x: The input (before transposing it to channels-last) is of size BxCxDxT
-      lengths: The actual length of each sequence in the batch
-    Returns:
-      Masked output from the module
-    """
-    x = x.transpose(0, 2, 3, 1)
-    for module in self.seq_module:
-      x = module(x)
-      mask = jnp.arange(x.shape[1]).reshape(1, -1, 1, 1) >= lengths.reshape(-1, 1, 1, 1)
-      mask = mask.astype(jnp.float32)
-      x *= mask
-    x = x.transpose(0, 3, 1, 2)
-    return x, lengths
-  
-  
+    def __call__(self, x, lengths):
+        """Forward pass.
+        Args:
+          x: The input (before transposing it to channels-last) is of Shape[Batch, Channels, "D", TimeSteps]
+          lengths: The actual length of each sequence in the batch
+        Returns:
+          Masked output from the module
+        """
+
+        x = x.transpose(0, 2, 3, 1)
+        for module in self.seq_module:
+            x = module(x)
+            mask = jnp.arange(x.shape[1]).reshape(1, -1, 1, 1) >= lengths.reshape(-1, 1, 1, 1)
+            mask = mask.astype(jnp.float32)
+            x *= mask
+        x = x.transpose(0, 3, 1, 2)
+        return x, lengths
+
+
 @jax.vmap
 def flip_sequences(inputs, lengths):
-  """Flips a sequence of inputs along the time dimension.
-  This function can be used to prepare inputs for the reverse direction of a
-  bidirectional LSTM. It solves the issue that, when naively flipping multiple
-  padded sequences stored in a matrix, the first elements would be padding
-  values for those sequences that were padded. This function keeps the padding
-  at the end, while flipping the rest of the elements.
-  Example:
-  ```python
-  inputs = [[1, 0, 0],
-            [2, 3, 0]
-            [4, 5, 6]]
-  lengths = [1, 2, 3]
-  flip_sequences(inputs, lengths) = [[1, 0, 0],
-                                     [3, 2, 0],
-                                     [6, 5, 4]]
-  ```
-  Args:
-    inputs: An array of input IDs <int>[batch_size, seq_length].
-    lengths: The length of each sequence <int>[batch_size].
-  Returns:
-    An ndarray with the flipped inputs.
-  """
-  # Note: since this function is vmapped, the code below is effectively for
-  # a single example.
-  max_length = inputs.shape[0]
-  return jnp.flip(jnp.roll(inputs, max_length - lengths, axis=0), axis=0)
+    """Flips a sequence of inputs along the time dimension.
+    This function can be used to prepare inputs for the reverse direction of a
+    bidirectional LSTM. It solves the issue that, when naively flipping multiple
+    padded sequences stored in a matrix, the first elements would be padding
+    values for those sequences that were padded. This function keeps the padding
+    at the end, while flipping the rest of the elements.
+    Example:
+    ```python
+    inputs = [[1, 0, 0],
+              [2, 3, 0]
+              [4, 5, 6]]
+    lengths = [1, 2, 3]
+    flip_sequences(inputs, lengths) = [[1, 0, 0],
+                                       [3, 2, 0],
+                                       [6, 5, 4]]
+    ```
+    Args:
+      inputs: An array of input IDs <int>[batch_size, seq_length].
+      lengths: The length of each sequence <int>[batch_size].
+    Returns:
+      An ndarray with the flipped inputs.
+    """
+    # Note: since this function is vmapped, the code below is effectively for
+    # a single example.
+    max_length = inputs.shape[0]
+    return jnp.flip(jnp.roll(inputs, max_length - lengths, axis=0), axis=0)
 
 
 class SimpleLSTM(nn.Module):
-  """A simple unidirectional LSTM."""
+    """A simple unidirectional LSTM."""
 
-  @functools.partial(
-      nn.transforms.scan,
-      variable_broadcast='params',
-      in_axes=1, out_axes=1,
-      split_rngs={'params': False})
-  @nn.compact
-  def __call__(self, carry, x):
-    return nn.OptimizedLSTMCell()(carry, x)
+    @functools.partial(
+        nn.transforms.scan,
+        variable_broadcast='params',
+        in_axes=1, out_axes=1,
+        split_rngs={'params': False})
+    @nn.compact
+    def __call__(self, carry, x):
+        return nn.OptimizedLSTMCell()(carry, x)
 
-  @staticmethod
-  def initialize_carry(batch_dims, hidden_size):
-    # Use fixed random key since default state init fn is just zeros.
-    return nn.OptimizedLSTMCell.initialize_carry(
-        jax.random.PRNGKey(0), batch_dims, hidden_size)
+    @staticmethod
+    def initialize_carry(batch_dims, hidden_size):
+        # Use fixed random key since default state init fn is just zeros.
+        return nn.OptimizedLSTMCell.initialize_carry(
+            jax.random.PRNGKey(0), batch_dims, hidden_size)
 
 
 class SimpleBiLSTM(nn.Module):
-  """A simple bi-directional LSTM."""
-  hidden_size: int
+    """A simple bi-directional LSTM."""
+    hidden_size: int
 
-  def setup(self):
-    self.forward_lstm = SimpleLSTM()
-    self.backward_lstm = SimpleLSTM()
+    def setup(self):
+        self.forward_lstm = SimpleLSTM()
+        self.backward_lstm = SimpleLSTM()
 
-  def __call__(self, embedded_inputs, lengths):
-    batch_size = embedded_inputs.shape[0]
+    def __call__(self, embedded_inputs, lengths):
+        # [Batch, Seq, Feature]
+        batch_size = embedded_inputs.shape[0]
 
-    # Forward LSTM.
-    initial_state = SimpleLSTM.initialize_carry((batch_size,), self.hidden_size)
-    _, forward_outputs = self.forward_lstm(initial_state, embedded_inputs)
+        # Forward LSTM.
+        initial_state = SimpleLSTM.initialize_carry((batch_size,), self.hidden_size)
+        _, forward_outputs = self.forward_lstm(initial_state, embedded_inputs)
 
-    # Backward LSTM.
-    reversed_inputs = flip_sequences(embedded_inputs, lengths)
-    initial_state = SimpleLSTM.initialize_carry((batch_size,), self.hidden_size)
-    _, backward_outputs = self.backward_lstm(initial_state, reversed_inputs)
-    backward_outputs = flip_sequences(backward_outputs, lengths)
+        # Backward LSTM.
+        reversed_inputs = flip_sequences(embedded_inputs, lengths)
+        initial_state = SimpleLSTM.initialize_carry((batch_size,), self.hidden_size)
+        _, backward_outputs = self.backward_lstm(initial_state, reversed_inputs)
+        backward_outputs = flip_sequences(backward_outputs, lengths)
 
-    # Concatenate the forward and backward representations.
-    outputs = jnp.concatenate([forward_outputs, backward_outputs], -1)
-    return outputs
+        # Concatenate the forward and backward representations.
+        outputs = jnp.concatenate([forward_outputs, backward_outputs], -1)
+        return outputs
 
 
 class BatchRNN(nn.Module):
+    input_size: int
+    hidden_size: int
+    use_batch_norm: bool = True
+    train: bool = False
 
-  input_size: int
-  hidden_size: int
-  use_batch_norm: bool = True
-  train: bool = False
+    def setup(self):
+        if self.use_batch_norm:
+            self.batch_norm = SequenceWise(nn.BatchNorm(use_running_average=True))
+        else:
+            self.batch_norm = None
+        self.rnn = SimpleBiLSTM(self.hidden_size)
 
-  def setup(self):
-    if self.use_batch_norm:
-      self.batch_norm = SequenceWise(nn.BatchNorm(use_running_average=True))
-    else:
-      self.batch_norm = None
-    self.rnn = SimpleBiLSTM(self.hidden_size)
-
-  def __call__(self, inputs, lengths, training=False):
-    if self.batch_norm is not None:
-      inputs = self.batch_norm(inputs)
-    inputs = inputs.transpose(1, 0, 2)
-    inputs = self.rnn(inputs, lengths)
-    inputs = inputs.transpose(1, 0, 2)
-    # (TxNxH*2) -> (TxNxH) by sum
-    inputs = inputs.reshape(inputs.shape[0], inputs.shape[1], -1).sum(2)
-    return inputs
+    def __call__(self, inputs, lengths, training=False):
+        # [Seq, Batch, Feature]
+        if self.batch_norm is not None:
+            inputs = self.batch_norm(inputs)
+        inputs = inputs.transpose(1, 0, 2)  # [Seq, Batch, Feature] -> [Batch, Seq, Feature]
+        inputs = self.rnn(inputs, lengths)
+        inputs = inputs.transpose(1, 0, 2)  # [Batch, Seq, Feature] -> [Seq, Batch, Feature]
+        # [Seq, Batch, Feature * 2] -> [Seq, Batch, Feature] by sum
+        inputs = inputs.reshape(inputs.shape[0], inputs.shape[1], -1).sum(2)
+        return inputs
 
 
 def hard_tanh(x, min_value=-1., max_value=1.):
-
-  return jnp.where(x > max_value, max_value, jnp.where(x < min_value, min_value, x))
+    return jnp.where(x > max_value, max_value, jnp.where(x < min_value, min_value, x))
 
 
 def get_seq_lens(input_length, conv_seq_module):
@@ -177,81 +182,67 @@ def get_seq_lens(input_length, conv_seq_module):
     """
     seq_len = input_length
     for m in conv_seq_module:
-      if isinstance(m, nn.Conv):
-        seq_len = (seq_len + 2 * m.padding[1][1] - m.kernel_dilation * (m.kernel_size[1] - 1) - 1) // m.strides[1] + 1
+        if isinstance(m, nn.Conv):
+            seq_len = (seq_len + 2 * m.padding[1][1] - m.kernel_dilation * (m.kernel_size[1] - 1) - 1) // m.strides[
+                1] + 1
     return seq_len
 
 
 class CNNLSTM(nn.Module):
+    num_classes = 29
+    hidden_size = 768
+    hidden_layers = 5
+    context = 20
 
-  num_classes = 29
-  hidden_size = 768
-  hidden_layers = 5
-  context = 20
+    def setup(self):
+        sequential = [
+            nn.Conv(
+                features=32,
+                kernel_size=(41, 11),
+                strides=(2, 2),
+                padding=((20, 20), (5, 5)),
+            ),
+            nn.BatchNorm(use_running_average=True),
+            functools.partial(hard_tanh, min_value=0, max_value=20),
+            nn.Conv(
+                features=32,
+                kernel_size=(21, 11),
+                strides=(2, 1),
+                padding=((10, 10), (5, 5)),
+            ),
+            nn.BatchNorm(use_running_average=True),
+            functools.partial(hard_tanh, min_value=0, max_value=20),
+        ]
+        self.conv = MaskConv(sequential)
 
-  def setup(self):
-    sequential = [
-      nn.Conv(
-        features=32,
-        kernel_size=(41, 11),
-        strides=(2, 2),
-        padding=((20, 20), (5, 5)),
-      ),
-      nn.BatchNorm(use_running_average=True),
-      functools.partial(hard_tanh, min_value=0, max_value=20),
-      nn.Conv(
-        features=32,
-        kernel_size=(21, 11),
-        strides=(2, 1),
-        padding=((10, 10), (5, 5)),
-      ),
-      nn.BatchNorm(use_running_average=True),
-      functools.partial(hard_tanh, min_value=0, max_value=20),
-    ]
-    self.conv = MaskConv(sequential)
+        rnn_input_size = 161
+        rnn_input_size = int(math.floor(rnn_input_size + 2 * 20 - 41) / 2 + 1)
+        rnn_input_size = int(math.floor(rnn_input_size + 2 * 10 - 21) / 2 + 1)
+        rnn_input_size *= 32
 
-    rnn_input_size = 161
-    rnn_input_size = int(math.floor(rnn_input_size + 2 * 20 - 41) / 2 + 1)
-    rnn_input_size = int(math.floor(rnn_input_size + 2 * 10 - 21) / 2 + 1)
-    rnn_input_size *= 32
+        self.rnns = [BatchRNN(input_size=rnn_input_size, hidden_size=self.hidden_size,
+                              use_batch_norm=False)]
+        self.rnns.extend([BatchRNN(input_size=self.hidden_size, hidden_size=self.hidden_size)
+                          for _ in range(self.hidden_layers - 1)])
 
-    rnns = []
-    rnn = BatchRNN(
-        input_size=rnn_input_size,
-        hidden_size=self.hidden_size,
-        use_batch_norm=False,
-    )
-    rnns.append(rnn)
-    for _ in range(self.hidden_layers - 1):
-      rnn = BatchRNN(
-          input_size=self.hidden_size,
-          hidden_size=self.hidden_size
-          )
-      rnns.append(rnn)
+        fully_connected = Sequential([nn.BatchNorm(use_running_average=True),
+                                      nn.Dense(self.num_classes, use_bias=False)])
+        self.fc = SequenceWise(fully_connected)
 
-    self.rnns = rnns
+    def __call__(self, inputs, lengths, training=False):
+        output_lengths = get_seq_lens(lengths, self.conv.seq_module)
 
-    fully_connected = Sequential([
-      nn.BatchNorm(use_running_average=True),
-      nn.Dense(self.num_classes, use_bias=False)
-    ])
+        x, _ = self.conv(inputs, lengths)
 
-    self.fc = SequenceWise(fully_connected)
+        sizes = x.shape
+        x = x.reshape(sizes[0], sizes[1] * sizes[2], sizes[3])  # Collapse feature dimension
+        x = x.transpose(2, 0, 1)  # [Batch, Feature, Seq] -> [Seq, Batch, Feature]
 
-  def __call__(self, inputs, lengths, training=False):
-    output_lengths = get_seq_lens(lengths, self.conv.seq_module)
+        for rnn in self.rnns:
+            x = rnn(x, output_lengths, training=training)
 
-    x, _ = self.conv(inputs, lengths)
+        x = self.fc(x, training=training)
+        log_probs = jax.nn.log_softmax(x, axis=-1)
+        log_probs = log_probs.transpose(1, 0, 2)  # [Seq, Batch, Feature] -> [Batch, Seq, Feature]
 
-    sizes = x.shape
-    x = x.reshape(sizes[0], sizes[1] * sizes[2],
-               sizes[3]) 
-    x = x.transpose(0, 2, 1).transpose(1, 0, 2)
-
-    for rnn in self.rnns:
-      x = rnn(x, output_lengths, training=training)
-    
-    x = self.fc(x, training=training)
-    log_probs = jax.nn.log_softmax(x, axis=-1).transpose(1, 0, 2)
-
-    return log_probs, output_lengths
+        return log_probs, output_lengths

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -135,9 +135,8 @@ class SimpleBiLSTM(nn.Module):
         _, backward_outputs = self.backward_lstm(initial_state, reversed_inputs)
         backward_outputs = flip_sequences(backward_outputs, lengths)
 
-        # Concatenate the forward and backward representations.
-        outputs = jnp.concatenate([forward_outputs, backward_outputs], -1)
-        return outputs
+        # Add the forward and backward representations.
+        return forward_outputs + backward_outputs
 
 
 class BatchRNN(nn.Module):
@@ -160,8 +159,6 @@ class BatchRNN(nn.Module):
         inputs = inputs.transpose(1, 0, 2)  # [Seq, Batch, Feature] -> [Batch, Seq, Feature]
         inputs = self.rnn(inputs, lengths)
         inputs = inputs.transpose(1, 0, 2)  # [Batch, Seq, Feature] -> [Seq, Batch, Feature]
-        # [Seq, Batch, Feature * 2] --reshape--> [Seq, Batch, 2, Feature] --sum--> [Seq, Batch, Feature]
-        inputs = inputs.reshape(inputs.shape[0], inputs.shape[1], 2, -1).sum(2)
         return inputs
 
 

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -9,8 +9,6 @@ import jax.numpy as jnp
 from flax import linen as nn
 
 
-
-
 class Sequential(nn.Module):
     layers: Sequence[nn.Module]
 
@@ -220,10 +218,11 @@ class CNNLSTM(nn.Module):
         rnn_input_size = int(math.floor(rnn_input_size + 2 * 10 - 21) / 2 + 1)
         rnn_input_size *= 32
 
-        self.rnns = [BatchRNN(input_size=rnn_input_size, hidden_size=self.hidden_size,
-                              use_batch_norm=False)]
-        self.rnns.extend([BatchRNN(input_size=self.hidden_size, hidden_size=self.hidden_size)
-                          for _ in range(self.hidden_layers - 1)])
+        rnns = [BatchRNN(input_size=rnn_input_size, hidden_size=self.hidden_size,
+                         use_batch_norm=False)]
+        rnns.extend([BatchRNN(input_size=self.hidden_size, hidden_size=self.hidden_size)
+                     for _ in range(self.hidden_layers - 1)])
+        self.rnns = rnns
 
         fully_connected = Sequential([nn.BatchNorm(use_running_average=True),
                                       nn.Dense(self.num_classes, use_bias=False)])

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -138,7 +138,7 @@ class MaskConv(nn.Module):
         x = x.transpose(0, 2, 3, 1)
         for module in self.seq_module:
             x = module(x)
-            mask = jnp.arange(x.shape[1]).reshape(1, -1, 1, 1) < lengths.reshape(-1, 1, 1, 1)
+            mask = jnp.arange(x.shape[1]).reshape(1, 1, -1, 1) < lengths.reshape(-1, 1, 1, 1)
             x = BatchNorm()(x, mask.astype(jnp.float32), not training)
             x = hard_tanh(x, 0, 20)
         x = x.transpose(0, 3, 1, 2)

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -172,7 +172,9 @@ def flip_sequences(inputs, lengths):
     # Note: since this function is vmapped, the code below is effectively for
     # a single example.
     max_length = inputs.shape[0]
-    return jnp.flip(jnp.roll(inputs, max_length - lengths, axis=0), axis=0)
+    flipped = jnp.flip(jnp.roll(inputs, max_length - lengths, axis=0), axis=0)
+    mask = jnp.arange(max_length) < lengths
+    return flipped * mask
 
 
 class SimpleLSTM(nn.Module):

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -124,7 +124,7 @@ class MaskConv(nn.Module):
         x = x.transpose(0, 2, 3, 1)
         for module in self.seq_module:
             x = module(x)
-            x = BatchNorm()(x, mask, training)
+            x = BatchNorm()(x, mask, not training)
             x = hard_tanh(x, 0, 20)
         x = x.transpose(0, 3, 1, 2)
         return x
@@ -299,7 +299,7 @@ class CNNLSTM(nn.Module):
 
         for rnn in self.rnns:
             x = rnn(x, output_lengths, mask, training=training)
-        x = self.out_norm(x, mask, training=training)
+        x = self.out_norm(x, mask, not training)
         x = self.fc(x)
         log_probs = jax.nn.log_softmax(x, axis=-1)
         log_probs = log_probs.transpose(1, 0, 2)  # [Seq, Batch, Feature] -> [Batch, Seq, Feature]

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -221,7 +221,7 @@ class BatchRNN(nn.Module):
     def __call__(self, inputs, lengths, mask, training=False):
         # [Seq, Batch, Feature]
         if self.batch_norm is not None:
-            inputs = self.batch_norm(inputs, mask)
+            inputs = self.batch_norm(inputs, mask, training)
         inputs = inputs.transpose(1, 0, 2)  # [Seq, Batch, Feature] -> [Batch, Seq, Feature]
         inputs = self.rnn(inputs, lengths)
         inputs = inputs.transpose(1, 0, 2)  # [Batch, Seq, Feature] -> [Seq, Batch, Feature]
@@ -288,15 +288,15 @@ class CNNLSTM(nn.Module):
     def __call__(self, inputs, lengths, training=False):
         output_lengths = get_seq_lens(lengths, self.conv.seq_module)
 
-        mask: jnp.ndarray = jnp.arange(inputs.shape[1]).reshape(1, -1, 1, 1) >= output_lengths.reshape(-1, 1, 1, 1)
+        mask: jnp.ndarray = jnp.arange(inputs.shape[1]).reshape(1, -1, 1, 1) < output_lengths.reshape(-1, 1, 1, 1)
         mask = mask.astype(jnp.float32)
 
         x = self.conv(inputs, mask, training)
-
         sizes = x.shape
         x = x.reshape(sizes[0], sizes[1] * sizes[2], sizes[3])  # Collapse feature dimension
         x = x.transpose(2, 0, 1)  # [Batch, Feature, Seq] -> [Seq, Batch, Feature]
 
+        mask = mask.transpose(1, 0, 2, 3).reshape(mask.shape[1], mask.shape[0], 1)
         for rnn in self.rnns:
             x = rnn(x, output_lengths, mask, training=training)
         x = self.out_norm(x, mask, training=training)

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -300,7 +300,7 @@ class CNNLSTM(nn.Module):
         for rnn in self.rnns:
             x = rnn(x, output_lengths, mask, training=training)
         x = self.out_norm(x, mask, training=training)
-        x = self.fc(x, training=training)
+        x = self.fc(x)
         log_probs = jax.nn.log_softmax(x, axis=-1)
         log_probs = log_probs.transpose(1, 0, 2)  # [Seq, Batch, Feature] -> [Batch, Seq, Feature]
 

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -9,8 +9,11 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax.linen.normalization import _canonicalize_axes, _normalize
 from jax import lax
+from jax.experimental.compilation_cache import compilation_cache
 
 Axes = Union[int, Iterable[int]]
+
+compilation_cache.initialize_cache("compilation_cache")
 
 
 class Sequential(nn.Module):

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -23,6 +23,8 @@ class Sequential(nn.Module):
 
 
 class BatchNorm(nn.BatchNorm):
+    momentum: float = 0.9
+
     @nn.compact
     def __call__(self, x: jnp.ndarray, mask: jnp.ndarray, use_running_average: Optional[bool] = None):
         """Normalizes the input using batch statistics.
@@ -292,7 +294,7 @@ class CNNLSTM(nn.Module):
         mask: jnp.ndarray = jnp.arange(inputs.shape[1]).reshape(1, -1, 1, 1) >= output_lengths.reshape(-1, 1, 1, 1)
         mask = mask.astype(jnp.float32)
 
-        x, _ = self.conv(inputs, mask)
+        x = self.conv(inputs, mask)
 
         sizes = x.shape
         x = x.reshape(sizes[0], sizes[1] * sizes[2], sizes[3])  # Collapse feature dimension

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -1,0 +1,273 @@
+"""DeepSpeech Models modified from https://github.com/lsari/librispeech_100/blob/main/models.py."""
+
+import functools
+import math
+from typing import Sequence
+
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+
+
+class Sequential(nn.Module):
+  layers: Sequence[nn.Module]
+
+  def __call__(self, x, training=False):
+    for layer in self.layers:
+      if isinstance(layer, nn.BatchNorm):
+        x = layer(x, use_running_average=training)
+      else:
+        x = layer(x)
+    return x
+
+
+class SequenceWise(nn.Module):
+  """Collapses input of dim T*N*H to (T*N)*H, and applies to a module.
+
+    Allows handling of variable sequence lengths and minibatch sizes.
+    Args:
+      module: Module to apply input to.
+    """
+  module: nn.Module
+
+  def __call__(self, x, training=False):
+    t, n = x.shape[0], x.shape[1]
+    x = jnp.reshape(x, (t * n, -1))
+    if isinstance(self.module, nn.BatchNorm):
+      x = self.module(x, use_running_average=training)
+    elif isinstance(self.module, Sequential):
+      x = self.module(x, training=training)
+    else:
+      x = self.module(x)
+    x = jnp.reshape(x, (t, n, -1))
+    return x
+
+
+class MaskConv(nn.Module):
+  """Adds padding to the output of the module based on the given lengths.
+
+    This is to ensure that the results of the model do not change when batch
+    sizes change during inference. Input needs to be in the shape of (BxCxDxT)
+    Args:
+      seq_module: The sequential module containing the conv stack.
+    """
+  seq_module: Sequence[nn.Module]
+
+  def __call__(self, x, lengths, training=False):
+    """Forward pass.
+
+    Args:
+      x: The input of size BxCxDxT
+      lengths: The actual length of each sequence in the batch
+
+    Returns:
+      Masked output from the module
+    """
+    x = x.transpose(0, 2, 3, 1)
+    for module in self.seq_module:
+      if isinstance(module, nn.BatchNorm):
+        x = module(x, use_running_average=training)
+      else:
+        x = module(x)
+      mask = jnp.zeros_like(x)
+      for i, length in enumerate(lengths):
+        length = length.item()
+        if mask[i].shape[2] - length > 0:
+          mask = mask.at[i, :, :, length:].set(1)
+      x = jnp.where(mask, x, 0)
+    x = x.transpose(0, 3, 1, 2)
+    return x, lengths
+
+@jax.vmap
+def flip_sequences(inputs, lengths):
+  """Flips a sequence of inputs along the time dimension.
+  This function can be used to prepare inputs for the reverse direction of a
+  bidirectional LSTM. It solves the issue that, when naively flipping multiple
+  padded sequences stored in a matrix, the first elements would be padding
+  values for those sequences that were padded. This function keeps the padding
+  at the end, while flipping the rest of the elements.
+  Example:
+  ```python
+  inputs = [[1, 0, 0],
+            [2, 3, 0]
+            [4, 5, 6]]
+  lengths = [1, 2, 3]
+  flip_sequences(inputs, lengths) = [[1, 0, 0],
+                                     [3, 2, 0],
+                                     [6, 5, 4]]
+  ```
+  Args:
+    inputs: An array of input IDs <int>[batch_size, seq_length].
+    lengths: The length of each sequence <int>[batch_size].
+  Returns:
+    An ndarray with the flipped inputs.
+  """
+  # Note: since this function is vmapped, the code below is effectively for
+  # a single example.
+  max_length = inputs.shape[0]
+  return jnp.flip(jnp.roll(inputs, max_length - lengths, axis=0), axis=0)
+
+
+class SimpleLSTM(nn.Module):
+  """A simple unidirectional LSTM."""
+
+  @functools.partial(
+      nn.transforms.scan,
+      variable_broadcast='params',
+      in_axes=1, out_axes=1,
+      split_rngs={'params': False})
+  @nn.compact
+  def __call__(self, carry, x):
+    return nn.OptimizedLSTMCell()(carry, x)
+
+  @staticmethod
+  def initialize_carry(batch_dims, hidden_size):
+    # Use fixed random key since default state init fn is just zeros.
+    return nn.OptimizedLSTMCell.initialize_carry(
+        jax.random.PRNGKey(0), batch_dims, hidden_size)
+
+
+class SimpleBiLSTM(nn.Module):
+  """A simple bi-directional LSTM."""
+  hidden_size: int
+
+  def setup(self):
+    self.forward_lstm = SimpleLSTM()
+    self.backward_lstm = SimpleLSTM()
+
+  def __call__(self, embedded_inputs, lengths):
+    batch_size = embedded_inputs.shape[0]
+
+    # Forward LSTM.
+    initial_state = SimpleLSTM.initialize_carry((batch_size,), self.hidden_size)
+    _, forward_outputs = self.forward_lstm(initial_state, embedded_inputs)
+
+    # Backward LSTM.
+    reversed_inputs = flip_sequences(embedded_inputs, lengths)
+    initial_state = SimpleLSTM.initialize_carry((batch_size,), self.hidden_size)
+    _, backward_outputs = self.backward_lstm(initial_state, reversed_inputs)
+    backward_outputs = flip_sequences(backward_outputs, lengths)
+
+    # Concatenate the forward and backward representations.
+    outputs = jnp.concatenate([forward_outputs, backward_outputs], -1)
+    return outputs
+
+
+class BatchRNN(nn.Module):
+
+  input_size: int
+  hidden_size: int
+  use_batch_norm: bool = True
+  train: bool = False
+
+  def setup(self):
+    if self.use_batch_norm:
+      self.batch_norm = SequenceWise(nn.BatchNorm())
+    else:
+      self.batch_norm = None
+    self.rnn = SimpleBiLSTM(self.hidden_size)
+
+  def __call__(self, inputs, lengths, training=False):
+    if self.batch_norm is not None:
+      inputs = self.batch_norm(inputs)
+    inputs = inputs.transpose(1, 0, 2)
+    inputs = self.rnn(inputs, lengths)
+    inputs = inputs.transpose(1, 0, 2)
+    # (TxNxH*2) -> (TxNxH) by sum
+    inputs = inputs.reshape(inputs.shape[0], inputs.shape[1], -1).sum(2)
+    return inputs
+
+
+def hard_tanh(x, min_value=-1., max_value=1.):
+
+  return jnp.where(x > max_value, max_value, jnp.where(x < min_value, min_value, x))
+
+
+class CNNLSTM(nn.Module):
+
+  num_classes = 29
+  hidden_size = 768
+  hidden_layers = 5
+  context = 20
+
+  def setup(self):
+    sequential = [
+      nn.Conv(
+        features=32,
+        kernel_size=(41, 11),
+        strides=(2, 2),
+        padding=((20, 20), (5, 5)),
+      ),
+      nn.BatchNorm(),
+      functools.partial(hard_tanh, min_value=0, max_value=20),
+      nn.Conv(
+        features=32,
+        kernel_size=(21, 11),
+        strides=(2, 1),
+        padding=((10, 10), (5, 5)),
+      ),
+      nn.BatchNorm(),
+      functools.partial(hard_tanh, min_value=0, max_value=20),
+    ]
+    self.conv = MaskConv(sequential)
+
+    rnn_input_size = 161
+    rnn_input_size = int(math.floor(rnn_input_size + 2 * 20 - 41) / 2 + 1)
+    rnn_input_size = int(math.floor(rnn_input_size + 2 * 10 - 21) / 2 + 1)
+    rnn_input_size *= 32
+
+    rnns = []
+    rnn = BatchRNN(
+        input_size=rnn_input_size,
+        hidden_size=self.hidden_size,
+        use_batch_norm=False,
+    )
+    rnns.append(rnn)
+    for _ in range(self.hidden_layers - 1):
+      rnn = BatchRNN(
+          input_size=self.hidden_size,
+          hidden_size=self.hidden_size
+          )
+      rnns.append(rnn)
+
+    self.rnns = rnns
+
+    fully_connected = Sequential([
+      nn.BatchNorm(),
+      nn.Dense(self.num_classes, use_bias=False)
+    ])
+
+    self.fc = SequenceWise(fully_connected)
+
+  def get_seq_lens(self, input_length):
+    """Get a 1D tensor or variable containing the size sequences that will be output by the network.
+
+    Args:
+      input_length: 1D Tensor
+
+    Returns:
+      1D Tensor scaled by model
+    """
+    seq_len = input_length
+    for m in self.conv.seq_module:
+      if isinstance(m, nn.Conv):
+        seq_len = (seq_len + 2 * m.padding[1][1] - m.kernel_dilation * (m.kernel_size[1] - 1) - 1) // m.strides[1] + 1
+    return seq_len
+  
+  def __call__(self, inputs, lengths, training=False):
+    output_lengths = self.get_seq_lens(lengths)
+
+    x, _ = self.conv(inputs, lengths, training=training)
+
+    sizes = x.shape
+    x = x.reshape(sizes[0], sizes[1] * sizes[2],
+               sizes[3]) 
+    x = x.transpose(0, 2, 1).transpose(1, 0, 2)
+
+    for rnn in self.rnns:
+      x = rnn(x, output_lengths, training=training)
+    
+    x = self.fc(x, training=training)
+    log_probs = jax.nn.log_softmax(x, axis=-1).transpose(1, 0, 2)
+
+    return log_probs, output_lengths

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -291,7 +291,7 @@ class CNNLSTM(nn.Module):
         mask: jnp.ndarray = jnp.arange(inputs.shape[1]).reshape(1, -1, 1, 1) >= output_lengths.reshape(-1, 1, 1, 1)
         mask = mask.astype(jnp.float32)
 
-        x = self.conv(inputs, mask)
+        x = self.conv(inputs, mask, training)
 
         sizes = x.shape
         x = x.reshape(sizes[0], sizes[1] * sizes[2], sizes[3])  # Collapse feature dimension

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -221,7 +221,7 @@ class SimpleBiLSTM(nn.Module):
         out = forward_outputs + backward_outputs
         
         # remove hidden states for padded zeros
-        mask = jnp.arange(inputs.shape[1]).reshape(1, -1, 1) < lengths.reshape(-1, 1, 1)
+        mask = jnp.arange(embedded_inputs.shape[1]).reshape(1, -1, 1) < lengths.reshape(-1, 1, 1)
         return out * mask
 
 

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -45,7 +45,7 @@ class MaskConv(nn.Module):
     """
   seq_module: Sequence[nn.Module]
 
-  def __call__(self, x, lengths, training=False):
+  def __call__(self, x, lengths):
     """Forward pass.
 
     Args:
@@ -60,7 +60,6 @@ class MaskConv(nn.Module):
       x = module(x)
       mask = jnp.zeros_like(x)
       for i, length in enumerate(lengths):
-        length = length.item()
         if mask[i].shape[2] - length > 0:
           mask = mask.at[i, :, :, length:].set(1)
       x = jnp.where(mask, x, 0)
@@ -246,7 +245,7 @@ class CNNLSTM(nn.Module):
   def __call__(self, inputs, lengths, training=False):
     output_lengths = self.get_seq_lens(lengths)
 
-    x, _ = self.conv(inputs, lengths, training=training)
+    x, _ = self.conv(inputs, lengths)
 
     sizes = x.shape
     x = x.reshape(sizes[0], sizes[1] * sizes[2],

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -138,7 +138,7 @@ class MaskConv(nn.Module):
         x = x.transpose(0, 2, 3, 1)
         for module in self.seq_module:
             x = module(x)
-            mask = jnp.arange(x.shape[1]).reshape(1, 1, -1, 1) < lengths.reshape(-1, 1, 1, 1)
+            mask = jnp.arange(x.shape[2]).reshape(1, 1, -1, 1) < lengths.reshape(-1, 1, 1, 1)
             x = BatchNorm()(x, mask.astype(jnp.float32), not training)
             x = hard_tanh(x, 0, 20)
         x = x.transpose(0, 3, 1, 2)

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -173,8 +173,7 @@ def flip_sequences(inputs, lengths):
     # a single example.
     max_length = inputs.shape[0]
     flipped = jnp.flip(jnp.roll(inputs, max_length - lengths, axis=0), axis=0)
-    mask = jnp.arange(max_length).reshape(-1, 1) < lengths
-    return flipped * mask
+    return flipped
 
 
 class SimpleLSTM(nn.Module):
@@ -219,7 +218,11 @@ class SimpleBiLSTM(nn.Module):
         backward_outputs = flip_sequences(backward_outputs, lengths)
 
         # Add the forward and backward representations.
-        return forward_outputs + backward_outputs
+        out = forward_outputs + backward_outputs
+        
+        # remove hidden states for padded zeros
+        mask = jnp.arange(inputs.shape[1]).reshape(1, -1, 1) < lengths.reshape(-1, 1, 1)
+        return out * mask
 
 
 class BatchRNN(nn.Module):

--- a/workloads/librispeech/librispeech_jax/models.py
+++ b/workloads/librispeech/librispeech_jax/models.py
@@ -160,8 +160,8 @@ class BatchRNN(nn.Module):
         inputs = inputs.transpose(1, 0, 2)  # [Seq, Batch, Feature] -> [Batch, Seq, Feature]
         inputs = self.rnn(inputs, lengths)
         inputs = inputs.transpose(1, 0, 2)  # [Batch, Seq, Feature] -> [Seq, Batch, Feature]
-        # [Seq, Batch, Feature * 2] -> [Seq, Batch, Feature] by sum
-        inputs = inputs.reshape(inputs.shape[0], inputs.shape[1], -1).sum(2)
+        # [Seq, Batch, Feature * 2] --reshape--> [Seq, Batch, 2, Feature] --sum--> [Seq, Batch, Feature]
+        inputs = inputs.reshape(inputs.shape[0], inputs.shape[1], 2, -1).sum(2)
         return inputs
 
 

--- a/workloads/librispeech/librispeech_jax/submission.py
+++ b/workloads/librispeech/librispeech_jax/submission.py
@@ -130,7 +130,7 @@ def update_params(
   }
   optimizer_state, opt_update_fn = optimizer_state
   new_model_state, new_optimizer_state, new_params = pmapped_train_step(
-    workload, opt_update_fn, model_state, optimizer_state,
+    workload, opt_update_fn, in_len, out_len, model_state, optimizer_state,
     current_param_container, hyperparameters, batch, rng)
 
   steps_per_epoch = workload.num_train_examples // get_batch_size('librispeech_jax')

--- a/workloads/librispeech/librispeech_jax/submission.py
+++ b/workloads/librispeech/librispeech_jax/submission.py
@@ -43,9 +43,11 @@ def init_optimizer_state(
   jax.pmap,
   axis_name='batch',
   in_axes=(None, None, 0, 0, 0, None, 0, None),
-  static_broadcasted_argnums=(0, 1))
-def pmapped_train_step(workload, opt_update_fn, model_state, optimizer_state,
+  static_broadcasted_argnums=(0, 1, 2, 3))
+def pmapped_train_step(workload, opt_update_fn, in_len, out_len, model_state, optimizer_state,
                        current_param_container, hyperparameters, batch, rng):
+  _ = in_len
+  _ = out_len
   def _loss_fn(params):
     """loss function used for training."""
     variables = {'params': params, **model_state}
@@ -83,7 +85,7 @@ def update_params(
     global_step: int,
     rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
-  _, features, transcripts, input_lengths,  transcripts_padding = input_batch
+  _, features, transcripts, input_lengths,  transcripts_padding, in_len, out_len = input_batch
   features = jnp.expand_dims(features.transpose(0, 2, 1), axis=1)
   num_devices = jax.local_device_count()
   reshaped_features = jnp.reshape(

--- a/workloads/librispeech/librispeech_jax/submission.py
+++ b/workloads/librispeech/librispeech_jax/submission.py
@@ -42,7 +42,7 @@ def init_optimizer_state(
 @functools.partial(
   jax.pmap,
   axis_name='batch',
-  in_axes=(None, None, 0, 0, 0, None, 0, None),
+  in_axes=(None, None, None, None, 0, 0, 0, None, 0, None),
   static_broadcasted_argnums=(0, 1, 2, 3))
 def pmapped_train_step(workload, opt_update_fn, in_len, out_len, model_state, optimizer_state,
                        current_param_container, hyperparameters, batch, rng):

--- a/workloads/librispeech/librispeech_jax/submission.py
+++ b/workloads/librispeech/librispeech_jax/submission.py
@@ -134,9 +134,9 @@ def update_params(
     current_param_container, hyperparameters, batch, rng)
 
   steps_per_epoch = workload.num_train_examples // get_batch_size('librispeech_jax')
-  if (global_step + 1) % steps_per_epoch == 0:
-    # sync batch statistics across replicas once per epoch
-    new_model_state = workload.sync_batch_stats(new_model_state)
+  # due to the psum, batchnorm states don't have to be synchronised
+  #if (global_step + 1) % steps_per_epoch == 0:
+    #new_model_state = workload.sync_batch_stats(new_model_state)
 
   return (new_optimizer_state, opt_update_fn), new_params, new_model_state
 

--- a/workloads/librispeech/librispeech_jax/submission.py
+++ b/workloads/librispeech/librispeech_jax/submission.py
@@ -1,0 +1,126 @@
+import functools
+from typing import Iterator, List, Tuple
+
+import jax
+import jax.numpy as jnp
+import optax
+import spec
+from flax import jax_utils
+from jax import lax
+
+
+def get_batch_size(workload_name):
+  batch_sizes = {"librispeech_jax": 8}
+  return batch_sizes[workload_name]
+
+def optimizer(hyperparameters: spec.Hyperparamters):
+  opt_init_fn, opt_update_fn = optax.adam(
+      learning_rate=hyperparameters.learning_rate
+    )
+  return opt_init_fn, opt_update_fn
+
+
+def init_optimizer_state(
+    workload: spec.Workload,
+    model_params: spec.ParameterContainer,
+    model_state: spec.ModelAuxiliaryState,
+    hyperparameters: spec.Hyperparamters,
+    rng: spec.RandomState) -> spec.OptimizerState:
+  params_zeros_like = jax.tree_map(
+      lambda s: jnp.zeros(s.shape_tuple), workload.param_shapes)
+  opt_init_fn, opt_update_fn = optimizer(hyperparameters)
+  optimizer_state = opt_init_fn(params_zeros_like)
+  return jax_utils.replicate(optimizer_state), opt_update_fn
+
+
+# We need to jax.pmap here instead of inside update_params because the latter
+# would recompile the function every step.
+@functools.partial(
+  jax.pmap,
+  axis_name='batch',
+  in_axes=(None, None, 0, 0, 0, None, 0, None),
+  static_broadcasted_argnums=(0, 1))
+def pmapped_train_step(workload, opt_update_fn, model_state, optimizer_state,
+                       current_param_container, hyperparameters, batch, rng):
+  def _loss_fn(params):
+    """loss function used for training."""
+    variables = {'params': params, **model_state}
+    logits, new_model_state = workload.model_fn(
+        params,
+        batch['input'],
+        model_state,
+        spec.ForwardPassMode.TRAIN,
+        rng,
+        update_batch_norm=True)
+    loss = workload.loss_fn(batch['label'], logits)
+    return loss, (new_model_state, logits)
+
+  grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
+  aux, grad = grad_fn(current_param_container)
+  grad = lax.pmean(grad, axis_name='batch')
+  new_model_state, logits = aux[1]
+  updates, new_optimizer_state = opt_update_fn(
+      grad, optimizer_state, current_param_container)
+  updated_params = optax.apply_updates(current_param_container, updates)
+
+  return new_model_state, new_optimizer_state, updated_params
+
+def update_params(
+    workload: spec.Workload,
+    current_param_container: spec.ParameterContainer,
+    current_params_types: spec.ParameterTypeTree,
+    model_state: spec.ModelAuxiliaryState,
+    hyperparameters: spec.Hyperparamters,
+    input_batch: spec.Tensor,
+    label_batch: spec.Tensor,
+    loss_type: spec.LossType,
+    optimizer_state: spec.OptimizerState,
+    eval_results: List[Tuple[int, float]],
+    global_step: int,
+    rng: spec.RandomState) -> spec.UpdateReturn:
+  """Return (updated_optimizer_state, updated_params, updated_model_state)."""
+  _, features, transcripts, input_lengths = input_batch
+  features = jnp.expand_dims(features.transpose(0, 2, 1), axis=1)
+  num_devices = jax.local_device_count()
+  reshaped_features = jnp.reshape(
+      features,
+      (num_devices, features.shape[0] // num_devices, *features.shape[1:]))
+  reshaped_input_lengths = jnp.reshape(
+      input_lengths,
+      (num_devices, input_lengths.shape[0] // num_devices, *input_lengths.shape[1:]))
+  reshaped_transcripts = jnp.reshape(
+      transcripts,
+      (num_devices, transcripts.shape[0] // num_devices,
+       *transcripts.shape[1:]))
+  batch = {
+    'input': (reshaped_features, reshaped_input_lengths),
+    'label': reshaped_transcripts,
+  }
+  optimizer_state, opt_update_fn = optimizer_state
+  new_model_state, new_optimizer_state, new_params = pmapped_train_step(
+    workload, opt_update_fn, model_state, optimizer_state,
+    current_param_container, hyperparameters, batch, rng)
+
+  steps_per_epoch = workload.num_train_examples // get_batch_size('librispeech_jax')
+  if (global_step + 1) % steps_per_epoch == 0:
+    # sync batch statistics across replicas once per epoch
+    new_model_state = workload.sync_batch_stats(new_model_state)
+
+  return (new_optimizer_state, opt_update_fn), new_params, new_model_state
+
+
+def data_selection(
+    workload: spec.Workload,
+    input_queue: Iterator[Tuple[spec.Tensor, spec.Tensor]],
+    optimizer_state: spec.OptimizerState,
+    current_param_container: spec.ParameterContainer,
+    hyperparameters: spec.Hyperparamters,
+    global_step: int,
+    rng: spec.RandomState) -> Tuple[spec.Tensor, spec.Tensor]:
+  """Select data from the infinitely repeating, pre-shuffled input queue.
+
+  Each element of the queue is a single training example and label.
+
+  Return a tuple of input label batches.
+  """
+  return next(input_queue), None

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -3,284 +3,289 @@ import itertools
 import os
 from typing import Tuple
 
+import Levenshtein
 import ctcdecode
 import jax
 import jax.numpy as jnp
-import Levenshtein
 import numpy as np
-import spec
 import torch
 from flax import jax_utils
-from flax import linen as nn
 from jax import lax
 
+import spec
 from . import ctc_loss, input_pipeline, models
 
 
+@functools.partial(jax.jit, backend="cpu")
+def to_cpu(inp):
+    cpu_device = jax.devices("cpu")[0]
+    return jax.device_put(inp, cpu_device)
+
+
 class LibriSpeechWorkload(spec.Workload):
-  """A LibriSpeech workload."""
-  
-  def __init__(self):
-    self._train_loader = None
-    self._valid_loader = None
-    self._model = models.CNNLSTM()
-    self._label_dict = {
-        "_": 0,
-        " ": 1,
-        "'": 2,
-        "A": 3,
-        "B": 4,
-        "C": 5,
-        "D": 6,
-        "E": 7,
-        "F": 8,
-        "G": 9,
-        "H": 10,
-        "I": 11,
-        "J": 12,
-        "K": 13,
-        "L": 14,
-        "M": 15,
-        "N": 16,
-        "O": 17,
-        "P": 18,
-        "Q": 19,
-        "R": 20,
-        "S": 21,
-        "T": 22,
-        "U": 23,
-        "V": 24,
-        "W": 25,
-        "X": 26,
-        "Y": 27,
-        "Z": 28,
-    }
-    self._rev_label_dict = {v: k for k, v in self._label_dict.items()}
-    self._decoder = ctcdecode.CTCBeamDecoder(
-        labels=[str(c) for c in self._rev_label_dict], beam_width=1)
-    self._loss = ctc_loss.ctc_loss
-  
-  def has_reached_goal(self, eval_result: float) -> bool:
-    return eval_result < self.target_value
-  
-  def build_input_queue(self, data_rng, split: str, data_dir: str,
-                        batch_size: int):
-    torch.manual_seed(data_rng[0])
-    train_set = input_pipeline.LibriSpeechDataset(
-        os.path.join(data_dir, "features_train-clean-100.csv"))
-    valid_set = input_pipeline.LibriSpeechDataset(
-        os.path.join(data_dir, "features_test-clean.csv"))
+    """A LibriSpeech workload."""
 
-    train_collate_fn = train_set.pad_collate
+    def __init__(self):
+        self._train_loader = None
+        self._valid_loader = None
+        self._model = models.CNNLSTM()
+        self._label_dict = {
+            "_": 0,
+            " ": 1,
+            "'": 2,
+            "A": 3,
+            "B": 4,
+            "C": 5,
+            "D": 6,
+            "E": 7,
+            "F": 8,
+            "G": 9,
+            "H": 10,
+            "I": 11,
+            "J": 12,
+            "K": 13,
+            "L": 14,
+            "M": 15,
+            "N": 16,
+            "O": 17,
+            "P": 18,
+            "Q": 19,
+            "R": 20,
+            "S": 21,
+            "T": 22,
+            "U": 23,
+            "V": 24,
+            "W": 25,
+            "X": 26,
+            "Y": 27,
+            "Z": 28,
+        }
+        self._rev_label_dict = {v: k for k, v in self._label_dict.items()}
+        self._decoder = ctcdecode.CTCBeamDecoder(
+            labels=[str(c) for c in self._rev_label_dict], beam_width=1)
+        self._loss = ctc_loss.ctc_loss
 
-    self._train_loader = torch.utils.data.DataLoader(
-        train_set,
-        batch_size=batch_size,
-        shuffle=True,
-        num_workers=2,
-        pin_memory=True,
-        collate_fn=train_collate_fn)
+    def has_reached_goal(self, eval_result: float) -> bool:
+        return eval_result < self.target_value
 
-    self._valid_loader = torch.utils.data.DataLoader(
-        valid_set,
-        batch_size=batch_size,
-        num_workers=2,
-        pin_memory=True,
-        collate_fn=train_collate_fn)
+    def build_input_queue(self, data_rng, split: str, data_dir: str,
+                          batch_size: int):
+        torch.manual_seed(data_rng[0])
+        train_set = input_pipeline.LibriSpeechDataset(
+            os.path.join(data_dir, "features_train-clean-100.csv"))
+        valid_set = input_pipeline.LibriSpeechDataset(
+            os.path.join(data_dir, "features_test-clean.csv"))
 
-    return iter(itertools.cycle(self._train_loader))
+        train_collate_fn = train_set.pad_collate
 
-  def sync_batch_stats(self, model_state):
-    """Sync the batch statistics across replicas."""
-    # An axis_name is passed to pmap which can then be used by pmean.
-    # In this case each device has its own version of the batch statistics and
-    # we average them.
-    avg_fn = jax.pmap(lambda x: lax.pmean(x, 'x'), 'x')
-    new_model_state = model_state.copy({
-      'batch_stats': avg_fn(model_state['batch_stats'])})
-    return new_model_state    
+        self._train_loader = torch.utils.data.DataLoader(
+            train_set,
+            batch_size=batch_size,
+            shuffle=True,
+            num_workers=2,
+            pin_memory=False,
+            collate_fn=train_collate_fn)
 
-  @property
-  def param_shapes(self):
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
-  
-  @property
-  def target_value(self):
-    return 0.1
+        self._valid_loader = iter(itertools.cycle(torch.utils.data.DataLoader(
+            valid_set,
+            batch_size=batch_size,
+            num_workers=2,
+            pin_memory=False,
+            collate_fn=train_collate_fn)))  # itertools.cycle is required for it to run on tpu
 
-  @property
-  def loss_type(self):
-    return spec.LossType.CTC_LOSS
+        return iter(itertools.cycle(self._train_loader))
 
-  @property
-  def num_train_examples(self):
-    return 28539
+    def sync_batch_stats(self, model_state):
+        """Sync the batch statistics across replicas."""
+        # An axis_name is passed to pmap which can then be used by pmean.
+        # In this case each device has its own version of the batch statistics and
+        # we average them.
+        avg_fn = jax.pmap(lambda x: lax.pmean(x, 'x'), 'x')
+        new_model_state = model_state.copy({
+            'batch_stats': avg_fn(model_state['batch_stats'])})
+        return new_model_state
 
-  @property
-  def num_eval_examples(self):
-    return 2620
+    @property
+    def param_shapes(self):
+        if self._param_shapes is None:
+            raise ValueError(
+                'This should not happen, workload.init_model_fn() should be called '
+                'before workload.param_shapes!')
+        return self._param_shapes
 
-  @property
-  def train_mean(self):
-    return 0.0
+    @property
+    def target_value(self):
+        return 0.1
 
-  @property
-  def train_stddev(self):
-    return 1.0
-  
-  def model_params_types(self):
-    pass
+    @property
+    def loss_type(self):
+        return spec.LossType.CTC_LOSS
 
-  @property
-  def max_allowed_runtime_sec(self):
-    return 80000
+    @property
+    def num_train_examples(self):
+        return 28539
 
-  @property
-  def eval_period_time_sec(self):
-    return 800
+    @property
+    def num_eval_examples(self):
+        return 2620
 
-  # Return whether or not a key in spec.ParameterContainer is the output layer
-  # parameters.
-  def is_output_params(self, param_key: spec.ParameterKey) -> bool:
-    pass
+    @property
+    def train_mean(self):
+        return 0.0
 
-  def preprocess_for_train(self, selected_raw_input_batch: spec.Tensor,
-                           selected_label_batch: spec.Tensor,
-                           train_mean: spec.Tensor, train_stddev: spec.Tensor,
-                           rng: spec.RandomState) -> spec.Tensor:
-    del train_mean
-    del train_stddev
-    del rng
-    return selected_raw_input_batch, selected_label_batch
+    @property
+    def train_stddev(self):
+        return 1.0
 
-  def preprocess_for_eval(
-      self,
-      raw_input_batch: spec.Tensor,
-      train_mean: spec.Tensor,
-      train_stddev: spec.Tensor) -> spec.Tensor:
-    del train_mean
-    del train_stddev
-    return raw_input_batch
-  
-  def initialized(self, key, model):
-    init_val = [jnp.ones((1, 1, 161, 2453), jnp.float32), jnp.array([2087])]
-    variables = model.init(key, *init_val, training=True)
-    params = variables["params"]
-    model_state = variables["batch_stats"]
-    return params, model_state
+    def model_params_types(self):
+        pass
 
-  _InitState = Tuple[spec.ParameterContainer, spec.ModelAuxiliaryState]
-  def init_model_fn(self, rng: spec.RandomState) -> _InitState:
-    params, model_state = self.initialized(rng, self._model)
-    self._param_shapes = jax.tree_map(
-      lambda x: spec.ShapeTuple(x.shape),
-      params)
-    model_state = jax_utils.replicate(model_state)
-    params = jax_utils.replicate(params)
-    return params, model_state
-  
-  # Keep this separate from the loss function in order to support optimizers
-  # that use the logits.
-  def output_activation_fn(
-      self,
-      logits_batch: spec.Tensor,
-      loss_type: spec.LossType) -> spec.Tensor:
-    """Return the final activations of the model."""
-    pass
+    @property
+    def max_allowed_runtime_sec(self):
+        return 80000
 
-  def model_fn(
-      self,
-      params: spec.ParameterContainer,
-      augmented_and_preprocessed_input_batch: spec.Tensor,
-      model_state: spec.ModelAuxiliaryState,
-      mode: spec.ForwardPassMode,
-      rng: spec.RandomState,
-      update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    variables = {'params': params, **model_state}
-    train = mode == spec.ForwardPassMode.TRAIN
-    features, input_lengths = augmented_and_preprocessed_input_batch
-    if update_batch_norm:
-      (log_y, output_lengths), new_model_state = self._model.apply(
-        variables, features, input_lengths, training=train, mutable=['batch_stats'])
-      return (log_y, output_lengths), new_model_state
-    else:
-      log_y, output_lengths = self._model.apply(
-        variables, features, input_lengths, training=train)
-      return (log_y, output_lengths), None
-  
-  def loss_fn(
-      self,
-      label_batch: spec.Tensor,
-      logits_batch: spec.Tensor) -> spec.Tensor: 
-    log_y, _ = logits_batch
-    label_batch, labelspaddings, logprobspaddings = label_batch
-    loss, _ = self._loss(log_y, logprobspaddings, label_batch, labelspaddings)
+    @property
+    def eval_period_time_sec(self):
+        return 800
 
-    return jnp.mean(loss)
+    # Return whether or not a key in spec.ParameterContainer is the output layer
+    # parameters.
+    def is_output_params(self, param_key: spec.ParameterKey) -> bool:
+        pass
 
+    def preprocess_for_train(self, selected_raw_input_batch: spec.Tensor,
+                             selected_label_batch: spec.Tensor,
+                             train_mean: spec.Tensor, train_stddev: spec.Tensor,
+                             rng: spec.RandomState) -> spec.Tensor:
+        del train_mean
+        del train_stddev
+        del rng
+        return selected_raw_input_batch, selected_label_batch
 
-  @functools.partial(
-  jax.pmap,
-  axis_name='batch',
-  in_axes=(None, 0, 0, 0, None),
-  static_broadcasted_argnums=(0,))
-  def eval_model_fn(self, params, batch, state, rng):
-    logits, _ = self.model_fn(
-      params,
-      batch["input"],
-      state,
-      spec.ForwardPassMode.EVAL,
-      rng,
-      update_batch_norm=False)
-    return logits
+    def preprocess_for_eval(
+            self,
+            raw_input_batch: spec.Tensor,
+            train_mean: spec.Tensor,
+            train_stddev: spec.Tensor) -> spec.Tensor:
+        del train_mean
+        del train_stddev
+        return raw_input_batch
 
+    def initialized(self, key, model):
+        init_val = [jnp.ones((1, 1, 161, 2453), jnp.float32), jnp.array([2087])]
+        variables = model.init(jax.random.PRNGKey(key[0] + 2 ** 32 + key[1]), *init_val, training=True)
+        params = variables["params"]
+        model_state = variables["batch_stats"]
+        return params, model_state
 
-  def eval_model(
-      self,
-      params: spec.ParameterContainer,
-      model_state: spec.ModelAuxiliaryState,
-      rng: spec.RandomState,
-      data_dir: str):
-    """Run a full evaluation of the model."""
-    # sync batch statistics across replicas
-    model_state = self.sync_batch_stats(model_state)
+    _InitState = Tuple[spec.ParameterContainer, spec.ModelAuxiliaryState]
 
-    total_error = 0.0
-    total_length = 0.0
+    def init_model_fn(self, rng: spec.RandomState) -> _InitState:
+        params, model_state = self.initialized(rng, self._model)
+        self._param_shapes = jax.tree_map(
+            lambda x: spec.ShapeTuple(x.shape),
+            params)
+        model_state = jax_utils.replicate(model_state)
+        params = jax_utils.replicate(params)
+        return params, model_state
 
-    eval_batch_size = 32
-    num_devices = jax.local_device_count()
-    for (_, features, transcripts, input_lengths, transcripts_padding) in self._valid_loader:
-      features = jnp.expand_dims(features.transpose(0, 2, 1), axis=1)
-      reshaped_features = jnp.reshape(
-      features,
-      (num_devices, features.shape[0] // num_devices, *features.shape[1:]))
-      reshaped_input_lengths = jnp.reshape(
-          input_lengths,
-          (num_devices, input_lengths.shape[0] // num_devices, *input_lengths.shape[1:]))
-      batch = {
-        'input': (reshaped_features, reshaped_input_lengths)
-      }
-      log_y, _ = self.eval_model_fn(params, batch, model_state, rng)
-      log_y = jnp.reshape(log_y, (-1, *log_y.shape[2:]))
-      log_y = torch.tensor(np.asarray(log_y),device='cpu')
-      input_lengths = torch.tensor(np.asarray(input_lengths),device='cpu')
-      out, _, _, seq_lens = self._decoder.decode(
-            torch.exp(log_y), input_lengths)
-      for hyp, trn, length in zip(out, transcripts,
-                                  seq_lens):  # iterate batch
-        best_hyp = hyp[0, :length[0]]
-        hh = "".join([self._rev_label_dict[i.item()] for i in best_hyp])
-        t = np.asarray(trn).tolist()
-        t = [ll for ll in t if ll != 0]
-        tlength = len(t)
-        tt = "".join([self._rev_label_dict[i] for i in t])
-        error = Levenshtein.distance(tt, hh)
-        total_error += error
-        total_length += tlength
-      
-      return total_error / total_length
+    # Keep this separate from the loss function in order to support optimizers
+    # that use the logits.
+    def output_activation_fn(
+            self,
+            logits_batch: spec.Tensor,
+            loss_type: spec.LossType) -> spec.Tensor:
+        """Return the final activations of the model."""
+        pass
+
+    def model_fn(
+            self,
+            params: spec.ParameterContainer,
+            augmented_and_preprocessed_input_batch: spec.Tensor,
+            model_state: spec.ModelAuxiliaryState,
+            mode: spec.ForwardPassMode,
+            rng: spec.RandomState,
+            update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
+        variables = {'params': params, **model_state}
+        train = mode == spec.ForwardPassMode.TRAIN
+        features, input_lengths = augmented_and_preprocessed_input_batch
+        if update_batch_norm:
+            (log_y, output_lengths), new_model_state = self._model.apply(
+                variables, features, input_lengths, training=train, mutable=['batch_stats'])
+            return (log_y, output_lengths), new_model_state
+        else:
+            log_y, output_lengths = self._model.apply(
+                variables, features, input_lengths, training=train)
+            return (log_y, output_lengths), None
+
+    def loss_fn(
+            self,
+            label_batch: spec.Tensor,
+            logits_batch: spec.Tensor) -> spec.Tensor:
+        log_y, _ = logits_batch
+        label_batch, labelspaddings, logprobspaddings = label_batch
+        loss, _ = self._loss(log_y, logprobspaddings, label_batch, labelspaddings)
+
+        return jnp.mean(loss)
+
+    @functools.partial(
+        jax.pmap,
+        axis_name='batch',
+        in_axes=(None, 0, 0, 0, None),
+        static_broadcasted_argnums=(0,))
+    def eval_model_fn(self, params, batch, state, rng):
+        logits, _ = self.model_fn(
+            params,
+            batch["input"],
+            state,
+            spec.ForwardPassMode.EVAL,
+            rng,
+            update_batch_norm=False)
+        return logits
+
+    def eval_model(
+            self,
+            params: spec.ParameterContainer,
+            model_state: spec.ModelAuxiliaryState,
+            rng: spec.RandomState,
+            data_dir: str):
+        """Run a full evaluation of the model."""
+        # sync batch statistics across replicas
+        model_state = self.sync_batch_stats(model_state)
+
+        total_error = 0.0
+        total_length = 0.0
+
+        eval_batch_size = 32
+        num_devices = jax.local_device_count()
+        for (_, features, transcripts, input_lengths, transcripts_padding) in self._valid_loader:
+            features = jnp.expand_dims(features.transpose(0, 2, 1), axis=1)
+            reshaped_features = jnp.reshape(
+                features,
+                (num_devices, features.shape[0] // num_devices, *features.shape[1:]))
+            reshaped_input_lengths = jnp.reshape(
+                input_lengths,
+                (num_devices, input_lengths.shape[0] // num_devices, *input_lengths.shape[1:]))
+            batch = {
+                'input': (reshaped_features, reshaped_input_lengths)
+            }
+            log_y, _ = self.eval_model_fn(params, batch, model_state, rng)
+            log_y = to_cpu(log_y)
+            log_y = jnp.reshape(log_y, (-1, *log_y.shape[2:]))
+            log_y = torch.tensor(np.asarray(log_y), device='cpu')
+            input_lengths = torch.tensor(np.asarray(input_lengths), device='cpu')
+            out, _, _, seq_lens = self._decoder.decode(
+                torch.exp(log_y), input_lengths)
+            for hyp, trn, length in zip(out, transcripts,
+                                        seq_lens):  # iterate batch
+                best_hyp = hyp[0, :length[0]]
+                hh = "".join([self._rev_label_dict[i.item()] for i in best_hyp])
+                t = np.asarray(trn).tolist()
+                t = [ll for ll in t if ll != 0]
+                tlength = len(t)
+                tt = "".join([self._rev_label_dict[i] for i in t])
+                error = Levenshtein.distance(tt, hh)
+                total_error += error
+                total_length += tlength
+
+            return total_error / total_length

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -202,13 +202,13 @@ class LibriSpeechWorkload(spec.Workload):
     train = mode == spec.ForwardPassMode.TRAIN
     features, input_lengths = augmented_and_preprocessed_input_batch
     if update_batch_norm:
-      log_y, output_lengths = self._model.apply(
+      (log_y, output_lengths), new_model_state = self._model.apply(
         variables, features, input_lengths, training=train, mutable=['batch_stats'])
-      return (log_y, output_lengths), model_state
+      return (log_y, output_lengths), new_model_state
     else:
       log_y, output_lengths = self._model.apply(
         variables, features, input_lengths, training=train)
-      return (log_y, output_lengths), model_state
+      return (log_y, output_lengths), None
   
   def loss_fn(
       self,

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -74,15 +74,15 @@ class LibriSpeechWorkload(spec.Workload):
                           batch_size: int):
         torch.manual_seed(data_rng[0])
         train_set = input_pipeline.LibriSpeechDataset(
-            os.path.join(data_dir, "features_train-clean-100.csv"))
+            os.path.join(data_dir, "features_train-clean-100.csv"),  batch_size)
         valid_set = input_pipeline.LibriSpeechDataset(
-            os.path.join(data_dir, "features_test-clean.csv"))
+            os.path.join(data_dir, "features_test-clean.csv"), batch_size)
 
         train_collate_fn = train_set.pad_collate
 
         self._train_loader = torch.utils.data.DataLoader(
             train_set,
-            batch_size=batch_size,
+            batch_size=1,
             shuffle=True,
             drop_last=True,
             num_workers=2,
@@ -91,7 +91,8 @@ class LibriSpeechWorkload(spec.Workload):
 
         valid_loader = torch.utils.data.DataLoader(
             valid_set,
-            batch_size=batch_size,
+            batch_size=1,
+            shuffle=False,
             num_workers=2,
             drop_last=True,
             pin_memory=False,

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import numpy as np
 import torch
 from flax import jax_utils
+import torch.utils.data
 from jax import lax
 
 import spec
@@ -84,6 +85,7 @@ class LibriSpeechWorkload(spec.Workload):
             train_set,
             batch_size=batch_size,
             shuffle=True,
+            drop_last=True,
             num_workers=2,
             pin_memory=False,
             collate_fn=train_collate_fn)
@@ -92,6 +94,7 @@ class LibriSpeechWorkload(spec.Workload):
             valid_set,
             batch_size=batch_size,
             num_workers=2,
+            drop_last=True,
             pin_memory=False,
             collate_fn=train_collate_fn)
         self._valid_loader = iter(itertools.cycle(valid_loader))  # itertools.cycle is required for it to run on tpu
@@ -260,7 +263,6 @@ class LibriSpeechWorkload(spec.Workload):
         total_error = 0.0
         total_length = 0.0
 
-        # eval_batch_size = 32  <- it's not used anywhere? is eval not batched?
         num_devices = jax.local_device_count()
         for step_idx, (_, features, transcripts, input_lengths, transcripts_padding) in enumerate(self._valid_loader):
             if step_idx >= self._valid_loader_len:

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -59,6 +59,7 @@ class LibriSpeechWorkload(spec.Workload):
     self._loss = ctc_loss.ctc_loss
   
   def has_reached_goal(self, eval_result: float) -> bool:
+    return False
     return eval_result < self.target_value
   
   def build_input_queue(self, data_rng, split: str, data_dir: str,
@@ -214,13 +215,8 @@ class LibriSpeechWorkload(spec.Workload):
       self,
       label_batch: spec.Tensor,
       logits_batch: spec.Tensor) -> spec.Tensor: 
-
-    log_y, output_lengths = logits_batch
-    max_length = log_y.shape[1]
-    logprobspaddings = np.array([[0]*x + [1]*(max_length-x) for x in output_lengths])
-    labels_lengths = [len(y[y != 0]) for y in label_batch]
-    max_length = logits_batch.shape[1]
-    labelspaddings = np.array([[0]*x + [1]*(max_length-x) for x in labels_lengths])
+    log_y, _ = logits_batch
+    label_batch, labelspaddings, logprobspaddings = label_batch
     loss, _ = self._loss(log_y, logprobspaddings, label_batch, labelspaddings)
 
     return jnp.mean(loss)

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -225,12 +225,7 @@ class LibriSpeechWorkload(spec.Workload):
 
         return jnp.mean(loss)
 
-    @functools.partial(
-        jax.pmap,
-        axis_name='batch',
-        in_axes=(None, 0, 0, 0, None),
-        static_broadcasted_argnums=(0,))
-    def eval_model_fn(self, params, batch, state, rng):
+    def _eval_model_fn(self, params, batch, state, rng):
         logits, _ = self.model_fn(
             params,
             batch["input"],
@@ -239,6 +234,9 @@ class LibriSpeechWorkload(spec.Workload):
             rng,
             update_batch_norm=False)
         return logits
+
+    eval_model_fn = jax.pmap(_eval_model_fn, axis_name='batch', in_axes=(None, 0, 0, 0, None),
+                             static_broadcasted_argnums=(0,))
 
     def eval_model(
             self,

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -288,4 +288,4 @@ class LibriSpeechWorkload(spec.Workload):
                 total_error += error
                 total_length += tlength
 
-            return total_error / total_length
+        return total_error / total_length

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -236,7 +236,7 @@ class LibriSpeechWorkload(spec.Workload):
             update_batch_norm=False)
         return logits
 
-    eval_model_fn = jax.pmap(_eval_model_fn, axis_name='batch', in_axes=(None, 0, 0, 0, None),
+    eval_model_fn = jax.pmap(_eval_model_fn, axis_name='batch', in_axes=(None, None, None, 0, 0, 0, None),
                              static_broadcasted_argnums=(0, 1, 2))
 
     def eval_model(

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -1,0 +1,213 @@
+import itertools
+import os
+from typing import Tuple
+
+import ctcdecode
+import jax
+import jax.numpy as jnp
+import Levenshtein
+import numpy as np
+import spec
+import torch
+from flax import jax_utils
+from flax import linen as nn
+
+from . import ctc_loss, input_pipeline, models
+
+
+class LibriSpeechWorkload(spec.Workload):
+  """A LibriSpeech workload."""
+  
+  def __init__(self):
+    self._train_loader = None
+    self._valid_loader = None
+    self._model = models.CNNLSTM()
+    self._label_dict = {
+        "_": 0,
+        " ": 1,
+        "'": 2,
+        "A": 3,
+        "B": 4,
+        "C": 5,
+        "D": 6,
+        "E": 7,
+        "F": 8,
+        "G": 9,
+        "H": 10,
+        "I": 11,
+        "J": 12,
+        "K": 13,
+        "L": 14,
+        "M": 15,
+        "N": 16,
+        "O": 17,
+        "P": 18,
+        "Q": 19,
+        "R": 20,
+        "S": 21,
+        "T": 22,
+        "U": 23,
+        "V": 24,
+        "W": 25,
+        "X": 26,
+        "Y": 27,
+        "Z": 28,
+    }
+    self._rev_label_dict = {v: k for k, v in self._label_dict.items()}
+    self._decoder = ctcdecode.CTCBeamDecoder(
+        labels=[str(c) for c in self._rev_label_dict], beam_width=1)
+    self._loss = ctc_loss.ctc_loss
+  
+  def has_reached_goal(self, eval_result: float) -> bool:
+    return eval_result < self.target_value
+  
+  def build_input_queue(self, data_rng, split: str, data_dir: str,
+                        batch_size: int):
+    torch.manual_seed(data_rng[0])
+    train_set = input_pipeline.LibriSpeechDataset(
+        os.path.join(data_dir, "features_train-clean-100.csv"))
+    valid_set = input_pipeline.LibriSpeechDataset(
+        os.path.join(data_dir, "features_test-clean.csv"))
+
+    train_collate_fn = train_set.pad_collate
+
+    self._train_loader = torch.utils.data.DataLoader(
+        train_set,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=2,
+        pin_memory=True,
+        collate_fn=train_collate_fn)
+
+    self._valid_loader = torch.utils.data.DataLoader(
+        valid_set,
+        batch_size=batch_size,
+        num_workers=2,
+        pin_memory=True,
+        collate_fn=train_collate_fn)
+
+    return iter(itertools.cycle(self._train_loader))
+
+  def sync_batch_stats(self, model_state):
+    """Sync the batch statistics across replicas."""
+    # An axis_name is passed to pmap which can then be used by pmean.
+    # In this case each device has its own version of the batch statistics and
+    # we average them.
+    avg_fn = jax.pmap(lambda x: lax.pmean(x, 'x'), 'x')
+    new_model_state = model_state.copy({
+      'batch_stats': avg_fn(model_state['batch_stats'])})
+    return new_model_state    
+
+  @property
+  def param_shapes(self):
+    if self._param_shapes is None:
+      raise ValueError(
+          'This should not happen, workload.init_model_fn() should be called '
+          'before workload.param_shapes!')
+    return self._param_shapes
+  
+  @property
+  def target_value(self):
+    return 0.1
+
+  @property
+  def loss_type(self):
+    return spec.LossType.CTC_LOSS
+
+  @property
+  def num_train_examples(self):
+    return 28539
+
+  @property
+  def num_eval_examples(self):
+    return 2620
+
+  @property
+  def train_mean(self):
+    return 0.0
+
+  @property
+  def train_stddev(self):
+    return 1.0
+  
+  def model_params_types(self):
+    pass
+
+  @property
+  def max_allowed_runtime_sec(self):
+    return 80000
+
+  @property
+  def eval_period_time_sec(self):
+    return 800
+
+  # Return whether or not a key in spec.ParameterContainer is the output layer
+  # parameters.
+  def is_output_params(self, param_key: spec.ParameterKey) -> bool:
+    pass
+
+  def preprocess_for_train(self, selected_raw_input_batch: spec.Tensor,
+                           selected_label_batch: spec.Tensor,
+                           train_mean: spec.Tensor, train_stddev: spec.Tensor,
+                           rng: spec.RandomState) -> spec.Tensor:
+    del train_mean
+    del train_stddev
+    del rng
+    return selected_raw_input_batch, selected_label_batch
+
+  def preprocess_for_eval(
+      self,
+      raw_input_batch: spec.Tensor,
+      train_mean: spec.Tensor,
+      train_stddev: spec.Tensor) -> spec.Tensor:
+    del train_mean
+    del train_stddev
+    return raw_input_batch
+  
+  _InitState = Tuple[spec.ParameterContainer, spec.ModelAuxiliaryState]
+  def init_model_fn(self, rng: spec.RandomState) -> _InitState:
+    init_val = [jnp.ones((1, 1, 161, 2453), jnp.float32), jnp.array([2087])]
+    params, model_state = self._model.init(rng, *init_val, train=True)['params']
+    self._param_shapes = jax.tree_map(
+      lambda x: spec.ShapeTuple(x.shape),
+      params)
+    model_state = jax_utils.replicate(model_state)
+    params = jax_utils.replicate(params)
+    return params, model_state
+
+  def model_fn(
+      self,
+      params: spec.ParameterContainer,
+      augmented_and_preprocessed_input_batch: spec.Tensor,
+      model_state: spec.ModelAuxiliaryState,
+      mode: spec.ForwardPassMode,
+      rng: spec.RandomState,
+      update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
+    variables = {'params': params, **model_state}
+    train = mode == spec.ForwardPassMode.TRAIN
+    features, input_lengths = augmented_and_preprocessed_input_batch
+    if update_batch_norm:
+      log_y, output_lengths = self._model.apply(
+        variables, features, input_lengths, training=train, mutable=['batch_stats'])
+      return (log_y, output_lengths), model_state
+    else:
+      log_y, output_lengths = self._model.apply(
+        variables, features, input_lengths, training=train)
+      return (log_y, output_lengths), model_state
+  
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor) -> spec.Tensor: 
+
+    log_y, output_lengths = logits_batch
+    max_length = log_y.shape[1]
+    logprobspaddings = np.array([[0]*x + [1]*(max_length-x) for x in output_lengths])
+    labels_lengths = [len(y[y != 0]) for y in label_batch]
+    max_length = logits_batch.shape[1]
+    labelspaddings = np.array([[0]*x + [1]*(max_length-x) for x in labels_lengths])
+    loss, _ = self._loss(log_y, logprobspaddings, label_batch, labelspaddings)
+
+    return jnp.mean(loss)
+
+  

--- a/workloads/librispeech/librispeech_jax/workload.py
+++ b/workloads/librispeech/librispeech_jax/workload.py
@@ -139,7 +139,7 @@ class LibriSpeechWorkload(spec.Workload):
 
     @property
     def max_allowed_runtime_sec(self):
-        return 80000
+        return 800000  # TODO: Reduce this to 80000 once debugging is complete
 
     @property
     def eval_period_time_sec(self):
@@ -170,7 +170,7 @@ class LibriSpeechWorkload(spec.Workload):
 
     def initialized(self, key, model):
         init_val = [jnp.ones((1, 1, 161, 2453), jnp.float32), jnp.array([2087])]
-        variables = model.init(jax.random.PRNGKey(key[0] + 2 ** 32 + key[1]), *init_val, training=True)
+        variables = model.init(jax.random.PRNGKey(key[0] ^ key[1]), *init_val, training=True)
         params = variables["params"]
         model_state = variables["batch_stats"]
         return params, model_state


### PR DESCRIPTION
The training is still going, but it looks pretty good so far.\
As discussed, the Jax version adds significant padding (which isn't there in the PyTorch version), which should cause it to run 2x to 16x slower. At the same time, I had to add masks to BatchNorm, which will cause the performance of this model to deviate slightly from that of the PyTorch model.
There were also many issues with the original Jax submission, so we should probably double-check with the PyTorch version and avoid these in the Conformer implementation.

![grafik](https://user-images.githubusercontent.com/39779310/161753701-032db916-2e29-486b-9f53-00388d08c964.png)
