### PR TITLE
Add `label_smoothing` argument to `loss_fn`

### DIFF
--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -224,7 +224,8 @@ class Workload(metaclass=abc.ABCMeta):
       self,
       label_batch: Tensor,  # Dense (not one-hot) labels.
       logits_batch: Tensor,
-      mask_batch: Optional[Tensor] = None) -> Tensor:  # differentiable
+      mask_batch: Optional[Tensor] = None,
+      label_smoothing: float = 0.0) -> Tensor:  # differentiable
     """return oned_array_of_losses_per_example"""
 
   @abc.abstractmethod

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -191,9 +191,15 @@ class CifarWorkload(BaseCifarWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self, label_batch: spec.Tensor,
-              logits_batch: spec.Tensor) -> spec.Tensor:  # differentiable
-    return F.cross_entropy(logits_batch, label_batch, reduction='none')
+  def loss_fn(self,
+              label_batch: spec.Tensor,
+              logits_batch: spec.Tensor,
+              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
+    return F.cross_entropy(
+        logits_batch,
+        label_batch,
+        reduction='none',
+        label_smoothing=label_smoothing)
 
   def _eval_metric(self, logits, labels):
     """Return the mean accuracy and loss as a dict."""

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/metrics.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/metrics.py
@@ -1,40 +1,7 @@
-"""Binary sigmoid cross-entropy, AUCROC, and mAP metrics."""
+"""Binary sigmoid cross-entropy metric."""
 
-from clu import metrics
-import flax
 import jax
 import jax.numpy as jnp
-import numpy as np
-from scipy.special import expit
-import sklearn.metrics
-
-
-def _conform_weights_to_targets(weights, targets):
-  """Conforms the shape of weights to targets to apply masking.
-
-  We allow shape of weights to be a prefix of the shape of targets, for example
-  for targets of shape (n_batches, n_tasks) we allow weights with shape
-  (n_batches, n_tasks) or (n_batches, ). Add the necessary trailing dimensions
-  of size 1 so that weights can be applied as a mask by a simple multiplication,
-  (n_batches, 1) in this case.
-
-  Args:
-    weights: None or a numpy array which shape is a prefix of targets shape
-    targets: numpy array to conform the weights to
-  Returns:
-    weights with proper dimensions added to apply it as a mask.
-  """
-  if weights is None:
-    weights = jnp.ones_like(targets)
-  elif weights.shape == targets.shape[:weights.ndim]:
-    # Add extra dimension if weights.shape is a prefix of targets.shape
-    # so that multiplication can be broadcasted.
-    weights = jnp.expand_dims(
-        weights, axis=tuple(range(weights.ndim, targets.ndim)))
-  elif weights.shape != targets.shape:
-    raise ValueError('Incorrect shapes. Got shape %s weights and %s targets.' %
-                     (str(weights.shape), str(targets.shape)))
-  return weights
 
 
 def per_example_sigmoid_binary_cross_entropy(logits, targets):

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
@@ -8,6 +8,7 @@ import flax
 from flax import jax_utils
 import jax
 import jax.numpy as jnp
+import optax
 
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
@@ -24,7 +25,7 @@ _VOCAB_SIZES = tuple([1024 * 128] * 26)
 # we can compute AUC metrics.
 @flax.struct.dataclass
 class EvalMetrics(clu_metrics.Collection):
-  loss: clu_metrics.Average.from_output("loss")
+  loss: clu_metrics.Average.from_output('loss')
 
 
 class Criteo1TbDlrmSmallWorkload(spec.Workload):
@@ -177,9 +178,11 @@ class Criteo1TbDlrmSmallWorkload(spec.Workload):
       self,
       label_batch: spec.Tensor,  # Dense (not one-hot) labels.
       logits_batch: spec.Tensor,
+      label_smoothing: float = 0.0,
       mask_batch: Optional[spec.Tensor] = None) -> spec.Tensor:
+    smoothed_targets = optax.smooth_labels(label_batch, label_smoothing)
     per_example_losses = metrics.per_example_sigmoid_binary_cross_entropy(
-        logits=logits_batch, targets=label_batch)
+        logits=logits_batch, targets=smoothed_targets)
     if mask_batch is not None:
       weighted_losses = per_example_losses * mask_batch
       normalization = mask_batch.sum()

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -29,14 +29,6 @@ USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
   @property
-  def param_shapes(self):
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
-
-  @property
   def model_params_types(self):
     """The shapes of the parameters in the workload model."""
     if self._param_types is None:
