### PR TITLE
Clean up & Fix bugs in imagenet_vit

### DIFF
--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -203,8 +203,9 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
                            rng: spec.RandomState,
                            data_dir: str):
     data_rng, model_rng = jax.random.split(rng, 2)
-    # Sync batch statistics across replicas before evaluating.
-    model_state = self.sync_batch_stats(model_state)
+    if model_state is not None:
+      # Sync batch statistics across replicas before evaluating.
+      model_state = self.sync_batch_stats(model_state)
     num_batches = int(math.ceil(num_examples / global_batch_size))
     # We already repeat the dataset indefinitely in tf.data.
     if split not in self._eval_iters:

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
@@ -148,7 +148,7 @@ class ViT(nn.Module):
   mlp_dim: Optional[int] = None  # Defaults to 4x input dim
   num_heads: int = 12
   posemb: str = 'sincos2d'  # Can also be "learn"
-  rep_size: Union[int, bool] = False
+  rep_size: Union[int, bool] = True
   dropout: float = 0.0
   pool_type: str = 'gap'  # Can also be 'map' or 'tok'
   reinit: Optional[Sequence[str]] = None
@@ -224,53 +224,3 @@ class ViT(nn.Module):
       x = out['logits'] = head(x)
 
     return x
-
-
-def decode_variant(variant):
-  """Converts a string like 'B/32' into a params dict.
-  NOTE(dsuo): modified to expect variant + patch size only.
-  Args:
-    variant: a string of `model_size`/`patch_size`.
-  Returns:
-    dict: an expanded dictionary of model hps.
-  """
-  v, patch = variant.split('/')
-
-  return {
-      # pylint:disable=line-too-long
-      # Reference: Table 2 of https://arxiv.org/abs/2106.04560.
-      'width': {
-          'Ti': 192,
-          'S': 384,
-          'M': 512,
-          'B': 768,
-          'L': 1024,
-          'H': 1280,
-          'g': 1408,
-          'G': 1664
-      }[v],
-      'depth': {
-          'Ti': 12,
-          'S': 12,
-          'M': 12,
-          'B': 12,
-          'L': 24,
-          'H': 32,
-          'g': 40,
-          'G': 48
-      }[v],
-      'mlp_dim': {
-          'Ti': 768,
-          'S': 1536,
-          'M': 2048,
-          'B': 3072,
-          'L': 4096,
-          'H': 5120,
-          'g': 6144,
-          'G': 8192
-      }[v],
-      'num_heads': {
-          'Ti': 3, 'S': 6, 'M': 8, 'B': 12, 'L': 16, 'H': 16, 'g': 16, 'G': 16
-      }[v],  # pylint:enable=line-too-long
-      'patch_size': (int(patch), int(patch))
-  }

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
@@ -1,4 +1,5 @@
 """ImageNet workload implemented in Jax."""
+import math
 from typing import Dict, Tuple
 
 from flax import jax_utils
@@ -25,7 +26,7 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     return params, model_state
 
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
-    model_kwargs = decode_variant('S/16')
+    model_kwargs = decode_variant('B/32')
     model = models.ViT(num_classes=1000, **model_kwargs)
     self._model = model
     params, model_state = self.initialized(rng, model)
@@ -46,6 +47,40 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     del model_state
     del update_batch_norm
     logits = self._model.apply({'params': params},
-                               augmented_and_preprocessed_input_batch['inputs'],
-                               mutable=False)
+                               augmented_and_preprocessed_input_batch['inputs'])
     return logits, None
