### PR TITLE
Fix recently introduced OGBG bugs

### DIFF
--- a/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
@@ -25,7 +25,7 @@ def _load_dataset(split, should_shuffle, data_rng, data_dir):
 
   read_config = tfds.ReadConfig(add_tfds_id=True, shuffle_seed=file_data_rng)
   dataset = tfds.load(
-      'ogbg_molpcba:0.1.3',
+      'ogbg_molpcba:0.1.2',
       split=split,
       shuffle_files=should_shuffle,
       read_config=read_config,

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -34,7 +34,7 @@ class BaseOgbgWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self):
-    return 10000
+    return 43793
 
   @property
   def num_validation_examples(self):

--- a/tests/reference_submission_tests.py
+++ b/tests/reference_submission_tests.py
@@ -22,6 +22,7 @@ from absl import logging
 from absl.testing import absltest
 import flax
 import jax
+from jraph import GraphsTuple
 import numpy as np
 import tensorflow as tf
 import torch
@@ -243,7 +244,7 @@ def _make_one_batch_workload(workload_class,
         for k, v in fake_batch.items():
           if isinstance(v, np.ndarray):
             new_fake_batch[k] = to_device(k, v)
-          elif isinstance(v, tuple):
+          elif isinstance(v, tuple) and not isinstance(v, GraphsTuple):
             new_fake_batch[k] = tuple(map(functools.partial(to_device, k), v))
           else:
             new_fake_batch[k] = v


### PR DESCRIPTION
1. The reference submission test was broken for OGBG with DDP by PR #170.
2. The version number of the OGBG dataset was `0.1.3` but should be `0.1.2`.
3. Fixes #149 by increasing the `num_eval_train_examples` to be larger than the max usable batch size (I used the same number of examples as for validation and test).