### PR TITLE
DLRM - JAX workload Refactor

### DIFF
--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -55,20 +55,21 @@ def _check_jax_install():
 
 
 def fold_in(seed, data):
-  _check_jax_install()
-  return jax_rng.fold_in(seed, data)
+  if FLAGS.framework == 'jax':
+    _check_jax_install()
+    return jax_rng.fold_in(seed, data)
   return _fold_in(seed, data)
 
 
 def split(seed, num=2):
-  # if FLAGS.framework == 'jax':
-  _check_jax_install()
-  return jax_rng.split(seed, num)
+  if FLAGS.framework == 'jax':
+    _check_jax_install()
+    return jax_rng.split(seed, num)
   return _split(seed, num)
 
 
 def PRNGKey(seed):  # pylint: disable=invalid-name
-  # if FLAGS.framework == 'jax':
-  _check_jax_install()
-  return jax_rng.PRNGKey(seed)
+  if FLAGS.framework == 'jax':
+    _check_jax_install()
+    return jax_rng.PRNGKey(seed)
   return _PRNGKey(seed)

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -55,21 +55,20 @@ def _check_jax_install():
 
 
 def fold_in(seed, data):
-  if FLAGS.framework == 'jax':
-    _check_jax_install()
-    return jax_rng.fold_in(seed, data)
+  _check_jax_install()
+  return jax_rng.fold_in(seed, data)
   return _fold_in(seed, data)
 
 
 def split(seed, num=2):
-  if FLAGS.framework == 'jax':
-    _check_jax_install()
-    return jax_rng.split(seed, num)
+  # if FLAGS.framework == 'jax':
+  _check_jax_install()
+  return jax_rng.split(seed, num)
   return _split(seed, num)
 
 
 def PRNGKey(seed):  # pylint: disable=invalid-name
-  if FLAGS.framework == 'jax':
-    _check_jax_install()
-    return jax_rng.PRNGKey(seed)
+  # if FLAGS.framework == 'jax':
+  _check_jax_install()
+  return jax_rng.PRNGKey(seed)
   return _PRNGKey(seed)

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/metrics.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/metrics.py
@@ -1,40 +1,7 @@
-"""Binary sigmoid cross-entropy, AUCROC, and mAP metrics."""
-
 from clu import metrics
 import flax
 import jax
 import jax.numpy as jnp
-import numpy as np
-from scipy.special import expit
-import sklearn.metrics
-
-
-def _conform_weights_to_targets(weights, targets):
-  """Conforms the shape of weights to targets to apply masking.
-
-  We allow shape of weights to be a prefix of the shape of targets, for example
-  for targets of shape (n_batches, n_tasks) we allow weights with shape
-  (n_batches, n_tasks) or (n_batches, ). Add the necessary trailing dimensions
-  of size 1 so that weights can be applied as a mask by a simple multiplication,
-  (n_batches, 1) in this case.
-
-  Args:
-    weights: None or a numpy array which shape is a prefix of targets shape
-    targets: numpy array to conform the weights to
-  Returns:
-    weights with proper dimensions added to apply it as a mask.
-  """
-  if weights is None:
-    weights = jnp.ones_like(targets)
-  elif weights.shape == targets.shape[:weights.ndim]:
-    # Add extra dimension if weights.shape is a prefix of targets.shape
-    # so that multiplication can be broadcasted.
-    weights = jnp.expand_dims(
-        weights, axis=tuple(range(weights.ndim, targets.ndim)))
-  elif weights.shape != targets.shape:
-    raise ValueError('Incorrect shapes. Got shape %s weights and %s targets.' %
-                     (str(weights.shape), str(targets.shape)))
-  return weights
 
 
 def per_example_sigmoid_binary_cross_entropy(logits, targets):
@@ -43,13 +10,15 @@ def per_example_sigmoid_binary_cross_entropy(logits, targets):
   Args:
     logits: float array of shape (batch, output_shape).
     targets: float array of shape (batch, output_shape).