@@ -185,9 +177,15 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self, label_batch: spec.Tensor,
-              logits_batch: spec.Tensor) -> spec.Tensor:  # differentiable
-    return F.cross_entropy(logits_batch, label_batch, reduction='none')
+  def loss_fn(self,
+              label_batch: spec.Tensor,
+              logits_batch: spec.Tensor,
+              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
+    return F.cross_entropy(
+        logits_batch,
+        label_batch,
+        reduction='none',
+        label_smoothing=label_smoothing)
 
   def _eval_metric(self, logits, labels):
     """Return the mean accuracy and loss as a dict."""

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
@@ -45,6 +45,8 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del update_batch_norm
+    del mode
+    del rng
     logits = self._model.apply({'params': params},
                                augmented_and_preprocessed_input_batch['inputs'])
     return logits, None

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -32,8 +32,7 @@ class _Model(nn.Module):
                       torch.nn.Linear(input_size, num_hidden, bias=True)),
                      ('layer1_sig', torch.nn.Sigmoid()),
                      ('layer2',
-                      torch.nn.Linear(num_hidden, num_classes, bias=True)),
-                     ('output', torch.nn.LogSoftmax(dim=1))]))
+                      torch.nn.Linear(num_hidden, num_classes, bias=True))]))
 
   def forward(self, x: spec.Tensor):
     x = x.view(x.size()[0], -1)
