### PR TITLE
Add mixup option to ImageNet workloads

### DIFF
--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -29,7 +29,7 @@ def shard_numpy_ds(xs):
   return jax.tree_map(_prepare, xs)
 
 
-def mixup(batch, alpha=0.1):
+def mixup_pytorch(batch, alpha=0.1):
   inputs, targets = batch
   # Transform to one-hot targets.
   targets = F.one_hot(targets, num_classes=1000)
@@ -55,7 +55,7 @@ def cycle(iterable,
       batch = next(iterator)
       if use_mixup:
         assert keys == ('inputs', 'targets')
-        batch = mixup(batch, alpha=mixup_alpha)
+        batch = mixup_pytorch(batch, alpha=mixup_alpha)
       assert len(keys) == len(batch)
       yield dict(zip(keys, batch))
     except StopIteration:

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -29,7 +29,7 @@ def shard_numpy_ds(xs):
   return jax.tree_map(_prepare, xs)
 
 
-def mixup_pytorch(batch, alpha=0.1):
+def mixup_pytorch(batch, alpha=0.2):
   inputs, targets = batch
   # Transform to one-hot targets.
   targets = F.one_hot(targets, num_classes=1000)
@@ -47,7 +47,7 @@ def cycle(iterable,
           keys=('inputs', 'targets'),
           custom_sampler=False,
           use_mixup=False,
-          mixup_alpha=0.1):
+          mixup_alpha=0.2):
   iterator = iter(iterable)
   epoch = 0
   while True:

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -2,6 +2,7 @@ import jax
 import numpy as np
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from torch.utils.data import DistributedSampler
 from torch.utils.data import Sampler
@@ -27,13 +28,33 @@ def shard_numpy_ds(xs):
   return jax.tree_map(_prepare, xs)
 
 
+def mixup(batch, alpha=0.1):
+  inputs, targets = batch
+  # Transform to one-hot targets.
+  targets = F.one_hot(targets, num_classes=1000)
+  # Compute weight for convex combination by sampling from Beta distribution.
+  beta_dist = torch.distributions.beta.Beta(alpha, alpha)
+  weight = beta_dist.sample()
+  # Return convex combination of original and shifted inputs and targets.
+  inputs = weight * inputs + (1.0 - weight) * torch.roll(inputs, 1, dims=0)
+  targets = weight * targets + (1.0 - weight) * torch.roll(targets, 1, dims=0)
+  return (inputs, targets)
+
+
 # github.com/pytorch/pytorch/issues/23900#issuecomment-518858050
-def cycle(iterable, keys=('inputs', 'targets'), custom_sampler=False):
+def cycle(iterable,
+          keys=('inputs', 'targets'),
+          custom_sampler=False,
+          use_mixup=False,
+          mixup_alpha=0.1):
   iterator = iter(iterable)
   epoch = 0
   while True:
     try:
       batch = next(iterator)
+      if use_mixup:
+        assert keys == ('inputs', 'targets')
+        batch = mixup(batch, alpha=mixup_alpha)
       assert len(keys) == len(batch)
       yield dict(zip(keys, batch))
     except StopIteration:

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -111,7 +111,9 @@ class Workload(metaclass=abc.ABCMeta):
                         global_batch_size: int,
                         cache: Optional[bool] = None,
                         repeat_final_dataset: Optional[bool] = None,
