### PR TITLE
Add general `output_activation_fn()` implementation

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -162,7 +162,7 @@ def update_params(
 - `current_param_container` is the same kind of nested structure as used by `model_fn` which constitutes a nested collection of `float32` arrays, each endowed with information about what kind of parameter that array represents stored in a parallel structure of `current_params_types`.
   - Parameter kind is one of {"weights", "biases", "embeddings", "conv", "batch norm"}
 - `model_state` holds auxiliary state necessary for some models, such as the current batch norm statistics
-- The loss function will be one of a small set of known possibilities and the update function is allowed to branch on the `loss_fn` enum/name.
+- The loss function will be one of a small set of known possibilities and the update function is allowed to branch on the `loss_type` enum/name.
 - The `loss_fn` produces a loss per example, so the submission code is responsible for summing or averaging
 - Allowed to update state for the optimizer
 - Uses the `model_fn` of the `workload` in order to decouple the loss from the model so that model outputs (forward passes) can be reused (by storing them in the optimizer state)

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -217,9 +217,8 @@ class Workload(metaclass=abc.ABCMeta):
     """return logits_batch"""
     # Possible side effect of updating BN.
 
-  def output_activation_fn(self, logits_batch: Tensor,
-                           loss_type: LossType) -> Tensor:
-    """Turn logits into probabilities."""
+  def output_activation_fn(self, logits_batch: Tensor) -> Tensor:
+    """Turn logits into probabilities, according to the loss_type property."""
     activation_fn = {
         LossType.MEAN_SQUARED_ERROR: lambda z: z,
         LossType.MEAN_ABSOLUTE_ERROR: lambda z: z,
@@ -231,7 +230,7 @@ class Workload(metaclass=abc.ABCMeta):
     activation_fn[LossType.SOFTMAX_CROSS_ENTROPY] = softmax_fn
     activation_fn[LossType.SIGMOID_CROSS_ENTROPY] = sigmoid_fn
     activation_fn[LossType.CTC_LOSS] = softmax_fn
-    return activation_fn[loss_type](logits_batch)
+    return activation_fn[self.loss_type](logits_batch)
 
   # LossFn = Callable[Tuple[Tensor, Tensor], Tensor]
   # Does NOT apply regularization, which is left to the submitter to do in

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -217,6 +217,9 @@ class Workload(metaclass=abc.ABCMeta):
   def output_activation_fn(self, logits_batch: Tensor,
                            framework: str) -> Tensor:
     """Turn logits into probabilities, according to the loss_type property."""
+    if framework not in ['pytorch', 'jax']:
+      raise ValueError(
+          f'`framework` has to be either `pytorch` or `jax`, got {framework}.')
     activation_fn = {
         LossType.MEAN_SQUARED_ERROR: lambda z: z,
         LossType.MEAN_ABSOLUTE_ERROR: lambda z: z,

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -243,7 +243,7 @@ class Workload(metaclass=abc.ABCMeta):
       logits_batch: Union[Tuple[Tensor, Tensor], Tensor],
       mask_batch: Optional[Tensor] = None,
       label_smoothing: float = 0.0) -> Tensor:  # differentiable
-    """Return one_array_of_losses_per_example."""
+    """Return 1-d array of per-example losses."""
 
   @abc.abstractmethod
   def _eval_model_on_split(self,
@@ -343,7 +343,6 @@ def update_params(
     model_state: ModelAuxiliaryState,
     hyperparameters: Hyperparameters,
     batch: Dict[str, Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: LossType,
     optimizer_state: OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
@@ -136,18 +136,6 @@ class CifarWorkload(BaseCifarWorkload):
         update_batch_norm=False)
     return self._compute_metrics(logits, batch['targets'])
 
-  # Keep this separate from the loss function in order to support optimizers
-  # that use the logits.
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    if loss_type == spec.LossType.SOFTMAX_CROSS_ENTROPY:
-      return jax.nn.softmax(logits_batch, axis=-1)
-    if loss_type == spec.LossType.SIGMOID_CROSS_ENTROPY:
-      return jax.nn.sigmoid(logits_batch)
-    if loss_type == spec.LossType.MEAN_SQUARED_ERROR:
-      return logits_batch
-
   def model_fn(
       self,
       params: spec.ParameterContainer,

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -183,17 +183,6 @@ class CifarWorkload(BaseCifarWorkload):
 
     return logits_batch, None
 
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-
-    activation_fn = {
-        spec.LossType.SOFTMAX_CROSS_ENTROPY: F.softmax,
-        spec.LossType.SIGMOID_CROSS_ENTROPY: F.sigmoid,
-        spec.LossType.MEAN_SQUARED_ERROR: lambda z: z
-    }
-    return activation_fn[loss_type](logits_batch)
-
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
   def loss_fn(self,

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -66,12 +66,6 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
   def eval_period_time_sec(self):
     return 10 * 60
 
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    """Return the final activations of the model."""
-    pass
-
   def _build_input_queue(self,
                          data_rng: jax.random.PRNGKey,
                          split: str,

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -57,18 +57,6 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         train=train)
     return logits, None
 
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-
-    activation_fn = {
-        spec.LossType.SOFTMAX_CROSS_ENTROPY: jax.nn.softmax,
-        spec.LossType.SIGMOID_CROSS_ENTROPY: jax.nn.sigmoid,
-        spec.LossType.MEAN_SQUARED_ERROR: lambda z: z,
-        spec.LossType.MEAN_ABSOLUTE_ERROR: lambda z: z
-    }
-    return activation_fn[loss_type](logits_batch)
-
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
   def loss_fn(self, label_batch: spec.Tensor,

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -156,18 +156,6 @@ class FastMRIWorkload(BaseFastMRIWorkload):
 
     return logit_batch, None
 
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-
-    activation_fn = {
-        spec.LossType.SOFTMAX_CROSS_ENTROPY: F.softmax,
-        spec.LossType.SIGMOID_CROSS_ENTROPY: F.sigmoid,
-        spec.LossType.MEAN_SQUARED_ERROR: lambda z: z,
-        spec.LossType.MEAN_ABSOLUTE_ERROR: lambda z: z
-    }
-    return activation_fn[loss_type](logits_batch)
-
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
   def loss_fn(self,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -104,14 +104,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     params = jax_utils.replicate(params)
     return params, model_state
 
-  # Keep this separate from the loss function in order to support optimizers
-  # that use the logits.
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    """Return the final activations of the model."""
-    pass
-
   @functools.partial(
       jax.pmap,
       axis_name='batch',

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -197,17 +197,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
     return logits_batch, None
 
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-
-    activation_fn = {
-        spec.LossType.SOFTMAX_CROSS_ENTROPY: F.softmax,
-        spec.LossType.SIGMOID_CROSS_ENTROPY: F.sigmoid,
-        spec.LossType.MEAN_SQUARED_ERROR: lambda z: z
-    }
-    return activation_fn[loss_type](logits_batch)
-
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
   def loss_fn(self,

--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -178,10 +178,3 @@ class BaseLibrispeechWorkload(spec.Workload):
   # parameters.
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     pass
-
-  # Keep this separate from the loss function in order to support optimizers
-  # that use the logits.
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    pass

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -117,18 +117,6 @@ class MnistWorkload(BaseMnistWorkload):
                                       initial_params)
     return jax_utils.replicate(initial_params), None
 
-  # Keep this separate from the loss function in order to support optimizers
-  # that use the logits.
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    if loss_type == spec.LossType.SOFTMAX_CROSS_ENTROPY:
-      return jax.nn.softmax(logits_batch, axis=-1)
-    if loss_type == spec.LossType.SIGMOID_CROSS_ENTROPY:
-      return jax.nn.sigmoid(logits_batch)
-    if loss_type == spec.LossType.MEAN_SQUARED_ERROR:
-      return logits_batch
-
   def model_fn(
       self,
       params: spec.ParameterContainer,

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -164,14 +164,6 @@ class MnistWorkload(BaseMnistWorkload):
 
     return logits_batch, None
 
-  # TODO(znado): Implement.
-  # Keep this separate from the loss function in order to support optimizers
-  # that use the logits.
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    raise NotImplementedError
-
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
   def loss_fn(self,

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -108,13 +108,6 @@ class BaseOgbgWorkload(spec.Workload):
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     pass
 
-  # Keep this separate from the loss function in order to support optimizers
-  # that use the logits.
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    pass
-
   def _eval_batch(self, params, batch, model_state, rng):
     logits, _ = self.model_fn(
         params,

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -202,12 +202,6 @@ class BaseWmtWorkload(spec.Workload):
           'before workload.param_shapes!')
     return self._param_shapes
 
-  def output_activation_fn(self,
-                           logits_batch: spec.Tensor,
-                           loss_type: spec.LossType) -> spec.Tensor:
-    """Return the final activations of the model."""
-    pass
-
   def loss_fn(
       self,
       label_batch: spec.Tensor,  # Dense (not one-hot) labels.

--- a/reference_submissions/cifar/cifar_pytorch/submission.py
+++ b/reference_submissions/cifar/cifar_pytorch/submission.py
@@ -59,7 +59,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/cifar/cifar_pytorch/submission.py
+++ b/reference_submissions/cifar/cifar_pytorch/submission.py
@@ -52,18 +52,17 @@ def init_optimizer_state(workload: spec.Workload,
   return optimizer_state
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
   del hyperparameters

--- a/reference_submissions/criteo1tb/criteo1tb_pytorch/submission.py
+++ b/reference_submissions/criteo1tb/criteo1tb_pytorch/submission.py
@@ -51,18 +51,17 @@ def init_optimizer_state(workload: spec.Workload,
   return optimizer_state
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
 
   current_model = current_param_container

--- a/reference_submissions/criteo1tb/criteo1tb_pytorch/submission.py
+++ b/reference_submissions/criteo1tb/criteo1tb_pytorch/submission.py
@@ -58,7 +58,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/fastmri/fastmri_pytorch/submission.py
+++ b/reference_submissions/fastmri/fastmri_pytorch/submission.py
@@ -40,18 +40,17 @@ def init_optimizer_state(workload: spec.Workload,
   return optimizer_state
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
   del loss_type

--- a/reference_submissions/fastmri/fastmri_pytorch/submission.py
+++ b/reference_submissions/fastmri/fastmri_pytorch/submission.py
@@ -47,7 +47,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/imagenet_resnet/imagenet_pytorch/submission.py
+++ b/reference_submissions/imagenet_resnet/imagenet_pytorch/submission.py
@@ -54,18 +54,17 @@ def init_optimizer_state(workload: spec.Workload,
   return optimizer_state
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
   del hyperparameters

--- a/reference_submissions/imagenet_resnet/imagenet_pytorch/submission.py
+++ b/reference_submissions/imagenet_resnet/imagenet_pytorch/submission.py
@@ -61,7 +61,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/imagenet_vit/imagenet_pytorch/submission.py
+++ b/reference_submissions/imagenet_vit/imagenet_pytorch/submission.py
@@ -53,18 +53,17 @@ def init_optimizer_state(workload: spec.Workload,
   return optimizer_state
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
   del loss_type

--- a/reference_submissions/imagenet_vit/imagenet_pytorch/submission.py
+++ b/reference_submissions/imagenet_vit/imagenet_pytorch/submission.py
@@ -60,7 +60,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/librispeech_conformer/librispeech_jax/submission.py
+++ b/reference_submissions/librispeech_conformer/librispeech_jax/submission.py
@@ -151,7 +151,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/librispeech_conformer/librispeech_jax/submission.py
+++ b/reference_submissions/librispeech_conformer/librispeech_jax/submission.py
@@ -144,18 +144,17 @@ def pmapped_train_step(workload,
   return new_model_state, new_optimizer_state, updated_params, loss, grad_norm
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
   del eval_results

--- a/reference_submissions/librispeech_conformer/librispeech_pytorch/submission.py
+++ b/reference_submissions/librispeech_conformer/librispeech_pytorch/submission.py
@@ -51,7 +51,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/librispeech_conformer/librispeech_pytorch/submission.py
+++ b/reference_submissions/librispeech_conformer/librispeech_pytorch/submission.py
@@ -44,18 +44,17 @@ def init_optimizer_state(workload: spec.Workload,
   return optimizer
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
   del eval_results

--- a/reference_submissions/librispeech_deepspeech/librispeech_jax/submission.py
+++ b/reference_submissions/librispeech_deepspeech/librispeech_jax/submission.py
@@ -138,7 +138,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/librispeech_deepspeech/librispeech_jax/submission.py
+++ b/reference_submissions/librispeech_deepspeech/librispeech_jax/submission.py
@@ -131,18 +131,17 @@ def pmapped_train_step(workload,
   return new_model_state, new_optimizer_state, updated_params, loss, grad_norm
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
   del eval_results

--- a/reference_submissions/mnist/mnist_jax/submission.py
+++ b/reference_submissions/mnist/mnist_jax/submission.py
@@ -83,7 +83,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/mnist/mnist_jax/submission.py
+++ b/reference_submissions/mnist/mnist_jax/submission.py
@@ -76,18 +76,17 @@ def pmapped_update_params(workload: spec.Workload,
   return new_optimizer_state, updated_params, new_model_state
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
   del loss_type

--- a/reference_submissions/mnist/mnist_pytorch/submission.py
+++ b/reference_submissions/mnist/mnist_pytorch/submission.py
@@ -29,18 +29,17 @@ def init_optimizer_state(workload: spec.Workload,
   return optimizer_state
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del hyperparameters
   del loss_type

--- a/reference_submissions/mnist/mnist_pytorch/submission.py
+++ b/reference_submissions/mnist/mnist_pytorch/submission.py
@@ -36,7 +36,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],

--- a/reference_submissions/ogbg/ogbg_jax/submission.py
+++ b/reference_submissions/ogbg/ogbg_jax/submission.py
@@ -73,18 +73,17 @@ def train_step(workload,
   return new_model_state, new_optimizer_state, updated_params
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
   del loss_type

--- a/reference_submissions/ogbg/ogbg_jax/submission.py
+++ b/reference_submissions/ogbg/ogbg_jax/submission.py
@@ -81,7 +81,6 @@ def update_params(
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
     loss_type: spec.LossType,
-    # This will define the output activation via `output_activation_fn`.
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],
     global_step: int,

--- a/reference_submissions/ogbg/ogbg_pytorch/submission.py
+++ b/reference_submissions/ogbg/ogbg_pytorch/submission.py
@@ -36,7 +36,6 @@ def update_params(
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
     loss_type: spec.LossType,
-    # This will define the output activation via `output_activation_fn`.
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],
     global_step: int,

--- a/reference_submissions/ogbg/ogbg_pytorch/submission.py
+++ b/reference_submissions/ogbg/ogbg_pytorch/submission.py
@@ -28,18 +28,17 @@ def init_optimizer_state(workload: spec.Workload,
   return optimizer_state
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params, updated_model_state)."""
   del current_params_types
   del loss_type

--- a/reference_submissions/wmt/wmt_jax/submission.py
+++ b/reference_submissions/wmt/wmt_jax/submission.py
@@ -143,18 +143,17 @@ def pmapped_train_step(workload,
   return new_optimizer_state, updated_params
 
 
-def update_params(
-    workload: spec.Workload,
-    current_param_container: spec.ParameterContainer,
-    current_params_types: spec.ParameterTypeTree,
-    model_state: spec.ModelAuxiliaryState,
-    hyperparameters: spec.Hyperparameters,
-    batch: Dict[str, spec.Tensor],
-    loss_type: spec.LossType,
-    optimizer_state: spec.OptimizerState,
-    eval_results: List[Tuple[int, float]],
-    global_step: int,
-    rng: spec.RandomState) -> spec.UpdateReturn:
+def update_params(workload: spec.Workload,
+                  current_param_container: spec.ParameterContainer,
+                  current_params_types: spec.ParameterTypeTree,
+                  model_state: spec.ModelAuxiliaryState,
+                  hyperparameters: spec.Hyperparameters,
+                  batch: Dict[str, spec.Tensor],
+                  loss_type: spec.LossType,
+                  optimizer_state: spec.OptimizerState,
+                  eval_results: List[Tuple[int, float]],
+                  global_step: int,
+                  rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
   del eval_results

--- a/reference_submissions/wmt/wmt_jax/submission.py
+++ b/reference_submissions/wmt/wmt_jax/submission.py
@@ -150,7 +150,6 @@ def update_params(
     model_state: spec.ModelAuxiliaryState,
     hyperparameters: spec.Hyperparameters,
     batch: Dict[str, spec.Tensor],
-    # This will define the output activation via `output_activation_fn`.
     loss_type: spec.LossType,
     optimizer_state: spec.OptimizerState,
     eval_results: List[Tuple[int, float]],


### PR DESCRIPTION
This PR resolves #158.

**Questions:**
- Currently, the function takes a `loss_type` argument. Why can't it just use `self.loss_type` instead, i.e. is there any use case for applying a different choice of output activation function?
- In `update_params` it also says that the `loss_type` keyword will determine the output activation function. Also, even if `self.loss_type` is used in `output_activation_fn`, it won't be used anywhere in the loss calculation, but only when the user explicitly calls the function. Moreover, it _can't_ be used in conjunction with `loss_fn`, since it requires logits.
- Not sure if there is a better way to select the framework besides using `FLAGS.framework`. Alternatively, we could add an additional argument, write Jax and PyTorch specific workload base classes, or set a `framework` property of the workload in the submission runner.