### PR TITLE
Update DLRM tf input_pipeline.py

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -39,7 +39,8 @@ def get_criteo1tb_dataset(split: str,
 
     int_features = []
     for idx in range(num_dense):
-      int_features.append(tf.math.log(fields[idx + num_labels] + 1))
+      positive_val = tf.nn.relu(fields[idx + num_labels]) 
+      int_features.append(tf.math.log(positive_val + 1))
     int_features = tf.stack(int_features, axis=1)
 
     cat_features = []


### PR DESCRIPTION
This PR adds setting negative integer features to zeros for the DLRM input pipeline

https://github.com/mlcommons/training_results_v2.0/blob/dae524ba88a8a339cbb97d77d232bdd2c0f72b1d/Google/benchmarks/dlrm/implementations/dlrm-research-tpu-v4-256-TF/criteo_util/criteo_preprocess.py#L5

Preprocessing util for criteo data. Transformations:
1. Fill missing features with zeros.
2. Set negative integer features to zeros.
3. Normalize integer features using log(x+1).
4. For categorical features (hex), convert to integer and take value modulus the
   MAX_IND_RANGE value.