-                        num_batches: Optional[int] = None) -> Dict[str, Any]:
+                        num_batches: Optional[int] = None,
+                        use_mixup: bool = False,
+                        mixup_alpha: float = 0.1) -> Dict[str, Any]:
     """Build the input queue for the workload data.
 
     This is the only function that is NOT allowed to be called by submitters.
@@ -223,7 +225,7 @@ class Workload(metaclass=abc.ABCMeta):
   @abc.abstractmethod
   def loss_fn(
       self,
-      # Dense (not one-hot) labels, or a tuple of (tensor, padding) for speech.
+      # Dense or one-hot labels, or a tuple of (tensor, padding) for speech.
       label_batch: Union[Tuple[Tensor, Tensor], Tensor],
       logits_batch: Union[Tuple[Tensor, Tensor], Tensor],
       mask_batch: Optional[Tensor] = None,

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -111,9 +111,7 @@ class Workload(metaclass=abc.ABCMeta):
                         global_batch_size: int,
                         cache: Optional[bool] = None,
                         repeat_final_dataset: Optional[bool] = None,
-                        num_batches: Optional[int] = None,
-                        use_mixup: bool = False,
-                        mixup_alpha: float = 0.1) -> Dict[str, Any]:
+                        num_batches: Optional[int] = None) -> Dict[str, Any]:
     """Build the input queue for the workload data.
 
     This is the only function that is NOT allowed to be called by submitters.

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -202,7 +202,7 @@ def preprocess_for_eval(image_bytes,
 # Modified from
 # github.com/google/init2winit/blob/master/init2winit/dataset_lib/ (cont. below)
 # image_preprocessing.py.
-def mixup_tf(key, inputs, targets, alpha=0.1):
+def mixup_tf(key, inputs, targets, alpha=0.2):
   """Perform mixup https://arxiv.org/abs/1710.09412.
   NOTE: Code taken from https://github.com/google/big_vision with variables
   renamed to match `mixup` in this file and logic to synchronize globally.

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -31,8 +31,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
                      global_batch_size: int,
                      cache: Optional[bool] = None,
                      repeat_final_dataset: Optional[bool] = None,
-                     use_mixup: bool = False,
-                     mixup_alpha: float = 0.1):
+                     use_mixup: bool = False):
     if split == 'test':
       np_iter = imagenet_v2.get_imagenet_v2_iter(
           data_dir,
@@ -62,7 +61,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         cache=not train if cache is None else cache,
         repeat_final_dataset=repeat_final_dataset,
         use_mixup=use_mixup,
-        mixup_alpha=mixup_alpha)
+        mixup_alpha=0.2)
     return ds
 
   def sync_batch_stats(self, model_state):

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -58,8 +58,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
                      global_batch_size: int,
                      cache: bool,
                      repeat_final_dataset: bool,
-                     use_mixup: bool = False,
-                     mixup_alpha: float = 0.1):
+                     use_mixup: bool = False):
     del data_rng
     del cache
     del repeat_final_dataset
@@ -129,7 +128,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         dataloader,
         custom_sampler=USE_PYTORCH_DDP,
         use_mixup=use_mixup,
-        mixup_alpha=mixup_alpha)
+        mixup_alpha=0.2)
 
     return dataloader
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -9,6 +9,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
     self._param_shapes = None
     self._param_types = None
     self._eval_iters = {}
+    self._num_classes = 1000
 
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/accuracy'] > self.target_value

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -96,9 +96,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
                         global_batch_size: int,
                         cache: Optional[bool] = None,
                         repeat_final_dataset: Optional[bool] = None,
-                        num_batches: Optional[int] = None,
-                        use_mixup: bool = False,
-                        mixup_alpha: float = 0.1):
+                        num_batches: Optional[int] = None):
     del num_batches
     if global_batch_size % jax.local_device_count() != 0:
       raise ValueError('Batch size must be divisible by the number of devices')
@@ -112,6 +110,4 @@ class BaseImagenetResNetWorkload(spec.Workload):
                                data_dir,
                                global_batch_size,
                                cache,
-                               repeat_final_dataset,
-                               use_mixup,
-                               mixup_alpha)
+                               repeat_final_dataset)

--- a/algorithmic_efficiency/workloads/imagenet_vit/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/workload.py
@@ -1,5 +1,7 @@
 """ImageNet ViT workload."""
+from typing import Optional
 
+from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.imagenet_resnet.workload import \
     BaseImagenetResNetWorkload
 
@@ -61,3 +63,19 @@ class BaseImagenetVitWorkload(BaseImagenetResNetWorkload):
   @property
   def eval_period_time_sec(self):
     return 6000  # 100 mins
+
+  def _build_dataset(self,
+                     data_rng: spec.RandomState,
+                     split: str,
+                     data_dir: str,
+                     global_batch_size: int,
+                     cache: bool,
+                     repeat_final_dataset: bool):
+    use_mixup = split == 'train'
+    return super()._build_dataset(data_rng,
+                                  split,
+                                  data_dir,
+                                  global_batch_size,
+                                  cache,
+                                  repeat_final_dataset,
+                                  use_mixup)

--- a/algorithmic_efficiency/workloads/imagenet_vit/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/workload.py
@@ -1,6 +1,4 @@
 """ImageNet ViT workload."""
-from typing import Optional
-
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.imagenet_resnet.workload import \
     BaseImagenetResNetWorkload

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
   six==1.16.0
   tensorflow==2.9.0
   tensorflow_datasets==4.4.0
+  tensorflow_probability==0.17.0
 python_requires = >=3.7
 
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -194,12 +194,20 @@ def train_once(
 
   # Workload setup.
   logging.info('Initializing dataset.')
+  use_mixup = (
+      hyperparameters.use_mixup
+      if hasattr(hyperparameters, 'use_mixup') else False)
+  mixup_alpha = (
+      hyperparameters.mixup_alpha
+      if hasattr(hyperparameters, 'mixup_alpha') else 0.1)
   with profiler.profile('Initializing dataset'):
     input_queue = workload.build_input_queue(
         data_rng,
         'train',
         data_dir=data_dir,
-        global_batch_size=global_batch_size)
+        global_batch_size=global_batch_size,
+        use_mixup=use_mixup,
+        mixup_alpha=mixup_alpha)
   logging.info('Initializing model.')
   with profiler.profile('Initializing model'):
     model_params, model_state = workload.init_model_fn(model_init_rng)

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -196,20 +196,12 @@ def train_once(
 
   # Workload setup.
   logging.info('Initializing dataset.')
-  use_mixup = (
-      hyperparameters.use_mixup
-      if hasattr(hyperparameters, 'use_mixup') else False)
-  mixup_alpha = (
-      hyperparameters.mixup_alpha
-      if hasattr(hyperparameters, 'mixup_alpha') else 0.1)
   with profiler.profile('Initializing dataset'):
     input_queue = workload.build_input_queue(
         data_rng,
         'train',
         data_dir=data_dir,
-        global_batch_size=global_batch_size,
-        use_mixup=use_mixup,
-        mixup_alpha=mixup_alpha)
+        global_batch_size=global_batch_size)
   logging.info('Initializing model.')
   with profiler.profile('Initializing model'):
     model_params, model_state = workload.init_model_fn(model_init_rng)


### PR DESCRIPTION
Adds mixup data augmentation option to the ImageNet workloads. It can be selected by specifying the hyperparameters `use_mixup` and optionally `mixup_alpha`. As discussed I went with the less efficient but simpler version where we take the convex combination over the one-hot labels instead over two losses.