@@ -170,10 +169,15 @@ class MnistWorkload(BaseMnistWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self, label_batch: spec.Tensor,
-              logits_batch: spec.Tensor) -> spec.Tensor:  # differentiable
-
-    return F.nll_loss(logits_batch, label_batch, reduction='none')
+  def loss_fn(self,
+              label_batch: spec.Tensor,
+              logits_batch: spec.Tensor,
+              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
+    return F.cross_entropy(
+        logits_batch,
+        label_batch,
+        reduction='none',
+        label_smoothing=label_smoothing)
 
   def _eval_model(
       self,

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -1,6 +1,6 @@
 import itertools
 import math
-from typing import Dict, Optional
+from typing import Dict
 
 from absl import flags
 import jax
@@ -91,13 +91,16 @@ class BaseOgbgWorkload(spec.Workload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(
-      self,
-      label_batch: spec.Tensor,
-      logits_batch: spec.Tensor,
-      mask_batch: Optional[spec.Tensor]) -> spec.Tensor:  # differentiable
+  def loss_fn(self,
+              label_batch: spec.Tensor,
+              logits_batch: spec.Tensor,
+              mask_batch: spec.Tensor,
+              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
     per_example_losses = self._binary_cross_entropy_with_mask(
-        labels=label_batch, logits=logits_batch, mask=mask_batch)
+        labels=label_batch,
+        logits=logits_batch,
+        mask=mask_batch,
+        label_smoothing=label_smoothing)
     return per_example_losses
 
   # Return whether or not a key in spec.ParameterContainer is the output layer

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -51,7 +51,8 @@ class WmtWorkload(BaseWmtWorkload):
     if N_GPUS > 1 and not USE_PYTORCH_DDP:
       loss_fn = torch.nn.DataParallel(loss_fn)
 
-    loss = loss_fn(logits, targets)
+    # PyTorch loss functions expect the class dim directly after the batch dim.
+    loss = loss_fn(logits.transpose(-2, -1), targets)
     if weights is not None:
       loss = loss * weights
     return loss

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -210,6 +210,6 @@ class BaseWmtWorkload(spec.Workload):
       self,
       label_batch: spec.Tensor,  # Dense (not one-hot) labels.
       logits_batch: spec.Tensor,
-      mask_batch: Optional[spec.Tensor] = None) -> spec.Tensor:
-    del mask_batch
-    return self.compute_weighted_cross_entropy(logits_batch, label_batch)
+      label_smoothing: float = 0.0) -> spec.Tensor:
+    return self.compute_weighted_cross_entropy(
+        logits_batch, label_batch, label_smoothing=label_smoothing)

--- a/reference_submissions/wmt/wmt_jax/submission.py
+++ b/reference_submissions/wmt/wmt_jax/submission.py
@@ -118,7 +118,8 @@ def pmapped_train_step(workload,
         update_batch_norm=False)
     targets = batch['targets']
     weights = jnp.where(targets > 0, 1.0, 0.0)
-    loss = (workload.loss_fn(targets, logits) * weights).sum() / weights.sum()
+    loss = (workload.loss_fn(targets, logits, label_smoothing=0.1) *
+            weights).sum() / weights.sum()
     return loss
 
   grad_fn = jax.value_and_grad(_loss_fn)

--- a/reference_submissions/wmt/wmt_pytorch/submission.py
+++ b/reference_submissions/wmt/wmt_pytorch/submission.py
@@ -120,7 +120,8 @@ def update_params(workload: spec.Workload,
 
   targets = batch['targets']
   weights = torch.where(targets > 0, 1.0, 0.0)
-  loss = (workload.loss_fn(targets, logits) * weights).sum() / weights.sum()
+  loss = (workload.loss_fn(targets, logits, label_smoothing=0.1) *
+          weights).sum() / weights.sum()
   loss.backward()
 
   lr = optimizer_state['scheduler'](global_step).item()

--- a/target_setting_runs/criteo1tb/jax_submission.py
+++ b/target_setting_runs/criteo1tb/jax_submission.py
@@ -26,7 +26,7 @@ def get_batch_size(workload_name):
 @functools.partial(
     jax.pmap,
     axis_name='batch',
-    in_axes=(None, None, 0, 0, 0, 0, 0),
+    in_axes=(None, None, 0, 0, 0, 0, 0, None),
     static_broadcasted_argnums=(0, 1))
 def pmapped_train_step(workload,
                        opt_update_fn,
@@ -34,7 +34,8 @@ def pmapped_train_step(workload,
                        optimizer_state,
                        current_param_container,
                        batch,
-                       rng):
+                       rng,
+                       label_smoothing):
 
   def _loss_fn(params):
     """Loss function used for training."""
@@ -45,7 +46,9 @@ def pmapped_train_step(workload,
         spec.ForwardPassMode.TRAIN,
         rng,
         update_batch_norm=False)
-    loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
+    loss = jnp.mean(
+        workload.loss_fn(
+            batch['targets'], logits, label_smoothing=label_smoothing))
     return loss, (new_model_state, logits)
 
   grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
@@ -70,15 +73,17 @@ def update_params(workload: spec.Workload,
                   rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
-  del hyperparameters
   del loss_type
   del eval_results
   del global_step
 
   optimizer_state, opt_update_fn = optimizer_state
   per_device_rngs = jax.random.split(rng, jax.local_device_count())
+  label_smoothing = (
+      hyperparameters.label_smoothing if hasattr(hyperparameters,
+                                                 'label_smoothing') else 0.0)
   new_model_state, new_optimizer_state, new_params = pmapped_train_step(
       workload, opt_update_fn, model_state, optimizer_state,
-      current_param_container, batch, per_device_rngs)
+      current_param_container, batch, per_device_rngs, label_smoothing)
 
   return (new_optimizer_state, opt_update_fn), new_params, new_model_state

--- a/target_setting_runs/fastmri/pytorch_submission.py
+++ b/target_setting_runs/fastmri/pytorch_submission.py
@@ -28,7 +28,6 @@ def update_params(workload: spec.Workload,
                   rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
-  del hyperparameters
   del loss_type
   del eval_results
   del global_step
@@ -45,8 +44,13 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=True)
 
+  label_smoothing = (
+      hyperparameters.label_smoothing if hasattr(hyperparameters,
+                                                 'label_smoothing') else 0.0)
   loss = workload.loss_fn(
-      targets_batch=batch['targets'], outputs_batch=outputs_batch).mean()
+      targets_batch=batch['targets'],
+      outputs_batch=outputs_batch,
+      label_smoothing=label_smoothing).mean()
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/target_setting_runs/imagenet_resnet/jax_submission.py
+++ b/target_setting_runs/imagenet_resnet/jax_submission.py
@@ -27,7 +27,7 @@ def get_batch_size(workload_name):
     jax.pmap,
     axis_name='batch',
     in_axes=(None, None, 0, 0, 0, 0, 0, None),
-    static_broadcasted_argnums=(0, 1, 7))
+    static_broadcasted_argnums=(0, 1))
 def pmapped_train_step(workload,
                        opt_update_fn,
                        model_state,
@@ -82,9 +82,11 @@ def update_params(workload: spec.Workload,
   optimizer_state, opt_update_fn = optimizer_state
 
   per_device_rngs = jax.random.split(rng, jax.local_device_count())
+  label_smoothing = (
+      hyperparameters.label_smoothing if hasattr(hyperparameters,
+                                                 'label_smoothing') else 0.0)
   new_model_state, new_optimizer_state, new_params = pmapped_train_step(
       workload, opt_update_fn, model_state, optimizer_state,
-      current_param_container, batch, per_device_rngs,
-      hyperparameters.label_smoothing)
+      current_param_container, batch, per_device_rngs, label_smoothing)
 
   return (new_optimizer_state, opt_update_fn), new_params, new_model_state

--- a/target_setting_runs/imagenet_resnet/jax_submission.py
+++ b/target_setting_runs/imagenet_resnet/jax_submission.py
@@ -26,15 +26,16 @@ def get_batch_size(workload_name):
 @functools.partial(
     jax.pmap,
     axis_name='batch',
-    in_axes=(None, None, 0, 0, 0, 0, 0),
-    static_broadcasted_argnums=(0, 1))
+    in_axes=(None, None, 0, 0, 0, 0, 0, None),
+    static_broadcasted_argnums=(0, 1, 7))
 def pmapped_train_step(workload,
                        opt_update_fn,
                        model_state,
                        optimizer_state,
                        current_param_container,
                        batch,
-                       rng):
+                       rng,
+                       label_smoothing):
 
   def _loss_fn(params):
     """Loss function used for training."""
