### PR TITLE
Fix vocab_path in tokenizer to use absolute path'

### DIFF
--- a/algorithmic_efficiency/workloads/wmt/tokenizer.py
+++ b/algorithmic_efficiency/workloads/wmt/tokenizer.py
@@ -121,7 +121,7 @@ def load_or_train_tokenizer(dataset: tf.data.Dataset,
                             data_keys: Tuple[str, str] = ('inputs', 'targets')):
   """Loads the tokenizer at `vocab_path` or trains a one from `dataset`."""
   try:
-    return _load_sentencepiece_tokenizer(vocab_path)
+    return _load_sentencepiece_tokenizer(os.path.expanduser(vocab_path))
   except tf.errors.NotFoundError:
     logging.info('SentencePiece vocab not found, building one from data.')
     vocab_path = _train_sentencepiece(


### PR DESCRIPTION
Running the WMT workload without a trained tokenizer may result in a StopIteration error. 

The tokenizer tries to train the vocab multiple times because the the `vocab_path` to save the model may not found if specified like this  `~/tensorflow_datasets/wmt_sentencepiece_model`, since the tilde expansion may not work.

Other paths in the code that use the tilde expansion get passed to torch or tfds methods which I believe modify the path to absolute paths since running other workloads have not raised any issues.