### PR TITLE
Refactor functions related to param_shapes and param_types

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,3 +25,4 @@ jobs:
         pytest -vx tests/workloads/imagenet_resnet/imagenet_jax/workload_test.py
         pytest -vx tests/test_num_params.py
         pytest -vx tests/test_param_shapes.py
+        pytest -vx tests/test_param_types.py

--- a/algorithmic_efficiency/param_utils.py
+++ b/algorithmic_efficiency/param_utils.py
@@ -37,9 +37,9 @@ def jax_param_types(param_shapes, parent_name=''):
     else:
       if 'bias' in name:
         param_types_dict[name] = spec.ParameterType.BIAS
-      elif 'BatchNorm' in parent_name:
+      elif 'batchnorm' in parent_name.lower():
         param_types_dict[name] = spec.ParameterType.BATCH_NORM
-      elif 'Conv' in parent_name:
+      elif 'conv' in parent_name.lower():
         param_types_dict[name] = spec.ParameterType.CONV_WEIGHT
       # Note that this is exact equality, not contained in, because
       # flax.linen.Embed names the embedding parameter "embedding"

--- a/algorithmic_efficiency/param_utils.py
+++ b/algorithmic_efficiency/param_utils.py
@@ -1,12 +1,14 @@
 """Utilities for dealing with parameter-related logic like types and shapes."""
+import jax
+
 from algorithmic_efficiency import spec
 
 
+def pytorch_param_shapes(model):
+  return {k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()}
+
+
 def pytorch_param_types(param_shapes):
-  if param_shapes is None:
-    raise ValueError(
-        'This should not happen, workload.init_model_fn() should be called '
-        'before workload.model_params_types!')
   param_types = {}
   for name in param_shapes.keys():
     if 'bias' in name:
@@ -22,9 +24,13 @@ def pytorch_param_types(param_shapes):
   return param_types
 
 
-def jax_param_types(param_tree):
+def jax_param_shapes(params):
+  return jax.tree_map(lambda x: spec.ShapeTuple(x.shape), params)
+
+
+def jax_param_types(param_shapes):
   param_types_dict = {}