@@ -45,7 +46,9 @@ def pmapped_train_step(workload,
         spec.ForwardPassMode.TRAIN,
         rng,
         update_batch_norm=True)
-    loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
+    loss = jnp.mean(
+        workload.loss_fn(
+            batch['targets'], logits, label_smoothing=label_smoothing))
     return loss, (new_model_state, logits)
 
   grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
@@ -72,7 +75,6 @@ def update_params(workload: spec.Workload,
                   rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
-  del hyperparameters
   del loss_type
   del eval_results
   del global_step
@@ -82,6 +84,7 @@ def update_params(workload: spec.Workload,
   per_device_rngs = jax.random.split(rng, jax.local_device_count())
   new_model_state, new_optimizer_state, new_params = pmapped_train_step(
       workload, opt_update_fn, model_state, optimizer_state,
-      current_param_container, batch, per_device_rngs)
+      current_param_container, batch, per_device_rngs,
+      hyperparameters.label_smoothing)
 
   return (new_optimizer_state, opt_update_fn), new_params, new_model_state

--- a/target_setting_runs/imagenet_resnet/pytorch_submission.py
+++ b/target_setting_runs/imagenet_resnet/pytorch_submission.py
@@ -30,7 +30,6 @@ def update_params(workload: spec.Workload,
                   rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
-  del hyperparameters
   del loss_type
   del eval_results
   del global_step
@@ -48,7 +47,9 @@ def update_params(workload: spec.Workload,
       update_batch_norm=True)
 
   loss = workload.loss_fn(
-      label_batch=batch['targets'], logits_batch=logits_batch).mean()
+      label_batch=batch['targets'],
+      logits_batch=logits_batch,
+      label_smoothing=hyperparameters.label_smoothing).mean()
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/target_setting_runs/imagenet_resnet/pytorch_submission.py
+++ b/target_setting_runs/imagenet_resnet/pytorch_submission.py
@@ -46,10 +46,13 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=True)
 
+  label_smoothing = (
+      hyperparameters.label_smoothing if hasattr(hyperparameters,
+                                                 'label_smoothing') else 0.0)
   loss = workload.loss_fn(
       label_batch=batch['targets'],
       logits_batch=logits_batch,
-      label_smoothing=hyperparameters.label_smoothing).mean()
+      label_smoothing=label_smoothing).mean()
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/target_setting_runs/imagenet_resnet/tuning_search_space.json
+++ b/target_setting_runs/imagenet_resnet/tuning_search_space.json
@@ -33,5 +33,10 @@
         "feasible_points": [
             7.6e-6
         ]
+    },
+    "label_smoothing": {
+        "feasible_points": [
+            0.1414
+        ]
     }
 }

--- a/target_setting_runs/imagenet_vit/pytorch_submission.py
+++ b/target_setting_runs/imagenet_vit/pytorch_submission.py
@@ -28,7 +28,6 @@ def update_params(workload: spec.Workload,
                   rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
-  del hyperparameters
   del loss_type
   del eval_results
   del global_step
@@ -45,8 +44,13 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=True)
 
