### PR TITLE
Remove `torch-scatter` requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@
    pip3 install -e '.[full]'
    ```
 
-   For the PyTorch version of the ogbg workload, you need to install
-   `torch-scatter` manually via
-   ```bash
-   pip install torch-scatter -f 'https://data.pyg.org/whl/torch-1.12.0+cu113.html'
-   ```
-
    Depending on the framework you want to use (e.g. `JAX` or `PyTorch`) you need to install them as well. You could either do this manually or by adding the corresponding options:
 
    **JAX (GPU)**

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,6 @@ ogbg =
   jraph==0.0.2.dev
   scikit-learn==1.0.1
   clu==0.0.7
-  torch-scatter==2.0.9
 
 librispeech =
   ctcdecode>=1.0.2


### PR DESCRIPTION
As discussed in PR #115, this PR removes the `torch-scatter` requirement by forking `scatter_sum`. As a result, the package does not have to be installed manually anymore (or at all for that matter).