+
+  def _eval_model_on_split(self,
+                           split: str,
+                           num_examples: int,
+                           global_batch_size: int,
+                           params: spec.ParameterContainer,
+                           model_state: spec.ModelAuxiliaryState,
+                           rng: spec.RandomState,
+                           data_dir: str):
+    data_rng, model_rng = jax.random.split(rng, 2)
+    num_batches = int(math.ceil(num_examples / global_batch_size))
+    # We already repeat the dataset indefinitely in tf.data.
+    if split not in self._eval_iters:
+      self._eval_iters[split] = self.build_input_queue(
+          data_rng,
+          split=split,
+          global_batch_size=global_batch_size,
+          data_dir=data_dir,
+          cache=True,
+          repeat_final_dataset=True,
+          num_batches=num_batches)
+
+    eval_metrics = {}
+    for _ in range(num_batches):
+      batch = next(self._eval_iters[split])
+      # We already average these metrics across devices inside _compute_metrics.
+      synced_metrics = self._eval_model(params, batch, model_state, model_rng)
+      for metric_name, metric_value in synced_metrics.items():
+        if metric_name not in eval_metrics:
+          eval_metrics[metric_name] = 0.0
+        eval_metrics[metric_name] += metric_value
+
+    eval_metrics = jax.tree_map(lambda x: float(x[0] / num_examples),
+                                eval_metrics)
+    return eval_metrics

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
@@ -25,7 +25,7 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
 
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     torch.random.manual_seed(rng[0])
-    model_kwargs = decode_variant('S/16')
+    model_kwargs = decode_variant('B/32')
     model = models.ViT(num_classes=1000, **model_kwargs)
     self._param_shapes = {
         k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()
@@ -48,13 +48,11 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del rng
+    del update_batch_norm
 
     model = params
 
     if mode == spec.ForwardPassMode.EVAL:
-      if update_batch_norm:
-        raise ValueError(
-            'Batch norm statistics cannot be updated during evaluation.')
       model.eval()
 
     if mode == spec.ForwardPassMode.TRAIN:

--- a/reference_submissions/imagenet_vit/imagenet_pytorch/submission.py
+++ b/reference_submissions/imagenet_vit/imagenet_pytorch/submission.py
@@ -12,7 +12,7 @@ from algorithmic_efficiency import spec
 def get_batch_size(workload_name):
   # Return the global batch size.
   del workload_name
-  return 512
+  return 2048
 
 
 def init_optimizer_state(workload: spec.Workload,
@@ -24,15 +24,14 @@ def init_optimizer_state(workload: spec.Workload,
   del rng
 
   batch_size = get_batch_size('imagenet_vit')
-  base_lr = hyperparameters.learning_rate * batch_size / 256.
+  base_lr = hyperparameters.learning_rate * batch_size / 1024.
   optimizer_state = {
       'optimizer':
-          torch.optim.SGD(
+          torch.optim.Adam(
               model_params.parameters(),
               lr=base_lr,
-              momentum=hyperparameters.momentum,
-              weight_decay=hyperparameters.l2,
-              nesterov=True)
+              betas=(hyperparameters.beta1, hyperparameters.beta2),
+              eps=hyperparameters.epsilon)
   }
 
   steps_per_epoch = workload.num_train_examples // batch_size

--- a/reference_submissions/imagenet_vit/tuning_search_space.json
+++ b/reference_submissions/imagenet_vit/tuning_search_space.json
@@ -1,7 +1,9 @@
 {
-    "learning_rate": {"feasible_points": [0.1]},
-    "warmup_epochs": {"feasible_points": [5]},
+    "learning_rate": {"feasible_points": [1e-3]},
+    "beta1": {"feasible_points": [0.9]},
+    "beta2": {"feasible_points": [0.999]},
+    "epsilon": {"feasible_points": [1e-8]},
     "num_epochs": {"feasible_points": [100]},
-    "l2": {"feasible_points": [1e-4]},
-    "momentum": {"feasible_points": [0.9]}
+    "warmup_epochs": {"feasible_points": [5]},
+    "l2": {"feasible_points": [1e-1]}
 }


### PR DESCRIPTION
This PR does the following:
- Clean-up code in `imagenet_vit` workload.
- Set hyperparameter configuration according to https://github.com/google/init2winit/blob/master/init2winit/model_lib/vit.py (e.g., use Adam optimizer with base LR 1e-3).
- Fix bug in `imagenet_pytorch` workload when `rep_size=True`.

I performed some profiling on top of this PR on 4 GPU machines (with a 10% validation target) and confirmed that the speed difference between PyTorch and Jax is within 10%.