### PR TITLE
loosening py req to 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
   six==1.16.0
   tensorflow==2.9.0
   tensorflow_datasets==4.4.0
-python_requires = >=3.9,<3.10
+python_requires = >=3.7,<3.10
 
 
 ###############################################################################


### PR DESCRIPTION
3.7 is usually the default version that comes with a lot of the ubuntu/debian images, so this is easier than having to upgrade python to 3.9 every time