-  for name, value in param_tree.items():
+  for name, value in param_shapes.items():
     if isinstance(value, dict):
       param_types_dict[name] = jax_param_types(value)
     else:

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -98,6 +98,10 @@ DataSelectionFn = Callable[[
 
 class Workload(metaclass=abc.ABCMeta):
 
+  _param_shapes: Optional[ParameterShapeTree] = None
+  _param_types: Optional[ParameterTypeTree] = None
+  _eval_iters: dict = {}
+
   @abc.abstractmethod
   def has_reached_goal(self, eval_result: float) -> bool:
     """Return whether or not the workload goal has been reached."""
@@ -123,16 +127,6 @@ class Workload(metaclass=abc.ABCMeta):
     convention should be plural key names because the values are batches of
     examples.
     """
-
-  @property
-  @abc.abstractmethod
-  def param_shapes(self):
-    """The shapes of the parameters in the workload model."""
-
-  @property
-  @abc.abstractmethod
-  def model_params_types(self) -> ParameterType:
-    """The types of the parameters in the workload model."""
 
   @property
   @abc.abstractmethod
@@ -183,6 +177,24 @@ class Workload(metaclass=abc.ABCMeta):
   @abc.abstractmethod
   def eval_period_time_sec(self):
     """The eval period of the workload in seconds."""
+
+  @property
+  def param_shapes(self):
+    """The shapes of the parameters in the workload model."""
+    if self._param_shapes is None:
+      raise ValueError(
+          'This should not happen, workload.init_model_fn() should be called '
+          'before workload.param_shapes!')
+    return self._param_shapes
+
+  @property
+  def model_params_types(self):
+    """The types of the parameters in the workload model."""
+    if self._param_types is None:
+      raise ValueError(
+          'This should not happen, workload.init_model_fn() should be called '
+          'before workload.param_types!')
+    return self._param_types
 
   @abc.abstractmethod
   def is_output_params(self, param_key: ParameterKey) -> bool:

--- a/algorithmic_efficiency/workloads/cifar/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/workload.py
@@ -5,11 +5,6 @@ from algorithmic_efficiency import spec
 
 class BaseCifarWorkload(spec.Workload):
 
-  def __init__(self):
-    self._eval_iters = {}
-    self._param_shapes = None
-    self._param_types = None
-
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/accuracy'] > self.target_value
 
@@ -65,22 +60,6 @@ class BaseCifarWorkload(spec.Workload):
   @property
   def eval_period_time_sec(self):
     return 600  # 10 mins
-
-  @property
-  def param_shapes(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
-
-  @property
-  def model_params_types(self):
-    """
-    TODO: return shape tuples from model as a tree
-    """
-    raise NotImplementedError
 
   # Return whether or not a key in spec.ParameterTree is the output layer
   # parameters.

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
@@ -17,16 +17,6 @@ from algorithmic_efficiency.workloads.criteo1tb.workload import \
 
 class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
 
-  @property
-  def model_params_types(self):
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    if self._param_types is None:
-      self._param_types = param_utils.jax_param_types(self._param_shapes)
-    return self._param_types
-
   def loss_fn(
       self,
       label_batch: spec.Tensor,  # Dense (not one-hot) labels.
@@ -64,10 +54,9 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
         init_rng,
         jnp.ones(input_shape, jnp.float32),
         jnp.ones(target_shape, jnp.float32))
-
     initial_params = initial_variables['params']
-    self._param_shapes = jax.tree_map(lambda x: spec.ShapeTuple(x.shape),
-                                      initial_params)
+    self._param_shapes = param_utils.jax_param_shapes(initial_params)
+    self._param_types = param_utils.jax_param_types(self._param_shapes)
     return jax_utils.replicate(initial_params), None
 
   def model_fn(

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -19,9 +19,6 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
     self.mlp_bottom_dims = (128, 128)
     self.mlp_top_dims = (256, 128, 1)
     self.embed_dim = 64
-    self._eval_iters = {}
-    self._param_shapes = None
-    self._param_types = None
 
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/loss'] < self.target_value
@@ -96,15 +93,6 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
   # parameters.
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     pass
-
-  @property
-  def param_shapes(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
 
   def _eval_model_on_split(self,
                            split: str,

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -19,19 +19,12 @@ from algorithmic_efficiency.workloads.fastmri.workload import \
 
 class FastMRIWorkload(BaseFastMRIWorkload):
 
-  @property
-  def model_params_types(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_types is None:
-      self._param_types = param_utils.jax_param_types(self._param_shapes)
-    return self._param_types
-
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     fake_batch = jnp.zeros((13, 320, 320))
     variables = jax.jit(models.UNet().init)({'params': rng}, fake_batch)
     params = variables['params']
-    self._param_shapes = jax.tree_map(lambda x: spec.ShapeTuple(x.shape),
-                                      params)
+    self._param_shapes = param_utils.jax_param_shapes(params)
+    self._param_types = param_utils.jax_param_types(self._param_shapes)
     params = jax_utils.replicate(params)
     return params, None
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -26,13 +26,6 @@ USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_utils.pytorch_setup()
 
 class FastMRIWorkload(BaseFastMRIWorkload):
 
-  @property
-  def model_params_types(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_types is None:
-      self._param_types = param_utils.pytorch_param_types(self._param_shapes)
-    return self._param_types
-
   def _build_input_queue(self,
                          data_rng: spec.RandomState,
                          split: str,
@@ -109,9 +102,8 @@ class FastMRIWorkload(BaseFastMRIWorkload):
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     torch.random.manual_seed(rng[0])
     model = unet()
-    self._param_shapes = {
-        k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()
-    }
+    self._param_shapes = param_utils.pytorch_param_shapes(model)
+    self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -8,11 +8,6 @@ from algorithmic_efficiency.workloads.fastmri import input_pipeline
 
 class BaseFastMRIWorkload(spec.Workload):
 
-  def __init__(self):
-    self._param_shapes = None
-    self._param_types = None
-    self._eval_iters = {}
-
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/ssim'] > self.target_value
 
@@ -63,22 +58,6 @@ class BaseFastMRIWorkload(spec.Workload):
   @property
   def eval_period_time_sec(self):
     return 6000  # 100 mins
-
-  @property
-  def param_shapes(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
-
-  @property
-  def model_params_types(self):
-    """
-    TODO: return shape tuples from model as a tree
-    """
-    raise NotImplementedError
 
   # Return whether or not a key in spec.ParameterTree is the output layer
   # parameters.

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/models.py
@@ -32,9 +32,9 @@ class ResNetBlock(nn.Module):
 
     if residual.shape != y.shape:
       residual = self.conv(
-          self.filters, (1, 1), self.strides, name='conv_proj')(
+          self.filters, (1, 1), self.strides, name='Conv_proj')(
               residual)
-      residual = self.norm(name='norm_proj')(residual)
+      residual = self.norm(name='BatchNorm_proj')(residual)
 
     return self.act(residual + y)
 
@@ -61,9 +61,9 @@ class BottleneckResNetBlock(nn.Module):
 
     if residual.shape != y.shape:
       residual = self.conv(
-          self.filters * 4, (1, 1), self.strides, name='conv_proj')(
+          self.filters * 4, (1, 1), self.strides, name='Conv_proj')(
               residual)
-      residual = self.norm(name='norm_proj')(residual)
+      residual = self.norm(name='BatchNorm_proj')(residual)
 
     return self.act(residual + y)
 
@@ -90,9 +90,9 @@ class ResNet(nn.Module):
     x = conv(
         self.num_filters, (7, 7), (2, 2),
         padding=[(3, 3), (3, 3)],
-        name='conv_init')(
+        name='Conv_init')(
             x)
-    x = norm(name='bn_init')(x)
+    x = norm(name='BatchNorm_init')(x)
     x = nn.relu(x)
     x = nn.max_pool(x, (3, 3), strides=(2, 2), padding='SAME')
     for i, block_size in enumerate(self.stage_sizes):

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -75,17 +75,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         {'batch_stats': avg_fn(model_state['batch_stats'])})
     return new_model_state
 
-  @property
-  def model_params_types(self):
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    if self._param_types is None:
-      self._param_types = param_utils.jax_param_types(
-          self._param_shapes.unfreeze())
-    return self._param_types
-
   def initialized(self, key, model):
     input_shape = (1, 224, 224, 3)
     variables = jax.jit(model.init)({'params': key},
@@ -98,8 +87,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     model = model_cls(num_classes=self._num_classes, dtype=jnp.float32)
     self._model = model
     params, model_state = self.initialized(rng, model)
-    self._param_shapes = jax.tree_map(lambda x: spec.ShapeTuple(x.shape),
-                                      params)
+    self._param_shapes = param_utils.jax_param_shapes(params)
+    self._param_types = param_utils.jax_param_types(self._param_shapes)
     model_state = jax_utils.replicate(model_state)
     params = jax_utils.replicate(params)
     return params, model_state

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
@@ -4,6 +4,7 @@ Adapted from torchvision:
 https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
 """
 
+import collections
 from typing import Any, Callable, List, Optional, Type, Union
 
 import torch
@@ -219,10 +220,12 @@ class ResNet(nn.Module):
       self.dilation *= stride
       stride = 1
     if stride != 1 or self.inplanes != planes * block.expansion:
-      downsample = nn.Sequential(
-          conv1x1(self.inplanes, planes * block.expansion, stride),
-          norm_layer(planes * block.expansion),
-      )
+      downsample = torch.nn.Sequential(
+          collections.OrderedDict([
+              ("conv", conv1x1(self.inplanes, planes * block.expansion,
+                               stride)),
+              ("bn", norm_layer(planes * block.expansion)),
+          ]))
 
     layers = []
     layers.append(

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -44,13 +44,6 @@ def imagenet_v2_to_torch(batch):
 
 class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
-  @property
-  def model_params_types(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_types is None:
-      self._param_types = param_utils.pytorch_param_types(self._param_shapes)
-    return self._param_types
-
   def _build_dataset(self,
                      data_rng: spec.RandomState,
                      split: str,
@@ -135,9 +128,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     torch.random.manual_seed(rng[0])
     model = resnet50()
-    self._param_shapes = {
-        k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()
-    }
+    self._param_shapes = param_utils.pytorch_param_shapes(model)
+    self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -9,9 +9,6 @@ from algorithmic_efficiency import spec
 class BaseImagenetResNetWorkload(spec.Workload):
 
   def __init__(self):
-    self._param_shapes = None
-    self._param_types = None
-    self._eval_iters = {}
     self._num_classes = 1000
 
   def has_reached_goal(self, eval_result: float) -> bool:
@@ -74,15 +71,6 @@ class BaseImagenetResNetWorkload(spec.Workload):
   @property
   def eval_period_time_sec(self):
     return 6000  # 100 mins
-
-  @property
-  def param_shapes(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
 
   # Return whether or not a key in spec.ParameterTree is the output layer
   # parameters.

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
@@ -6,6 +6,7 @@ from flax import jax_utils
 import jax
 import jax.numpy as jnp
 
+from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax.workload import \
     ImagenetResNetWorkload
@@ -31,8 +32,8 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     }
     model = models.ViT(**self._model_kwargs)
     params, model_state = self.initialized(rng, model)
-    self._param_shapes = jax.tree_map(lambda x: spec.ShapeTuple(x.shape),
-                                      params)
+    self._param_shapes = param_utils.jax_param_shapes(params)
+    self._param_types = param_utils.jax_param_types(self._param_shapes)
     model_state = jax_utils.replicate(model_state)
     params = jax_utils.replicate(params)
     return params, model_state

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
@@ -241,8 +241,8 @@ class ViT(nn.Module):
     num_patches = (self.image_height // self.patch_size[0]) * \
                   (self.image_width // self.patch_size[1])
     if self.posemb == 'learn':
-      self.pos_embedding = nn.Parameter(torch.randn(1, num_patches, width))
-      self.pos_embedding.data.normal_(std=1 / math.sqrt(self.width))
+      self.pos_embed = nn.Parameter(torch.randn(1, num_patches, width))
+      self.pos_embed.data.normal_(std=1 / math.sqrt(self.width))
 
     if self.pool_type == 'tok':
       self.cls = nn.Parameter(torch.randn(1, 1, width)).type(self.dtype)
@@ -253,13 +253,13 @@ class ViT(nn.Module):
       self.pre_logits = nn.Linear(self.width, rep_size)
       init_weights(self.pre_logits)
 
-    self.embedding = nn.Conv2d(
+    self.embed = nn.Conv2d(
         self.channels,
         self.width,
         self.patch_size,
         stride=self.patch_size,
         padding='valid')
-    init_weights(self.embedding)
+    init_weights(self.embed)
     self.dropout = nn.Dropout(p=dropout)
 
     self.encoder = Encoder(
@@ -277,7 +277,7 @@ class ViT(nn.Module):
 
   def get_posemb(self, x: Tensor) -> Tensor:
     if self.posemb == 'learn':
-      return self.pos_embedding.type(self.dtype)
+      return self.pos_embed.type(self.dtype)
     elif self.posemb == 'sincos2d':
       return posemb_sincos_2d(x).type(self.dtype)
     else:
@@ -287,7 +287,7 @@ class ViT(nn.Module):
     out = {}
 
     # Patch extraction
-    x = out['stem'] = self.embedding(x)
+    x = out['stem'] = self.embed(x)
 
     # Add posemb before adding extra token.
     n, c, h, w = x.shape

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional, Tuple
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
 
+from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import pytorch_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_pytorch.workload import \
@@ -27,9 +28,8 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     torch.random.manual_seed(rng[0])
     model_kwargs = decode_variant('B/32')
     model = models.ViT(num_classes=1000, **model_kwargs)
-    self._param_shapes = {
-        k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()
-    }
+    self._param_shapes = param_utils.pytorch_param_shapes(model)
+    self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -51,10 +51,8 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     pad = torch.zeros_like(wave)
     _ = model(wave, pad)
     conformer_model.initialize(model)
-
-    self._param_shapes = {
-        k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()
-    }
+    self._param_shapes = param_utils.pytorch_param_shapes(model)
+    self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
@@ -109,12 +107,6 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       logits, logits_paddings = model(inputs, input_paddings)
 
     return (logits, logits_paddings), None
-
-  @property
-  def model_params_types(self):
-    if self._param_types is None:
-      self._param_types = param_utils.pytorch_param_types(self._param_shapes)
-    return self._param_types
 
   def _build_input_queue(self,
                          data_rng: jax.random.PRNGKey,

--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -15,9 +15,6 @@ FLAGS = flags.FLAGS
 class BaseLibrispeechWorkload(spec.Workload):
 
   def __init__(self) -> None:
-    self._eval_iters = {}
-    self._param_shapes = None
-    self._param_types = None
     self._num_outputs = 1024
 
   def has_reached_goal(self, eval_result: float) -> bool:
@@ -62,14 +59,6 @@ class BaseLibrispeechWorkload(spec.Workload):
   @property
   def eval_period_time_sec(self):
     return 2500
-
-  @property
-  def param_shapes(self):
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
 
   def _build_input_queue(self,
                          data_rng: spec.RandomState,

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_jax/workload.py
@@ -7,6 +7,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.librispeech_conformer.librispeech_jax.workload import \
     LibriSpeechConformerWorkload
@@ -36,9 +37,8 @@ class LibriSpeechDeepSpeechWorkload(LibriSpeechConformerWorkload,
 
     model_state = variables['batch_stats']
     params = variables['params']
-
-    self._param_shapes = jax.tree_map(lambda x: spec.ShapeTuple(x.shape),
-                                      params)
+    self._param_shapes = param_utils.jax_param_shapes(params)
+    self._param_types = param_utils.jax_param_types(self._param_shapes)
     model_state = jax_utils.replicate(model_state)
     params = jax_utils.replicate(params)
     return params, model_state

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -114,9 +114,7 @@ class MnistWorkload(BaseMnistWorkload):
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     torch.random.manual_seed(rng[0])
     model = _Model()
-    self._param_shapes = {
-        k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()
-    }
+    self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
     if N_GPUS > 1:

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -94,13 +94,6 @@ class MnistWorkload(BaseMnistWorkload):
 
     return dataloader
 
-  @property
-  def model_params_types(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_types is None:
-      self._param_types = param_utils.pytorch_param_types(self._param_shapes)
-    return self._param_types
-
   # Return whether or not a key in spec.ParameterContainer is the output layer
   # parameters.
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
@@ -124,6 +117,7 @@ class MnistWorkload(BaseMnistWorkload):
     self._param_shapes = {
         k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()
     }
+    self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -17,11 +17,6 @@ USE_PYTORCH_DDP = 'LOCAL_RANK' in os.environ
 
 class BaseMnistWorkload(spec.Workload):
 
-  def __init__(self):
-    self._eval_iters = {}
-    self._param_shapes = None
-    self._param_types = None
-
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/accuracy'] > self.target_value
 
@@ -64,15 +59,6 @@ class BaseMnistWorkload(spec.Workload):
   @property
   def eval_period_time_sec(self):
     return 10
-
-  @property
-  def param_shapes(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
 
   def _eval_model(
       self,

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
@@ -114,22 +114,11 @@ class OgbgWorkload(BaseOgbgWorkload):
 
       yield batch
 
-  @property
-  def model_params_types(self):
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    if self._param_types is None:
-      self._param_types = param_utils.pytorch_param_types(self._param_shapes)
-    return self._param_types
-
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     torch.random.manual_seed(rng[0])
     model = GNN(self._num_outputs)
-    self._param_shapes = {
-        k: spec.ShapeTuple(v.shape) for k, v in model.named_parameters()
-    }
+    self._param_shapes = param_utils.pytorch_param_shapes(model)
+    self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -15,9 +15,6 @@ FLAGS = flags.FLAGS
 class BaseOgbgWorkload(spec.Workload):
 
   def __init__(self) -> None:
-    self._eval_iters = {}
-    self._param_shapes = None
-    self._param_types = None
     self._num_outputs = 128
 
   def has_reached_goal(self, eval_result: float) -> bool:
@@ -64,14 +61,6 @@ class BaseOgbgWorkload(spec.Workload):
   @property
   def eval_period_time_sec(self):
     return 120
-
-  @property
-  def param_shapes(self):
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
 
   def _build_input_queue(self,
                          data_rng: jax.random.PRNGKey,

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -193,8 +193,8 @@ class WmtWorkload(BaseWmtWorkload):
         jnp.ones(target_shape, jnp.float32))
 
     initial_params = initial_variables['params']
-    self._param_shapes = jax.tree_map(lambda x: spec.ShapeTuple(x.shape),
-                                      initial_params)
+    self._param_shapes = param_utils.jax_param_shapes(initial_params)
+    self._param_types = param_utils.jax_param_types(self._param_shapes)
     return jax_utils.replicate(initial_params), None
 
   def model_fn(
@@ -236,13 +236,3 @@ class WmtWorkload(BaseWmtWorkload):
         targets_segmentation=targets_segmentations,
         rngs={'dropout': rng})
     return logits_batch, None
-
-  @property
-  def model_params_types(self):
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    if self._param_types is None:
-      self._param_types = param_utils.jax_param_types(self._param_shapes)
-    return self._param_types

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -22,9 +22,6 @@ class BaseWmtWorkload(spec.Workload):
   """A WMT workload."""
 
   def __init__(self):
-    self._eval_iters = {}
-    self._param_shapes = None
-    self._param_types = None
     self._tokenizer = None
     self._vocab_size = 32000
 
@@ -192,15 +189,6 @@ class BaseWmtWorkload(spec.Workload):
   # parameters.
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     pass
-
-  @property
-  def param_shapes(self):
-    """The shapes of the parameters in the workload model."""
-    if self._param_shapes is None:
-      raise ValueError(
-          'This should not happen, workload.init_model_fn() should be called '
-          'before workload.param_shapes!')
-    return self._param_shapes
 
   def output_activation_fn(self,
                            logits_batch: spec.Tensor,

--- a/tests/test_param_types.py
+++ b/tests/test_param_types.py
@@ -33,10 +33,6 @@ from algorithmic_efficiency.workloads.wmt.wmt_pytorch.workload import \
 WORKLOADS = ['mnist', 'cifar', 'imagenet_resnet', 'imagenet_vit', 'wmt', 'ogbg']
 
 
-# Ideally we would match the types layer-wise, but for that we
-# have to ensure the exact same number of the types and that the
-# types of the weights of the same layer type actually match between
-# Jax and PyTorch, which is not always the case.
 @pytest.mark.parametrize('workload', WORKLOADS)
 def test_param_types(workload):
   jax_workload, pytorch_workload = get_workload(workload)

--- a/tests/test_param_types.py
+++ b/tests/test_param_types.py
@@ -1,0 +1,106 @@
+import jax
+import pytest
+
+from algorithmic_efficiency.workloads.cifar.cifar_jax.workload import \
+    CifarWorkload as JaxCifarWorkload
+from algorithmic_efficiency.workloads.cifar.cifar_pytorch.workload import \
+    CifarWorkload as PyTorchCifarWorkload
+from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_jax.workload import \
+    Criteo1TbDlrmSmallWorkload as JaxCriteoWorkload
+from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_pytorch.workload import \
+    Criteo1TbDlrmSmallWorkload as PyTorchCriteoWorkload
+from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax.workload import \
+    ImagenetResNetWorkload as JaxImagenetResNetWorkload
+from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_pytorch.workload import \
+    ImagenetResNetWorkload as PyTorchImagenetResNetWorkload
+from algorithmic_efficiency.workloads.imagenet_vit.imagenet_jax.workload import \
+    ImagenetVitWorkload as JaxImagenetViTWorkload
+from algorithmic_efficiency.workloads.imagenet_vit.imagenet_pytorch.workload import \
+    ImagenetVitWorkload as PyTorchImagenetViTWorkload
+from algorithmic_efficiency.workloads.mnist.mnist_jax.workload import \
+    MnistWorkload as JaxMnistWorkload
+from algorithmic_efficiency.workloads.mnist.mnist_pytorch.workload import \
+    MnistWorkload as PyTorchMnistWorkload
+from algorithmic_efficiency.workloads.ogbg.ogbg_jax.workload import \
+    OgbgWorkload as JaxOgbgWorkload
+from algorithmic_efficiency.workloads.ogbg.ogbg_pytorch.workload import \
+    OgbgWorkload as PyTorchOgbgWorkload
+from algorithmic_efficiency.workloads.wmt.wmt_jax.workload import \
+    WmtWorkload as JaxWmtWorkload
+from algorithmic_efficiency.workloads.wmt.wmt_pytorch.workload import \
+    WmtWorkload as PyTorchWmtWorkload
+
+WORKLOADS = ['mnist', 'cifar', 'imagenet_resnet', 'imagenet_vit', 'wmt', 'ogbg']
+
+
+# Ideally we would match the types layer-wise, but for that we
+# have to ensure the exact same number of the types and that the
+# types of the weights of the same layer type actually match between
+# Jax and PyTorch, which is not always the case.
+@pytest.mark.parametrize('workload', WORKLOADS)
+def test_param_types(workload):
+  jax_workload, pytorch_workload = get_workload(workload)
+  # Compare number of parameter tensors of both models.
+  jax_param_types = jax.tree_leaves(jax_workload.model_params_types)
+  pytorch_param_types = jax.tree_leaves(pytorch_workload.model_params_types)
+  assert len(jax_param_types) == len(pytorch_param_types)
+
+  def count_param_types(param_types):
+    types_dict = {}
+    for t in param_types:
+      if t not in types_dict:
+        types_dict[t] = 1
+      else:
+        types_dict[t] += 1
+    return types_dict
+
+  jax_param_types_dict = count_param_types(jax_param_types)
+  pytorch_param_types_dict = count_param_types(pytorch_param_types)
+  assert jax_param_types_dict.keys() == pytorch_param_types_dict.keys()
+  # Check if total number of each type match.
+  for key in list(jax_param_types_dict.keys()):
+    assert jax_param_types_dict[key] == pytorch_param_types_dict[key]
+
+
+def get_workload(workload):
+  if workload == 'mnist':
+    # Init Jax workload.
+    jax_workload = JaxMnistWorkload()
+    # Init PyTorch workload.
+    pytorch_workload = PyTorchMnistWorkload()
+  elif workload == 'cifar':
+    # Init Jax workload.
+    jax_workload = JaxCifarWorkload()
+    # Init PyTorch workload.
+    pytorch_workload = PyTorchCifarWorkload()
+  elif workload == 'criteo1tb':
+    # Init Jax workload.
+    jax_workload = JaxCriteoWorkload()
+    # Init PyTorch workload.
+    pytorch_workload = PyTorchCriteoWorkload()
+  elif workload == 'imagenet_resnet':
+    # Init Jax workload.
+    jax_workload = JaxImagenetResNetWorkload()
+    # Init PyTorch workload.
+    pytorch_workload = PyTorchImagenetResNetWorkload()
+  elif workload == 'imagenet_vit':
+    # Init Jax workload.
+    jax_workload = JaxImagenetViTWorkload()
+    # Init PyTorch workload.
+    pytorch_workload = PyTorchImagenetViTWorkload()
+  elif workload == 'wmt':
+    # Init Jax workload.
+    jax_workload = JaxWmtWorkload()
+    jax_workload._global_batch_size = 128
+    # Init PyTorch workload.
+    pytorch_workload = PyTorchWmtWorkload()
+  elif workload == 'ogbg':
+    # Init Jax workload.
+    jax_workload = JaxOgbgWorkload()
+    # Init PyTorch workload.
+    pytorch_workload = PyTorchOgbgWorkload()
+  else:
+    raise ValueError(f'Workload {workload} is not available.')
+  _ = jax_workload.init_model_fn(jax.random.PRNGKey(0))
+  _ = pytorch_workload.init_model_fn([0])
+  return jax_workload, pytorch_workload


### PR DESCRIPTION
This PR address #157 

Specifically, the PR does the followings:
-  Add functions `pytorch_param_shapes` and `jax_param_shapes` in `param_utils.py` to unify the shape computation process.
- Creates `_param_shapes`, `_param_types`, and `_eval_iters` in the base workload and removes duplicate initializations.
- Unify properties `param_shapes` and `model_param_shapes` across all workloads. 
- Fixes code so that we assign the correct type in `param_types`.
- Add unit test for matching `model_param_types`.
