### PR TITLE
README.md jax_gpu installation link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
    **JAX (GPU)**
 
    ```bash
-   pip3 install -e '.[jax_gpu]' -f 'https://storage.googleapis.com/jax-releases/jax_releases.html'
+   pip3 install -e '.[jax_gpu]' -f 'https://storage.googleapis.com/jax-releases/jax_cuda_releases.html'
    ```
 
    **JAX (CPU)**


### PR DESCRIPTION
```
pip3 install -e '.[jax_gpu]' -f 'https://storage.googleapis.com/jax-releases/jax_releases.html'
```
At the moment, the above command for installing jax_gpu on Ubuntu raises an error shown below:
```
ERROR: Could not find a version that satisfies the requirement jaxlib==0.1.76+cuda11.cudnn82 (from jax[cuda]) (from versions: 0.1.32, 0.1.40, 0.1.41, 0.1.42, 0.1.43, 0.1.44, 0.1.46, 0.1.50, 0.1.51, 0.1.52, 0.1.55, 0.1.56, 0.1.57, 0.1.58, 0.1.59, 0.1.60, 0.1.61, 0.1.62, 0.1.63, 0.1.64, 0.1.65, 0.1.66, 0.1.67, 0.1.68, 0.1.69, 0.1.70, 0.1.71, 0.1.72, 0.1.73, 0.1.74, 0.1.75, 0.1.76, 0.3.0, 0.3.2, 0.3.5, 0.3.7, 0.3.8, 0.3.10, 0.3.14)
ERROR: No matching distribution found for jaxlib==0.1.76+cuda11.cudnn82
```
The error can be removed by replacing the link `https://storage.googleapis.com/jax-releases/jax_releases.html` with `https://storage.googleapis.com/jax-releases/jax_cuda_releases.html` and running the command:
```
pip3 install -e '.[jax_gpu]' -f 'https://storage.googleapis.com/jax-releases/jax_cuda_releases.html'
```
This PR fixes README.md accordingly. 

@mikerabbat This should fix the issue you mentioned. 