### PR TITLE
Add `use_wandb` flag + refactor use of workload class attributes

### DIFF
--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -138,14 +138,6 @@ def _get_cpu_model_name() -> str:
                     output)[0].split('Model name:')[1].strip()
 
 
-def _get_os_package_list() -> str:
-  return subprocess.check_output(['dpkg', '-l']).decode('ascii').strip()
-
-
-def _get_pip_package_list() -> str:
-  return subprocess.check_output(['pip', 'freeze']).decode('ascii').strip()
-
-
 def _is_primitive_type(item: Any) -> bool:
   primitive = (float, int, str, bool)
   return isinstance(item, primitive)

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -101,9 +101,10 @@ DataSelectionFn = Callable[[
 
 class Workload(metaclass=abc.ABCMeta):
 
-  _param_shapes: Optional[ParameterShapeTree] = None
-  _param_types: Optional[ParameterTypeTree] = None
-  _eval_iters: dict = {}
+  def __init__(self) -> None:
+    self._param_shapes: Optional[ParameterShapeTree] = None
+    self._param_types: Optional[ParameterTypeTree] = None
+    self._eval_iters: Dict[str, Iterator] = {}
 
   @abc.abstractmethod
   def has_reached_goal(self, eval_result: float) -> bool:

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 from absl import flags
 import jax
@@ -13,12 +13,11 @@ FLAGS = flags.FLAGS
 class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
   """Criteo1tb workload."""
 
-  def __init__(self):
-    self.vocab_sizes = tuple([1024 * 128] * 26)
-    self.num_dense_features = 13
-    self.mlp_bottom_dims = (128, 128)
-    self.mlp_top_dims = (256, 128, 1)
-    self.embed_dim = 64
+  vocab_sizes: Tuple[int] = tuple([1024 * 128] * 26)
+  num_dense_features: int = 13
+  mlp_bottom_dims: Tuple[int, int] = (128, 128)
+  mlp_top_dims: Tuple[int, int, int] = (256, 128, 1)
+  embed_dim: int = 64
 
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/loss'] < self.target_value

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -8,8 +8,7 @@ from algorithmic_efficiency import spec
 
 class BaseImagenetResNetWorkload(spec.Workload):
 
-  def __init__(self):
-    self._num_classes = 1000
+  _num_classes: int = 1000
 
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/accuracy'] > self.target_value

--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -14,8 +14,7 @@ FLAGS = flags.FLAGS
 
 class BaseLibrispeechWorkload(spec.Workload):
 
-  def __init__(self) -> None:
-    self._num_outputs = 1024
+  _num_outputs: int = 1024
 
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/wer'] < self.target_value

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -48,10 +48,6 @@ def _param_types(param_tree):
 
 class MnistWorkload(BaseMnistWorkload):
 
-  def __init__(self):
-    super().__init__()
-    self._model = _Model()
-
   def _normalize(self, image):
     return (tf.cast(image, tf.float32) - self.train_mean) / self.train_stddev
 
@@ -98,8 +94,8 @@ class MnistWorkload(BaseMnistWorkload):
 
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     init_val = jnp.ones((1, 28, 28, 1), jnp.float32)
-    initial_params = self._model.init({'params': rng}, init_val,
-                                      train=True)['params']
+    initial_params = _Model().init({'params': rng}, init_val,
+                                   train=True)['params']
     self._param_shapes = param_utils.jax_param_shapes(initial_params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
     return jax_utils.replicate(initial_params), None
@@ -121,7 +117,7 @@ class MnistWorkload(BaseMnistWorkload):
     del aux_dropout_rate
     del update_batch_norm
     train = mode == spec.ForwardPassMode.TRAIN
-    logits_batch = self._model.apply(
+    logits_batch = _Model().apply(
         {'params': params},
         augmented_and_preprocessed_input_batch['inputs'],
         train=train)

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
@@ -30,7 +30,7 @@ def _pytorch_map(inputs: Any) -> Any:
 def _shard(inputs: Any) -> Any:
   if not USE_PYTORCH_DDP:
     return inputs
-  return jax.tree_map(lambda tensor: tensor[RANK].to(DEVICE), inputs)
+  return jax.tree_map(lambda tensor: tensor[RANK], inputs)
 
 
 def _graph_map(function: Callable, graph: GraphsTuple) -> GraphsTuple:

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -14,8 +14,7 @@ FLAGS = flags.FLAGS
 
 class BaseOgbgWorkload(spec.Workload):
 
-  def __init__(self) -> None:
-    self._num_outputs = 128
+  _num_outputs: int = 128
 
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/mean_average_precision'] > self.target_value

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -28,7 +28,7 @@ def _to_host(x):
 class WmtWorkload(BaseWmtWorkload):
   """WMT Jax workload."""
 
-  def __init__(self):
+  def __init__(self) -> None:
     super().__init__()
     self._eval_config = models.TransformerConfig(deterministic=True)
 

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -21,9 +21,11 @@ FLAGS = flags.FLAGS
 class BaseWmtWorkload(spec.Workload):
   """A WMT workload."""
 
-  def __init__(self):
+  _vocab_size: int = 32000
+
+  def __init__(self) -> None:
+    super().__init__()
     self._tokenizer = None
-    self._vocab_size = 32000
 
   def has_reached_goal(self, eval_result: float) -> bool:
     return eval_result['validation/bleu'] > self.target_value

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -121,9 +121,12 @@ flags.DEFINE_string(
     'experiment_dir',
     None,
     'The root directory to store all experiments. '
-    'It is not required, but the directory should have '
+    'It is required and the directory should have '
     'an absolute path rather than a relative path.')
 flags.DEFINE_string('experiment_name', None, 'Name of the experiment.')
+flags.DEFINE_boolean('use_wandb',
+                     False,
+                     'Whether to use Weights & Biases logging.')
 flags.DEFINE_boolean('profile', False, 'Whether to produce profiling output.')
 
 FLAGS = flags.FLAGS
@@ -482,6 +485,5 @@ if __name__ == '__main__':
   flags.mark_flag_as_required('workload')
   flags.mark_flag_as_required('framework')
   flags.mark_flag_as_required('submission_path')
-  flags.mark_flag_as_required('tuning_search_space')
   flags.mark_flag_as_required('experiment_dir')
   app.run(main)


### PR DESCRIPTION
This PR
- adds a `use_wandb` flag, so having the package in the env does not force you to use it,
- fixes some minor things in the submission runner and removes a redundant device transfer in the OGBG workload,
- and refactors the use of workload class attributes (only use class attributes for constants which should be the same for all class instances).