+  label_smoothing = (
+      hyperparameters.label_smoothing if hasattr(hyperparameters,
+                                                 'label_smoothing') else 0.0)
   loss = workload.loss_fn(
-      label_batch=batch['targets'], logits_batch=logits_batch).mean()
+      label_batch=batch['targets'],
+      logits_batch=logits_batch,
+      label_smoothing=label_smoothing).mean()
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/target_setting_runs/ogbg/pytorch_submission.py
+++ b/target_setting_runs/ogbg/pytorch_submission.py
@@ -30,7 +30,6 @@ def update_params(workload: spec.Workload,
                   rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
-  del hyperparameters
   del loss_type
   del eval_results
   del global_step
@@ -48,7 +47,11 @@ def update_params(workload: spec.Workload,
       update_batch_norm=True)
 
   mask = batch['weights']
-  per_example_losses = workload.loss_fn(batch['targets'], logits, mask)
+  label_smoothing = (
+      hyperparameters.label_smoothing if hasattr(hyperparameters,
+                                                 'label_smoothing') else 0.0)
+  per_example_losses = workload.loss_fn(
+      batch['targets'], logits, mask, label_smoothing=label_smoothing)
   loss = torch.where(mask, per_example_losses, 0).sum() / mask.sum()
 
   loss.backward()

--- a/target_setting_runs/wmt/jax_submission.py
+++ b/target_setting_runs/wmt/jax_submission.py
@@ -24,7 +24,7 @@ def get_batch_size(workload_name):
     jax.pmap,
     in_axes=(None, None, 0, 0, 0, 0, None),
     axis_name='batch',
-    static_broadcasted_argnums=(0, 1, 6))
+    static_broadcasted_argnums=(0, 1))
 def pmapped_train_step(workload,
                        opt_update_fn,
                        optimizer_state,
@@ -78,6 +78,9 @@ def update_params(workload: spec.Workload,
 
   optimizer_state, opt_update_fn = optimizer_state
   dropout_rngs = jax.random.split(rng, jax.local_device_count())
+  label_smoothing = (
+      hyperparameters.label_smoothing if hasattr(hyperparameters,
+                                                 'label_smoothing') else 0.0)
   new_optimizer_state, updated_params = pmapped_train_step(
       workload,
       opt_update_fn,
@@ -85,5 +88,5 @@ def update_params(workload: spec.Workload,
       current_param_container,
       batch,
       dropout_rngs,
-      hyperparameters.label_smoothing)
+      label_smoothing)
   return (new_optimizer_state, opt_update_fn), updated_params, None

--- a/target_setting_runs/wmt/pytorch_submission.py
+++ b/target_setting_runs/wmt/pytorch_submission.py
@@ -32,7 +32,6 @@ def update_params(workload: spec.Workload,
   del current_params_types
   del eval_results
   del loss_type
-  del hyperparameters
   del global_step
 
   current_model = current_param_container
@@ -49,7 +48,9 @@ def update_params(workload: spec.Workload,
 
   targets = batch['targets']
   weights = torch.where(targets > 0, 1.0, 0.0)
-  loss = (workload.loss_fn(targets, logits) * weights).sum() / weights.sum()
+  loss = (workload.loss_fn(
+      targets, logits, label_smoothing=hyperparameters.label_smoothing) *
+          weights).sum() / weights.sum()
   loss.backward()
 
   optimizer_state['optimizer'].step()

--- a/target_setting_runs/wmt/pytorch_submission.py
+++ b/target_setting_runs/wmt/pytorch_submission.py
@@ -48,8 +48,10 @@ def update_params(workload: spec.Workload,
 
   targets = batch['targets']
   weights = torch.where(targets > 0, 1.0, 0.0)
-  loss = (workload.loss_fn(
-      targets, logits, label_smoothing=hyperparameters.label_smoothing) *
+  label_smoothing = (
+      hyperparameters.label_smoothing if hasattr(hyperparameters,
+                                                 'label_smoothing') else 0.0)
+  loss = (workload.loss_fn(targets, logits, label_smoothing=label_smoothing) *
           weights).sum() / weights.sum()
   loss.backward()
 

--- a/target_setting_runs/wmt/tuning_search_space.json
+++ b/target_setting_runs/wmt/tuning_search_space.json
@@ -28,5 +28,10 @@
         "feasible_points": [
             0.081354
         ]
+    },
+    "label_smoothing": {
+        "feasible_points": [
+            0.1
+        ]
     }
 }


### PR DESCRIPTION
This PR adds a `label_smoothing` argument to `workload.loss_fn`.

I have also deleted `_conform_weights_to_targets` in `algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/metrics.py`, since it is not used anywhere.

**Question:**
~~Until now we have used a different implementation of label smoothing for the WMT workload than the standard variation implemented in init2winit, optax, and PyTorch (see this [docstring](https://github.com/google/init2winit/blob/master/init2winit/model_lib/model_utils.py#L158-L169) for an explanation of the difference). Should we stick to the different variation for that workload or switch to the one used for all other workloads?~~