### PR TITLE
Imagenet v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,12 @@ To automatically fix formatting errors, run the following (*WARNING:* this will 
 yapf -i -r -vv -p algorithmic_efficiency baselines target_setting_runs reference_submissions tests *.py
 ```
 
-To print out all offending import orderings, run the following (you will need to manually make the edits, because reordering Python imports can cause side-effects):
+To sort all import orderings, run the following:
+```bash
+isort .
+```
+
+To just print out all offending import orderings, run the following:
 ```bash
 isort . --check --diff
 ```

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -252,7 +252,7 @@ class Workload(metaclass=abc.ABCMeta):
                  model_state: ModelAuxiliaryState,
                  rng: RandomState,
                  data_dir: str,
-                 imagenet_v2_data_dir: str,
+                 imagenet_v2_data_dir: Optional[str],
                  global_step: int) -> Dict[str, float]:
     """Run a full evaluation of the model."""
     logging.info('Evaluating on the training split.')

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -252,6 +252,7 @@ class Workload(metaclass=abc.ABCMeta):
                  model_state: ModelAuxiliaryState,
                  rng: RandomState,
                  data_dir: str,
+                 imagenet_v2_data_dir: str,
                  global_step: int) -> Dict[str, float]:
     """Run a full evaluation of the model."""
     logging.info('Evaluating on the training split.')
@@ -278,7 +279,7 @@ class Workload(metaclass=abc.ABCMeta):
         global_step=global_step)
     for k, v in validation_metrics.items():
       eval_metrics['validation/' + k] = v
-    # Evaluate on the test set if we have one.
+    # Evaluate on the test set. TODO(znado): always eval on the test set.
     try:
       if self.num_test_examples is not None:
         logging.info('Evaluating on the test split.')
@@ -289,7 +290,7 @@ class Workload(metaclass=abc.ABCMeta):
             params=params,
             model_state=model_state,
             rng=rng,
-            data_dir=data_dir,
+            data_dir=imagenet_v2_data_dir if imagenet_v2_data_dir else data_dir,
             global_step=global_step)
         for k, v in test_metrics.items():
           eval_metrics['test/' + k] = v

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -209,11 +209,9 @@ def create_split(split,
                  stddev_rgb,
                  cache=False,
                  repeat_final_dataset=False,
-                 num_batches=None,
                  aspect_ratio_range=(0.75, 4.0 / 3.0),
                  area_range=(0.08, 1.0)):
   """Creates a split from the ImageNet dataset using TensorFlow Datasets."""
-  del num_batches
 
   shuffle_rng, preprocess_rng = jax.random.split(rng, 2)
 
@@ -281,8 +279,7 @@ def create_input_iter(split,
                       area_range,
                       train,
                       cache,
-                      repeat_final_dataset,
-                      num_batches):
+                      repeat_final_dataset):
   ds = create_split(
       split,
       dataset_builder,
@@ -295,7 +292,6 @@ def create_input_iter(split,
       stddev_rgb=stddev_rgb,
       cache=cache,
       repeat_final_dataset=repeat_final_dataset,
-      num_batches=num_batches,
       aspect_ratio_range=aspect_ratio_range,
       area_range=area_range)
   it = map(data_utils.shard_numpy_ds, ds)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -22,22 +22,6 @@ from algorithmic_efficiency.workloads.imagenet_resnet.workload import \
 
 class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
-  def build_input_queue(self,
-                        data_rng: spec.RandomState,
-                        split: str,
-                        data_dir: str,
-                        global_batch_size: int,
-                        cache: Optional[bool] = None,
-                        repeat_final_dataset: Optional[bool] = None,
-                        num_batches: Optional[int] = None):
-    return self._build_dataset(data_rng,
-                               split,
-                               data_dir,
-                               global_batch_size,
-                               cache,
-                               repeat_final_dataset,
-                               num_batches)
-
   def _build_dataset(self,
                      data_rng: spec.RandomState,
                      split: str,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -32,10 +32,12 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
                      cache: Optional[bool] = None,
                      repeat_final_dataset: Optional[bool] = None):
     if split == 'test':
-      np_iter = imagenet_v2.get_imagenet_v2_iter(data_dir,
-                                                 global_batch_size,
-                                                 self.train_mean,
-                                                 self.train_stddev)
+      np_iter = imagenet_v2.get_imagenet_v2_iter(
+          data_dir,
+          global_batch_size,
+          shard_batch=True,
+          mean_rgb=self.train_mean,
+          stddev_rgb=self.train_stddev)
       return itertools.cycle(np_iter)
 
     ds_builder = tfds.builder('imagenet2012:5.*.*', data_dir=data_dir)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -28,8 +28,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
                      data_dir: str,
                      batch_size: int,
                      cache: Optional[bool] = None,
-                     repeat_final_dataset: Optional[bool] = None,
-                     num_batches: Optional[int] = None):
+                     repeat_final_dataset: Optional[bool] = None):
     if batch_size % jax.local_device_count() != 0:
       raise ValueError('Batch size must be divisible by the number of devices')
     ds_builder = tfds.builder('imagenet2012:5.*.*', data_dir=data_dir)
@@ -50,8 +49,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         self.scale_ratio_range,
         train=train,
         cache=not train if cache is None else cache,
-        repeat_final_dataset=repeat_final_dataset,
-        num_batches=num_batches)
+        repeat_final_dataset=repeat_final_dataset)
     return ds
 
   def sync_batch_stats(self, model_state):

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/README.md
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/README.md
@@ -1,4 +1,0 @@
-## ImageNet PyTorch Workload
-
-Preliminary test of sample submission: the target performance of >76% validation accuracy is reached after about 239120 seconds (almost 66.5 hours) on 8 x NVIDIA RTX 2080Ti GPUs. Proper test result using the competition hardware (8 x NVIDIA v100 GPUs) will follow soon.
-

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -41,12 +41,10 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
                      data_dir: str,
                      batch_size: int,
                      cache,
-                     repeat_final_dataset,
-                     num_batches):
+                     repeat_final_dataset):
     del data_rng
     del cache
     del repeat_final_dataset
-    del num_batches
     is_train = split == 'train'
 
     eval_transform_config = transforms.Compose([

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -35,19 +35,18 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     return self._param_types
 
-  def build_input_queue(self,
-                        data_rng: spec.RandomState,
-                        split: str,
-                        data_dir: str,
-                        global_batch_size: int):
-    return self._build_dataset(data_rng, split, data_dir, global_batch_size)
-
   def _build_dataset(self,
                      data_rng: spec.RandomState,
                      split: str,
                      data_dir: str,
-                     batch_size: int):
+                     batch_size: int,
+                     cache,
+                     repeat_final_dataset,
+                     num_batches):
     del data_rng
+    del cache
+    del repeat_final_dataset
+    del num_batches
     is_train = split == 'train'
 
     eval_transform_config = transforms.Compose([

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
@@ -1,0 +1,59 @@
+"""ImageNet-v2 tf.data input pipeline.
+
+Uses TFDS https://www.tensorflow.org/datasets/catalog/imagenet_v2.
+"""
+from flax import jax_utils
+import itertools
+import jax
+import numpy as np
+import tensorflow_datasets as tfds
+
+from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax import \
+    input_pipeline
+
+
+def _shard(x):
+  return x.reshape((jax.local_device_count(), -1, *x.shape[1:]))
+
+
+def shard_and_maybe_pad_batch(desired_batch_size, tf_batch):
+  batch_axis = 0
+  batch = jax.tree_map(lambda x: x._numpy(), tf_batch)
+  batch_size = batch['inputs'].shape[batch_axis]
+  batch['weights'] = np.ones(batch_size, dtype=np.float32)
+
+  batch_pad = desired_batch_size - batch_size
+  # Most batches will not need padding so we quickly return to avoid slowdown.
+  if batch_pad == 0:
+    return jax.tree_map(_shard, batch)
+
+  def zero_pad(x):
+    padding = [(0, 0)] * x.ndim
+    padding[batch_axis] = (0, batch_pad)
+    padded = np.pad(x, padding, mode='constant', constant_values=0.0)
+    return _shard(padded)
+
+  return jax.tree_map(zero_pad, batch)
+
+
+def get_imagenet_v2_iter(global_batch_size, mean_rgb, stddev_rgb):
+  """Always caches and repeats indefinitely."""
+  ds = tfds.load(
+      'imagenet_v2/matched-frequency',
+      split='test',
+      decoders={
+          'image': tfds.decode.SkipDecoding(),
+      })
+
+  def _decode_example(example):
+    image = input_pipeline.preprocess_for_eval(
+        example['image'], mean_rgb, stddev_rgb)
+    return {
+        'inputs': image,
+        'targets': example['label'],
+    }
+
+  ds = ds.map(_decode_example, num_parallel_calls=16)
+  ds = ds.batch(global_batch_size)
+  it = map(shard_and_maybe_pad_batch, iter(ds))
+  return itertools.cycle(it)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
@@ -36,11 +36,12 @@ def shard_and_maybe_pad_batch(desired_batch_size, tf_batch):
   return jax.tree_map(zero_pad, batch)
 
 
-def get_imagenet_v2_iter(global_batch_size, mean_rgb, stddev_rgb):
+def get_imagenet_v2_iter(data_dir, global_batch_size, mean_rgb, stddev_rgb):
   """Always caches and repeats indefinitely."""
   ds = tfds.load(
       'imagenet_v2/matched-frequency',
       split='test',
+      data_dir=data_dir,
       decoders={
           'image': tfds.decode.SkipDecoding(),
       })

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
@@ -39,7 +39,7 @@ def shard_and_maybe_pad_batch(desired_batch_size, tf_batch):
 def get_imagenet_v2_iter(data_dir, global_batch_size, mean_rgb, stddev_rgb):
   """Always caches and repeats indefinitely."""
   ds = tfds.load(
-      'imagenet_v2/matched-frequency',
+      'imagenet_v2/matched-frequency:3.0.0',
       split='test',
       data_dir=data_dir,
       decoders={

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -1,6 +1,8 @@
 """ImageNet workload parent class."""
+from typing import Optional
 
 from algorithmic_efficiency import spec
+from algorithmic_efficiency.workloads.imagenet_resnet import imagenet_v2
 
 
 class BaseImagenetResNetWorkload(spec.Workload):
@@ -35,7 +37,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def num_test_examples(self):
-    return None
+    return 10000  # ImageNet-v2
 
   @property
   def train_mean(self):
@@ -84,3 +86,22 @@ class BaseImagenetResNetWorkload(spec.Workload):
   # parameters.
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     raise NotImplementedError
+
+  def build_input_queue(self,
+                        data_rng: spec.RandomState,
+                        split: str,
+                        data_dir: str,
+                        global_batch_size: int,
+                        cache: Optional[bool] = None,
+                        repeat_final_dataset: Optional[bool] = None,
+                        num_batches: Optional[int] = None):
+    if split == 'test':
+      return imagenet_v2.get_imagenet_v2_iter(
+          global_batch_size, self.train_mean, self.train_stddev)
+    return self._build_dataset(data_rng,
+                               split,
+                               data_dir,
+                               global_batch_size,
+                               cache,
+                               repeat_final_dataset,
+                               num_batches)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -1,4 +1,5 @@
 """ImageNet workload parent class."""
+from multiprocessing.sharedctypes import Value
 from typing import Optional
 
 from algorithmic_efficiency import spec
@@ -47,7 +48,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
   def train_stddev(self):
     return [0.229 * 255, 0.224 * 255, 0.225 * 255]
 
-  # data augmentation settings
+  # Data augmentation settings.
 
   @property
   def scale_ratio_range(self):
@@ -95,13 +96,18 @@ class BaseImagenetResNetWorkload(spec.Workload):
                         cache: Optional[bool] = None,
                         repeat_final_dataset: Optional[bool] = None,
                         num_batches: Optional[int] = None):
+    del num_batches
     if split == 'test':
+      del data_rng
+      if not cache:
+        raise ValueError('cache must be True for split=test.')
+      if not repeat_final_dataset:
+        raise ValueError('repeat_final_dataset must be True for split=test.')
       return imagenet_v2.get_imagenet_v2_iter(
-          global_batch_size, self.train_mean, self.train_stddev)
+          data_dir, global_batch_size, self.train_mean, self.train_stddev)
     return self._build_dataset(data_rng,
                                split,
                                data_dir,
                                global_batch_size,
                                cache,
-                               repeat_final_dataset,
-                               num_batches)
+                               repeat_final_dataset)

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -363,6 +363,8 @@ def score_submission_on_workload(workload: spec.Workload,
       rng, _ = prng.split(rng, 2)
       logging.info('--- Tuning run %d/%d ---', hi + 1, num_tuning_trials)
       with profiler.profile('Train'):
+        if 'imagenet' not in workload_name:
+          imagenet_v2_data_dir = None
         timing, metrics = train_once(workload, global_batch_size,
                                      data_dir, imagenet_v2_data_dir,
                                      init_optimizer_state,


### PR DESCRIPTION
Adding 'imagenet_v2/matched-frequency:3.0.0' as a test set for ImageNet. Uses tf.data for both jax and pytorch, and caches all images in memory.

Question: is it ok to call `itertools.cycle` (which saves a copy of an iterator in python to be run through endlessly) after moving the test images to the GPU, or will that always reserve them in GPU memory? Is that OK, or should we move them to GPU each eval?