-    weights: None or float array of shape (batch,).
   Returns:
     Sigmoid binary cross entropy computed per example, shape (batch,).
   """
   log_p = jax.nn.log_sigmoid(logits)
   log_not_p = jax.nn.log_sigmoid(-logits)
-  per_example_losses = -1.0 * (targets * log_p + (1 - targets) * log_not_p)
-  per_example_losses = (per_example_losses).reshape(per_example_losses.shape[0],
-                                                    -1)
-  return jnp.sum(per_example_losses, axis=-1)
+  losses = -1.0 * (targets * log_p + (1 - targets) * log_not_p)
+  return jnp.sum(losses.reshape(losses.shape[0], -1), axis=-1)
+
+
+@flax.struct.dataclass
+class EvalMetrics(metrics.Collection):
+  loss: metrics.Average.from_output('loss')

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/models.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/models.py
@@ -105,9 +105,8 @@ class DlrmSmall(nn.Module):
           fan_out,
           kernel_init=jnn.initializers.normal(
               stddev=jnp.sqrt(2.0 / (fan_in + fan_out))),
-          bias_init=jnn.initializers.normal(
-              stddev=jnp.sqrt(1.0 / fan_out)))(
-                  top_mlp_input)
+          bias_init=jnn.initializers.normal(stddev=jnp.sqrt(1.0 / fan_out)))(
+              top_mlp_input)
       if layer_idx < (num_layers_top - 1):
         top_mlp_input = nn.relu(top_mlp_input)
     logits = top_mlp_input

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/models.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/models.py
@@ -37,6 +37,16 @@ def dot_interact(concat_features):
 
 
 class DlrmSmall(nn.Module):
+  """Define a DLRM-Small model.
+
+  Parameters:
+    vocab_sizes: list of vocab sizes of embedding tables.
+    total_vocab_sizes: sum of embedding table sizes (for jit compilation).
+    num_dense_features: number of dense features as the bottom mlp input.
+    mlp_bottom_dims: dimensions of dense layers of the bottom mlp.
+    mlp_top_dims: dimensions of dense layers of the top mlp.
+    embed_dim: embedding dimension.
+  """
 
   vocab_sizes: Sequence[int]
   total_vocab_sizes: int

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
@@ -1,161 +1,20 @@
-"""Criteo1TB DLRM-Small workload implemented in Jax."""
 import functools
-import math
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
-from clu import metrics as clu_metrics
-import flax
 from flax import jax_utils
 import jax
 import jax.numpy as jnp
-
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
-from algorithmic_efficiency.workloads.criteo1tb import input_pipeline
 from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_jax import \
-    dlrm_small_model
+    models
 from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_jax import metrics
-
-_NUM_DENSE_FEATURES = 13
-_VOCAB_SIZES = tuple([1024 * 128] * 26)
-
-
-# We use CLU metrics to handle aggregating per-example outputs across batches so
-# we can compute AUC metrics.
-@flax.struct.dataclass
-class EvalMetrics(clu_metrics.Collection):
-  loss: clu_metrics.Average.from_output("loss")
+from algorithmic_efficiency.workloads.criteo1tb.workload import \
+    BaseCriteo1TbDlrmSmallWorkload
 
 
-class Criteo1TbDlrmSmallWorkload(spec.Workload):
+class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
   """Criteo1TB DLRM-Small Jax workload."""
-
-  def __init__(self):
-    self._eval_iters = {}
-    self._param_shapes = None
-    self._param_types = None
-    self._flax_module = dlrm_small_model.DlrmSmall(
-        vocab_sizes=_VOCAB_SIZES,
-        total_vocab_sizes=sum(_VOCAB_SIZES),
-        num_dense_features=_NUM_DENSE_FEATURES)
-
-  def has_reached_goal(self, eval_result: float) -> bool:
-    return eval_result['validation/loss'] < self.target_value
-
-  @property
-  def target_value(self):
-    return 0.12
-
-  @property
-  def loss_type(self):
-    return spec.LossType.SIGMOID_CROSS_ENTROPY
-
-  @property
-  def num_train_examples(self):
-    return 4_195_197_692
-
-  @property
-  def num_eval_train_examples(self):
-    return 100_000
-
-  @property
-  def num_validation_examples(self):
-    return 131072 * 8  # TODO(znado): finalize the validation split size.
-
-  @property
-  def num_test_examples(self):
-    return None
-
-  @property
-  def train_mean(self):
-    return 0.0
-
-  @property
-  def train_stddev(self):
-    return 1.0
-
-  @property
-  def max_allowed_runtime_sec(self):
-    return 6 * 60 * 60
-
-  @property
-  def eval_period_time_sec(self):
-    return 20 * 60
-
-  def build_input_queue(self,
-                        data_rng: jax.random.PRNGKey,
-                        split: str,
-                        data_dir: str,
-                        global_batch_size: int,
-                        num_batches: Optional[int] = None,
-                        repeat_final_dataset: bool = False):
-    del data_rng
-    ds = input_pipeline.get_criteo1tb_dataset(
-        split=split,
-        data_dir=data_dir,
-        is_training=(split == 'train'),
-        global_batch_size=global_batch_size,
-        num_dense_features=_NUM_DENSE_FEATURES,
-        vocab_sizes=_VOCAB_SIZES,
-        num_batches=num_batches,
-        repeat_final_dataset=repeat_final_dataset)
-    for batch in iter(ds):
-      batch = jax.tree_map(lambda x: x._numpy(), batch)  # pylint: disable=protected-access
-      yield batch
-
-  @functools.partial(
-      jax.pmap, axis_name='batch', static_broadcasted_argnums=(0,))
-  def eval_step_pmapped(self, params, batch):
-    """Calculate evaluation metrics on a batch."""
-    inputs = batch['inputs']
-    targets = batch['targets']
-    weights = batch['weights']
-    logits = self._flax_module.apply({'params': params}, inputs, targets)
-    per_example_losses = metrics.per_example_sigmoid_binary_cross_entropy(
-        logits, targets)
-    return EvalMetrics.gather_from_model_output(
-        loss=per_example_losses, targets=targets, logits=logits, mask=weights)
-
-  def _eval_model_on_split(self,
-                           split: str,
-                           num_examples: int,
-                           global_batch_size: int,
-                           params: spec.ParameterContainer,
-                           model_state: spec.ModelAuxiliaryState,
-                           rng: spec.RandomState,
-                           data_dir: str) -> Dict[str, float]:
-    """Run a full evaluation of the model."""
-    del model_state
-    num_batches = int(math.ceil(num_examples / global_batch_size))
-    if split not in self._eval_iters:
-      # These iterators will repeat indefinitely.
-      self._eval_iters[split] = self.build_input_queue(
-          rng,
-          split,
-          data_dir,
-          global_batch_size,
-          num_batches,
-          repeat_final_dataset=True)
-    metrics_bundle = EvalMetrics.empty()
-    for _ in range(num_batches):
-      eval_batch = next(self._eval_iters[split])
-      metrics_bundle = metrics_bundle.merge(
-          self.eval_step_pmapped(params, eval_batch).unreplicate())
-    return metrics_bundle.compute()
-
-  # Return whether or not a key in spec.ParameterContainer is the output layer
-  # parameters.
-  def is_output_params(self, param_key: spec.ParameterKey) -> bool:
-    pass
-
-  @property
-  def param_shapes(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
 
   @property
   def model_params_types(self):
@@ -167,35 +26,22 @@ class Criteo1TbDlrmSmallWorkload(spec.Workload):
       self._param_types = param_utils.jax_param_types(self._param_shapes)
     return self._param_types
 
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    """Return the final activations of the model."""
-    pass
-
-  def loss_fn(
-      self,
-      label_batch: spec.Tensor,  # Dense (not one-hot) labels.
-      logits_batch: spec.Tensor,
-      mask_batch: Optional[spec.Tensor] = None) -> spec.Tensor:
-    per_example_losses = metrics.per_example_sigmoid_binary_cross_entropy(
-        logits=logits_batch, targets=label_batch)
-    if mask_batch is not None:
-      weighted_losses = per_example_losses * mask_batch
-      normalization = mask_batch.sum()
-    else:
-      weighted_losses = per_example_losses
-    normalization = label_batch.shape[0]
-    return jnp.sum(weighted_losses, axis=-1) / normalization
-
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+    self._model = models.DlrmSmall(
+        vocab_sizes=self.vocab_sizes,
+        total_vocab_sizes=sum(self.vocab_sizes),
+        num_dense_features=self.num_dense_features,
+        mlp_bottom_dims=(128, 128),
+        mlp_top_dims=(256, 128, 1),
+        embed_dim=64)
+
     rng, init_rng = jax.random.split(rng)
     init_fake_batch_size = 2
-    input_size = _NUM_DENSE_FEATURES + len(_VOCAB_SIZES)
+    input_size = self.num_dense_features + len(self.vocab_sizes)
     input_shape = (init_fake_batch_size, input_size)
     target_shape = (init_fake_batch_size, input_size)
 
-    initial_variables = jax.jit(self._flax_module.init)(
+    initial_variables = jax.jit(self._model.init)(
         init_rng,
         jnp.ones(input_shape, jnp.float32),
         jnp.ones(target_shape, jnp.float32))
@@ -219,9 +65,25 @@ class Criteo1TbDlrmSmallWorkload(spec.Workload):
     del update_batch_norm
     inputs = augmented_and_preprocessed_input_batch['inputs']
     targets = augmented_and_preprocessed_input_batch['targets']
-    logits_batch = self._flax_module.apply({'params': params}, inputs, targets)
+    logits_batch = self._model.apply({'params': params}, inputs, targets)
     return logits_batch, None
 
-  @property
-  def step_hint(self):
-    return 64_000  # TODO(znado): finalize.
+  def _eval_metric(self, labels, logits):
+    per_example_losses = self.loss_fn(label_batch=labels, logits_batch=logits)
+    loss = jnp.sum(per_example_losses)
+    return metrics.EvalMetrics.single_from_model_output(
+        loss=loss, logits=logits, labels=labels)
+
+  @functools.partial(
+      jax.pmap,
+      axis_name='batch',
+      in_axes=(None, 0, 0, 0, None),
+      static_broadcasted_argnums=(0,))
+  def _eval_batch(self, params, batch, model_state, rng):
+    return super()._eval_batch(params, batch, model_state, rng)
+
+  def loss_fn(self, label_batch: spec.Tensor,
+              logits_batch: spec.Tensor) -> spec.Tensor:
+    per_example_losses = metrics.per_example_sigmoid_binary_cross_entropy(
+        logits=logits_batch, targets=label_batch)
+    return per_example_losses

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
@@ -70,9 +70,8 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
 
   def _eval_metric(self, labels, logits):
     per_example_losses = self.loss_fn(label_batch=labels, logits_batch=logits)
-    loss = jnp.sum(per_example_losses)
     return metrics.EvalMetrics.single_from_model_output(
-        loss=loss, logits=logits, labels=labels)
+        loss=per_example_losses, logits=logits, labels=labels)
 
   @functools.partial(
       jax.pmap,
@@ -82,7 +81,8 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
   def _eval_batch(self, params, batch, model_state, rng):
     return super()._eval_batch(params, batch, model_state, rng)
 
-  def loss_fn(self, label_batch: spec.Tensor,
+  def loss_fn(self,
+              label_batch: spec.Tensor,
               logits_batch: spec.Tensor) -> spec.Tensor:
     per_example_losses = metrics.per_example_sigmoid_binary_cross_entropy(
         logits=logits_batch, targets=label_batch)

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
@@ -4,11 +4,11 @@ from typing import Dict, Tuple
 from flax import jax_utils
 import jax
 import jax.numpy as jnp
+
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
-from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_jax import \
-    models
 from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_jax import metrics
+from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_jax import models
 from algorithmic_efficiency.workloads.criteo1tb.workload import \
     BaseCriteo1TbDlrmSmallWorkload
 
@@ -81,8 +81,7 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
   def _eval_batch(self, params, batch, model_state, rng):
     return super()._eval_batch(params, batch, model_state, rng)
 
-  def loss_fn(self,
-              label_batch: spec.Tensor,
+  def loss_fn(self, label_batch: spec.Tensor,
               logits_batch: spec.Tensor) -> spec.Tensor:
     per_example_losses = metrics.per_example_sigmoid_binary_cross_entropy(
         logits=logits_batch, targets=label_batch)

--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -39,7 +39,8 @@ def get_criteo1tb_dataset(split: str,
 
     int_features = []
     for idx in range(num_dense):
-      int_features.append(tf.math.log(fields[idx + num_labels] + 1))
+      positive_val = tf.nn.relu(fields[idx + num_labels])
+      int_features.append(tf.math.log(positive_val + 1))
     int_features = tf.stack(int_features, axis=1)
 
     cat_features = []
@@ -50,8 +51,6 @@ def get_criteo1tb_dataset(split: str,
     cat_features = tf.cast(
         tf.stack(cat_features, axis=1), dtype=int_features.dtype)
     features['inputs'] = tf.concat([int_features, cat_features], axis=1)
-    features['weights'] = tf.ones(
-        shape=(features['inputs'].shape[0],), dtype=features['inputs'].dtype)
     return features
 
   ds = tf.data.Dataset.list_files(file_path, shuffle=False)
@@ -63,9 +62,7 @@ def get_criteo1tb_dataset(split: str,
       block_length=per_device_batch_size // 8,
       num_parallel_calls=128,
       deterministic=False)
-  # TODO(znado): we will need to select a validation split size that is evenly
-  # divisible by the batch size.
-  ds = ds.batch(per_device_batch_size, drop_remainder=True)
+  ds = ds.batch(per_device_batch_size, drop_remainder=False)
   ds = ds.map(_parse_example_fn, num_parallel_calls=16)
   if num_batches is not None:
     ds = ds.take(num_batches)

--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -62,7 +62,7 @@ def get_criteo1tb_dataset(split: str,
       block_length=per_device_batch_size // 8,
       num_parallel_calls=128,
       deterministic=False)
-  ds = ds.batch(per_device_batch_size, drop_remainder=False)
+  ds = ds.batch(per_device_batch_size, drop_remainder=is_training)
   ds = ds.map(_parse_example_fn, num_parallel_calls=16)
   if num_batches is not None:
     ds = ds.take(num_batches)

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -106,14 +106,9 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
         vocab_sizes=self.vocab_sizes,
         num_batches=num_batches,
         repeat_final_dataset=repeat_final_dataset)
-
-    # Separate function is necessary because the code above has to be executed
-    # when build_input_queue is called (not when next() is first called on it).
-    def _input_queue_generator():
-      for batch in iter(ds):
-        yield batch
-
-    return _input_queue_generator()
+    for batch in iter(ds):
+      batch = jax.tree_map(lambda x: x._numpy(), batch)  # pylint: disable=protected-access
+      yield batch
 
   # Return whether or not a key in spec.ParameterContainer is the output layer
   # parameters.

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -74,6 +74,10 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
     return tuple([1024] * 26)
 
   @property
+  def step_hint(self):
+    return 64_000  # TODO(znado): finalize.
+
+  @property
   def param_shapes(self):
     """The shapes of the parameters in the workload model."""
     if self._param_shapes is None:

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -1,0 +1,165 @@
+import math
+from typing import Dict, Optional
+
+import jax
+from absl import flags
+
+from algorithmic_efficiency import random_utils as prng
+from algorithmic_efficiency import spec
+from algorithmic_efficiency.pytorch_utils import pytorch_setup
+from algorithmic_efficiency.workloads.criteo1tb import input_pipeline
+
+USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
+
+FLAGS = flags.FLAGS
+
+
+class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
+  """Criteo1tb workload."""
+
+  def __init__(self):
+    self._eval_iters = {}
+    self._param_shapes = None
+    self._param_types = None
+
+  def has_reached_goal(self, eval_result: float) -> bool:
+    return eval_result['validation/loss'] < self.target_value
+
+  @property
+  def target_value(self):
+    return 0.13
+
+  @property
+  def loss_type(self):
+    return spec.LossType.SIGMOID_CROSS_ENTROPY
+
+  @property
+  def num_train_examples(self):
+    return 4_195_197_692
+
+  @property
+  def num_eval_train_examples(self):
+    return 4_195_197_692
+
+  @property
+  def num_validation_examples(self):
+    return 89_137_318
+
+  @property
+  def num_test_examples(self):
+    return None
+
+  @property
+  def train_mean(self):
+    return 0.0
+
+  @property
+  def train_stddev(self):
+    return 1.0
+
+  @property
+  def max_allowed_runtime_sec(self):
+    return 6 * 60 * 60
+
+  @property
+  def eval_period_time_sec(self):
+    return 20 * 60
+
+  @property
+  def num_dense_features(self):
+    return 13
+
+  @property
+  def vocab_sizes(self):
+    return tuple([1024] * 26)
+
+  @property
+  def param_shapes(self):
+    """The shapes of the parameters in the workload model."""
+    if self._param_shapes is None:
+      raise ValueError(
+          'This should not happen, workload.init_model_fn() should be called '
+          'before workload.param_shapes!')
+    return self._param_shapes
+
+  @property
+  def model_params_types(self):
+    """
+    TODO: return shape tuples from model as a tree
+    """
+    raise NotImplementedError
+
+  def build_input_queue(self,
+                        data_rng: jax.random.PRNGKey,
+                        split: str,
+                        data_dir: str,
+                        global_batch_size: int,
+                        num_batches: Optional[int] = None,
+                        repeat_final_dataset: bool = False):
+    is_training = split == 'train'
+    ds = input_pipeline.get_criteo1tb_dataset(
+        split=split,
+        data_dir=data_dir,
+        is_training=is_training,
+        global_batch_size=global_batch_size,
+        num_dense_features=self.num_dense_features,
+        vocab_sizes=self.vocab_sizes,
+        num_batches=num_batches,
+        repeat_final_dataset=repeat_final_dataset)
+
+    # Separate function is necessary because the code above has to be executed
+    # when build_input_queue is called (not when next() is first called on it).
+    def _input_queue_generator():
+      for batch in iter(ds):
+        yield batch
+
+    return _input_queue_generator()
+
+  # Return whether or not a key in spec.ParameterContainer is the output layer
+  # parameters.
+  def is_output_params(self, param_key: spec.ParameterKey) -> bool:
+    pass
+
+  def output_activation_fn(self,
+                           logits_batch: spec.Tensor,
+                           loss_type: spec.LossType) -> spec.Tensor:
+    pass
+
+  def _eval_batch(self, params, batch, model_state, rng):
+    logits, _ = self.model_fn(
+        params,
+        batch,
+        model_state,
+        spec.ForwardPassMode.EVAL,
+        rng,
+        update_batch_norm=False)
+    return self._eval_metric(batch['targets'], logits, batch['weights'])
+
+  def _eval_model_on_split(self,
+                           split: str,
+                           num_examples: int,
+                           global_batch_size: int,
+                           params: spec.ParameterContainer,
+                           model_state: spec.ModelAuxiliaryState,
+                           rng: spec.RandomState,
+                           data_dir: str) -> Dict[str, float]:
+    """Run a full evaluation of the model."""
+    data_rng, model_rng = prng.split(rng, 2)
+    if split not in self._eval_iters:
+      self._eval_iters[split] = self.build_input_queue(
+          data_rng, split, data_dir, global_batch_size=global_batch_size)
+
+    total_metrics = None
+    num_eval_steps = int(math.ceil(float(num_examples) / global_batch_size))
+    # Loop over graph batches in eval dataset.
+    for _ in range(num_eval_steps):
+      batch = next(self._eval_iters[split])
+      batch_metrics = self._eval_batch(params, batch, model_state, model_rng)
+      total_metrics = (
+          batch_metrics
+          if total_metrics is None else total_metrics.merge(batch_metrics))
+    if total_metrics is None:
+      return {}
+    if FLAGS.framework == 'jax':
+      total_metrics = total_metrics.reduce()
+    return {k: float(v) for k, v in total_metrics.compute().items()}

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -133,7 +133,7 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
         spec.ForwardPassMode.EVAL,
         rng,
         update_batch_norm=False)
-    return self._eval_metric(batch['targets'], logits, batch['weights'])
+    return self._eval_metric(batch['targets'], logits)
 
   def _eval_model_on_split(self,
                            split: str,

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -1,8 +1,8 @@
 import math
 from typing import Dict, Optional
 
-import jax
 from absl import flags
+import jax
 
 from algorithmic_efficiency import random_utils as prng
 from algorithmic_efficiency import spec

--- a/reference_submissions/criteo1tb/criteo1tb_jax/submission.py
+++ b/reference_submissions/criteo1tb/criteo1tb_jax/submission.py
@@ -15,7 +15,7 @@ from algorithmic_efficiency import spec
 def get_batch_size(workload_name):
   # Return the global batch size.
   del workload_name
-  return 131072
+  return 128
 
 
 def create_learning_rate_fn(workload: spec.Workload,

--- a/reference_submissions/criteo1tb/criteo1tb_jax/submission.py
+++ b/reference_submissions/criteo1tb/criteo1tb_jax/submission.py
@@ -119,7 +119,7 @@ def data_selection(workload: spec.Workload,
                    global_step: int,
                    rng: spec.RandomState) -> Dict[str, spec.Tensor]:
   """Select data from the infinitely repeating, pre-shuffled input queue.
