### PR TITLE
Small fixes fastmri

### DIFF
--- a/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
@@ -178,11 +178,13 @@ def load_fastmri_split(global_batch_size,
   if split not in ['train', 'eval_train', 'validation', 'test']:
     raise ValueError('Unrecognized split {}'.format(split))
 
-  # Check if data directories exist because glob below wil not raise an error if they don't
+  # Check if data directories exist because glob wil not raise an error 
   if not os.path.exists(os.path.join(data_dir, _TRAIN_DIR)):
-    raise NotADirectoryError("Directory not found: {}".format(os.path.join(data_dir, _TRAIN_DIR)))
+    raise NotADirectoryError("Directory not found: {}".format(
+      os.path.join(data_dir, _TRAIN_DIR)))
   if not os.path.exists(os.path.join(data_dir, _VAL_DIR)):
-    raise NotADirectoryError("Directory not found: {}".format(os.path.join(data_dir, _VAL_DIR)))
+    raise NotADirectoryError("Directory not found: {}".format(
+      os.path.join(data_dir, _VAL_DIR)))
 
   if split in ['train', 'eval_train']:
     file_pattern = os.path.join(data_dir, _TRAIN_DIR, '*.h5')

--- a/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
@@ -178,7 +178,7 @@ def load_fastmri_split(global_batch_size,
   if split not in ['train', 'eval_train', 'validation', 'test']:
     raise ValueError('Unrecognized split {}'.format(split))
 
-  # Check if data directories exist because glob wil not raise an error 
+  # Check if data directories exist because glob wil not raise an error
   if not os.path.exists(os.path.join(data_dir, _TRAIN_DIR)):
     raise NotADirectoryError("Directory not found: {}".format(
       os.path.join(data_dir, _TRAIN_DIR)))

--- a/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
@@ -175,8 +175,14 @@ def load_fastmri_split(global_batch_size,
   Returns:
     A `tf.data.Dataset`.
   """
-  if split not in ['train', 'eval_train', 'validation']:
+  if split not in ['train', 'eval_train', 'validation', 'test']:
     raise ValueError('Unrecognized split {}'.format(split))
+
+  # Check if data directories exist because glob below wil not raise an error if they don't
+  if not os.path.exists(os.path.join(data_dir, _TRAIN_DIR)):
+    raise NotADirectoryError("Directory not found: {}".format(os.path.join(data_dir, _TRAIN_DIR)))
+  if not os.path.exists(os.path.join(data_dir, _VAL_DIR)):
+    raise NotADirectoryError("Directory not found: {}".format(os.path.join(data_dir, _VAL_DIR)))
 
   if split in ['train', 'eval_train']:
     file_pattern = os.path.join(data_dir, _TRAIN_DIR, '*.h5')
@@ -185,6 +191,7 @@ def load_fastmri_split(global_batch_size,
     file_pattern = os.path.join(data_dir, _VAL_DIR, '*.h5')
     h5_paths = sorted(glob.glob(file_pattern))[:100]
   elif split == 'test':
+    # The fastmri validation set is split into a validation and test set
     file_pattern = os.path.join(data_dir, _VAL_DIR, '*.h5')
     h5_paths = sorted(glob.glob(file_pattern))[100:]
 

--- a/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
@@ -178,12 +178,12 @@ def load_fastmri_split(global_batch_size,
   if split not in ['train', 'eval_train', 'validation', 'test']:
     raise ValueError('Unrecognized split {}'.format(split))
 
-  # Check if data directories exist because glob wil not raise an error
+  # Check if data directories exist because glob will not raise an error
   if not os.path.exists(os.path.join(data_dir, _TRAIN_DIR)):
-    raise NotADirectoryError("Directory not found: {}".format(
+    raise NotADirectoryError('Directory not found: {}'.format(
       os.path.join(data_dir, _TRAIN_DIR)))
   if not os.path.exists(os.path.join(data_dir, _VAL_DIR)):
-    raise NotADirectoryError("Directory not found: {}".format(
+    raise NotADirectoryError('Directory not found: {}'.format(
       os.path.join(data_dir, _VAL_DIR)))
 
   if split in ['train', 'eval_train']:

--- a/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
@@ -181,10 +181,10 @@ def load_fastmri_split(global_batch_size,
   # Check if data directories exist because glob will not raise an error
   if not os.path.exists(os.path.join(data_dir, _TRAIN_DIR)):
     raise NotADirectoryError('Directory not found: {}'.format(
-      os.path.join(data_dir, _TRAIN_DIR)))
+        os.path.join(data_dir, _TRAIN_DIR)))
   if not os.path.exists(os.path.join(data_dir, _VAL_DIR)):
     raise NotADirectoryError('Directory not found: {}'.format(
-      os.path.join(data_dir, _VAL_DIR)))
+        os.path.join(data_dir, _VAL_DIR)))
 
   if split in ['train', 'eval_train']:
     file_pattern = os.path.join(data_dir, _TRAIN_DIR, '*.h5')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -350,6 +350,10 @@ def score_submission_on_workload(workload: spec.Workload,
                                  num_tuning_trials: Optional[int] = None,
                                  log_dir: Optional[str] = None,
                                  tokenizer_vocab_path: Optional[str] = None):
+  # Expand paths because '~' will not be recognized
+  data_dir = os.path.expanduser(data_dir)
+  imagenet_v2_data_dir = os.path.expanduser(data_dir)
+
   # Remove the trailing '.py' and convert the filepath to a Python module.
   submission_module_path = convert_filepath_to_module(submission_path)
   submission_module = importlib.import_module(submission_module_path)

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -350,7 +350,7 @@ def score_submission_on_workload(workload: spec.Workload,
                                  num_tuning_trials: Optional[int] = None,
                                  log_dir: Optional[str] = None,
                                  tokenizer_vocab_path: Optional[str] = None):
-  # Expand paths because '~' will not be recognized
+  # Expand paths because '~' may not be recognized
   data_dir = os.path.expanduser(data_dir)
   imagenet_v2_data_dir = os.path.expanduser(data_dir)
 

--- a/target_setting_runs/pytorch_nadamw.py
+++ b/target_setting_runs/pytorch_nadamw.py
@@ -186,7 +186,6 @@ def init_optimizer_state(workload: spec.Workload,
                          hyperparameters: spec.Hyperparameters,
                          rng: spec.RandomState) -> spec.OptimizerState:
   """Creates a NAdamW optimizer and a learning rate schedule."""
-  del workload
   del model_state
   del rng
 


### PR DESCRIPTION
- Add os.path.expanduser to directories passed into submission_runner. Operations like glob do not recognize that ~ means /home/$USER
- Add check in FastMRI to make sure data directories exist. This will hopefully prevent confusion early on if the data_dir is not recognized, which will without this check just result in empty data iterators and a StopIteration error
- Add 'test' to validity check for split names in fastmri input_pipeline.