-  
+
   Each element of the queue is a batch of training examples and labels.
   """
   del workload

--- a/reference_submissions/criteo1tb/criteo1tb_jax/submission.py
+++ b/reference_submissions/criteo1tb/criteo1tb_jax/submission.py
@@ -119,6 +119,7 @@ def data_selection(workload: spec.Workload,
                    global_step: int,
                    rng: spec.RandomState) -> Dict[str, spec.Tensor]:
   """Select data from the infinitely repeating, pre-shuffled input queue.
+  
   Each element of the queue is a batch of training examples and labels.
   """
   del workload

--- a/reference_submissions/criteo1tb/tuning_search_space.json
+++ b/reference_submissions/criteo1tb/tuning_search_space.json
@@ -1,6 +1,7 @@
 {
-  "learning_rate": {"feasible_points": [7e-4]},
+  "learning_rate": {"feasible_points": [0.01]},
   "warmup_steps": {"feasible_points": [3200]},
-  "weight_decay": {"feasible_points": [1e-4]},
-  "beta1": {"feasible_points": [0.9]}
+  "weight_decay": {"feasible_points": [1e-5]},
+  "beta1": {"feasible_points": [0.9]},
+  "step_hint": {"feasible_points": [64000]}
 }

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -18,15 +18,18 @@ import struct
 import time
 from typing import Optional, Tuple
 
+from absl import app
+from absl import flags
+from absl import logging
 import tensorflow as tf
 import torch
 import torch.distributed as dist
-from absl import app, flags, logging
 
 from algorithmic_efficiency import halton
 from algorithmic_efficiency import random_utils as prng
 from algorithmic_efficiency import spec
-from algorithmic_efficiency.profiler import PassThroughProfiler, Profiler
+from algorithmic_efficiency.profiler import PassThroughProfiler
+from algorithmic_efficiency.profiler import Profiler
 from algorithmic_efficiency.pytorch_utils import pytorch_setup
 
 # Hide any GPUs form TensorFlow. Otherwise TF might reserve memory and make

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -18,18 +18,15 @@ import struct
 import time
 from typing import Optional, Tuple
 
-from absl import app
-from absl import flags
-from absl import logging
 import tensorflow as tf
 import torch
 import torch.distributed as dist
+from absl import app, flags, logging
 
 from algorithmic_efficiency import halton
 from algorithmic_efficiency import random_utils as prng
 from algorithmic_efficiency import spec
-from algorithmic_efficiency.profiler import PassThroughProfiler
-from algorithmic_efficiency.profiler import Profiler
+from algorithmic_efficiency.profiler import PassThroughProfiler, Profiler
 from algorithmic_efficiency.pytorch_utils import pytorch_setup
 
 # Hide any GPUs form TensorFlow. Otherwise TF might reserve memory and make

--- a/tests/reference_submission_tests.py
+++ b/tests/reference_submission_tests.py
@@ -35,9 +35,7 @@ PYTORCH_DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 _EXPECTED_METRIC_NAMES = {
     'cifar': ['train/loss', 'validation/loss', 'test/accuracy'],
-    'criteo1tb': [
-        'train/loss', 'validation/loss'
-    ],
+    'criteo1tb': ['train/loss', 'validation/loss'],
     'fastmri': ['train/ssim', 'validation/ssim'],
     'imagenet_resnet': ['train/accuracy', 'validation/accuracy'],
     'imagenet_vit': ['train/accuracy', 'validation/accuracy'],

--- a/tests/reference_submission_tests.py
+++ b/tests/reference_submission_tests.py
@@ -34,23 +34,23 @@ FLAGS = flags.FLAGS
 PYTORCH_DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 _EXPECTED_METRIC_NAMES = {
-    'cifar': ['train/loss', 'validation/loss', 'test/accuracy'],
+    # 'cifar': ['train/loss', 'validation/loss', 'test/accuracy'],
     'criteo1tb': [
-        'train/loss', 'train/average_precision', 'validation/auc_roc'
+        'train/loss', 'validation/loss'
     ],
-    'fastmri': ['train/ssim', 'validation/ssim'],
-    'imagenet_resnet': ['train/accuracy', 'validation/accuracy'],
-    'imagenet_vit': ['train/accuracy', 'validation/accuracy'],
-    'librispeech': [
-        'train/word_error_rate',
-        'validation/word_error_rate',
-        'train/word_error_rate',
-    ],
-    'mnist': ['train/loss', 'validation/accuracy', 'test/accuracy'],
-    'ogbg': [
-        'train/accuracy', 'validation/loss', 'test/mean_average_precision'
-    ],
-    'wmt': ['train/bleu', 'validation/loss', 'validation/accuracy'],
+    # 'fastmri': ['train/ssim', 'validation/ssim'],
+    # 'imagenet_resnet': ['train/accuracy', 'validation/accuracy'],
+    # 'imagenet_vit': ['train/accuracy', 'validation/accuracy'],
+    # 'librispeech': [
+    #     'train/word_error_rate',
+    #     'validation/word_error_rate',
+    #     'train/word_error_rate',
+    # ],
+    # 'mnist': ['train/loss', 'validation/accuracy', 'test/accuracy'],
+    # 'ogbg': [
+    #     'train/accuracy', 'validation/loss', 'test/mean_average_precision'
+    # ],
+    # 'wmt': ['train/bleu', 'validation/loss', 'validation/accuracy'],
 }
 
 
@@ -296,7 +296,9 @@ class ReferenceSubmissionTest(absltest.TestCase):
             submission_path,
             search_space_path,
             data_dir=None,
-            use_fake_input_queue=FLAGS.use_fake_input_queue)
+            # use_fake_input_queue=FLAGS.use_fake_input_queue)
+            use_fake_input_queue = True)
+
         expected_names = _EXPECTED_METRIC_NAMES[workload_name]
         actual_names = list(eval_result.keys())
         for expected_name in expected_names:
@@ -305,3 +307,4 @@ class ReferenceSubmissionTest(absltest.TestCase):
 
 if __name__ == '__main__':
   absltest.main()
+

--- a/tests/reference_submission_tests.py
+++ b/tests/reference_submission_tests.py
@@ -34,23 +34,23 @@ FLAGS = flags.FLAGS
 PYTORCH_DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 _EXPECTED_METRIC_NAMES = {
-    # 'cifar': ['train/loss', 'validation/loss', 'test/accuracy'],
+    'cifar': ['train/loss', 'validation/loss', 'test/accuracy'],
     'criteo1tb': [
         'train/loss', 'validation/loss'
     ],
-    # 'fastmri': ['train/ssim', 'validation/ssim'],
-    # 'imagenet_resnet': ['train/accuracy', 'validation/accuracy'],
-    # 'imagenet_vit': ['train/accuracy', 'validation/accuracy'],
-    # 'librispeech': [
-    #     'train/word_error_rate',
-    #     'validation/word_error_rate',
-    #     'train/word_error_rate',
-    # ],
-    # 'mnist': ['train/loss', 'validation/accuracy', 'test/accuracy'],
-    # 'ogbg': [
-    #     'train/accuracy', 'validation/loss', 'test/mean_average_precision'
-    # ],
-    # 'wmt': ['train/bleu', 'validation/loss', 'validation/accuracy'],
+    'fastmri': ['train/ssim', 'validation/ssim'],
+    'imagenet_resnet': ['train/accuracy', 'validation/accuracy'],
+    'imagenet_vit': ['train/accuracy', 'validation/accuracy'],
+    'librispeech': [
+        'train/word_error_rate',
+        'validation/word_error_rate',
+        'train/word_error_rate',
+    ],
+    'mnist': ['train/loss', 'validation/accuracy', 'test/accuracy'],
+    'ogbg': [
+        'train/accuracy', 'validation/loss', 'test/mean_average_precision'
+    ],
+    'wmt': ['train/bleu', 'validation/loss', 'validation/accuracy'],
 }
 
 
@@ -296,9 +296,7 @@ class ReferenceSubmissionTest(absltest.TestCase):
             submission_path,
             search_space_path,
             data_dir=None,
-            # use_fake_input_queue=FLAGS.use_fake_input_queue)
-            use_fake_input_queue = True)
-
+            use_fake_input_queue=FLAGS.use_fake_input_queue)
         expected_names = _EXPECTED_METRIC_NAMES[workload_name]
         actual_names = list(eval_result.keys())
         for expected_name in expected_names:
@@ -307,4 +305,3 @@ class ReferenceSubmissionTest(absltest.TestCase):
 
 if __name__ == '__main__':
   absltest.main()
-


### PR DESCRIPTION
In this PR, the followings are modified:
- Refactor workload `dlrm_jax` so that we can share existing code with the upcoming PyTorch implementation (will submit PR soon).
- Update incorrect numbers in `BaseCriteo1TbDlrmSmallWorkload`. 
- Update hyperparameters and architecture to match the ones in the `init2wint` repository [here](https://github.com/google/init2winit/blob/master/init2winit/model_lib/dlrm.py).
- Incorporates pre-processing change from #103.
- Update reference submission and confirm that it passes.

TODO: We (cc' @rakshithvasudev) still need to run the workload to check if the targeted score can be achieved with this update. 