### PR TITLE
Fix OOM issue on GCP

### DIFF
--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -14,7 +14,7 @@ def shard_numpy_ds(xs):
   Convert an input batch from tf Tensors to numpy arrays and reshape it to be
   sharded across devices.
   """
-  local_device_count = jax.local_device_count()
+  local_device_count = max(torch.cuda.device_count(), jax.local_device_count())
 
   def _prepare(x):
     # Use _numpy() for zero-copy conversion between TF and NumPy.

--- a/algorithmic_efficiency/pytorch_utils.py
+++ b/algorithmic_efficiency/pytorch_utils.py
@@ -2,6 +2,7 @@ import os
 from typing import Tuple
 
 from absl import logging
+import jax
 import tensorflow as tf
 import torch
 import torch.distributed as dist
@@ -20,6 +21,10 @@ def pytorch_setup() -> Tuple[bool, int, torch.device, int]:
 def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler) -> None:
   # Make sure no GPU memory is preallocated to Jax.
   os.environ['XLA_PYTHON_CLIENT_PREALLOCATE'] = 'false'
+  # Only use CPU for Jax to avoid memory issues.
+  # Setting the corresponding environment variable here has no effect; it has to
+  # be done before jax and tensorflow (!) are imported for the first time.
+  jax.config.update('jax_platforms', 'cpu')
   # From the docs: "(...) causes cuDNN to benchmark multiple convolution
   # algorithms and select the fastest."
   torch.backends.cudnn.benchmark = True

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
@@ -48,7 +48,7 @@ def _distorted_bounding_box_crop(image,
     cropped image `Tensor`
   """
   shape = tf.shape(image)
-  sample_distorted_bounding_box = tf.image.stateless_sample_distorted_bounding_box(  # pylint: disable=line-too-long
+  bbox_begin, bbox_size, _ = tf.image.stateless_sample_distorted_bounding_box(
       shape,
       seed=rng,
       bounding_boxes=bbox,
@@ -57,7 +57,6 @@ def _distorted_bounding_box_crop(image,
       area_range=area_range,
       max_attempts=max_attempts,
       use_image_if_no_bounding_boxes=True)
-  bbox_begin, bbox_size, _ = sample_distorted_bounding_box
 
   # Crop the image to the specified bounding box.
   offset_y, offset_x, _ = tf.unstack(bbox_begin)

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
@@ -45,8 +45,6 @@ class CifarWorkload(BaseCifarWorkload):
                      cache: Optional[bool] = None,
                      repeat_final_dataset: Optional[bool] = None,
                      num_batches: Optional[int] = None):
-    if batch_size % jax.local_device_count() > 0:
-      raise ValueError('Batch size must be divisible by the number of devices')
     ds_builder = tfds.builder('cifar10:3.0.2', data_dir=data_dir)
     ds_builder.download_and_prepare()
     train = split == 'train'

--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -11,6 +11,7 @@ from typing import Optional, Sequence
 
 import jax
 import tensorflow as tf
+import torch
 
 from algorithmic_efficiency import data_utils
 
@@ -29,7 +30,7 @@ def get_criteo1tb_dataset(split: str,
     file_path = os.path.join(data_dir, 'day_[0-22]_*')
   else:
     file_path = os.path.join(data_dir, 'day_23_*')
-  num_devices = jax.local_device_count()
+  num_devices = max(torch.cuda.device_count(), jax.local_device_count())
   per_device_batch_size = global_batch_size // num_devices
 
   @tf.function

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -13,7 +13,6 @@ from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import pytorch_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.interop_utils import jax_to_pytorch
-from algorithmic_efficiency.interop_utils import pytorch_to_jax
 import algorithmic_efficiency.random_utils as prng
 from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.models import \
     unet
@@ -179,11 +178,11 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         update_batch_norm=False)
     ssim_sum = jax_to_pytorch(
         ssim(
-            pytorch_to_jax(outputs),
-            pytorch_to_jax(batch['targets']),
-            mean=pytorch_to_jax(batch['mean']),
-            std=pytorch_to_jax(batch['std']),
-            volume_max=pytorch_to_jax(batch['volume_max']))).sum()
+            outputs.cpu().numpy(),
+            batch['targets'].cpu().numpy(),
+            mean=batch['mean'].cpu().numpy(),
+            std=batch['std'].cpu().numpy(),
+            volume_max=batch['volume_max'].cpu().numpy())).sum()
     loss = self.loss_fn(batch['targets'], outputs).sum()
     return {'ssim': ssim_sum, 'loss': loss, 'weight': batch['weights'].sum()}
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -50,7 +50,7 @@ def _distorted_bounding_box_crop(image_bytes,
     cropped image `Tensor`
   """
   shape = tf.io.extract_jpeg_shape(image_bytes)
-  sample_distorted_bounding_box = tf.image.stateless_sample_distorted_bounding_box(  # pylint: disable=line-too-long
+  bbox_begin, bbox_size, _ = tf.image.stateless_sample_distorted_bounding_box(
       shape,
       seed=rng,
       bounding_boxes=bbox,
@@ -59,7 +59,6 @@ def _distorted_bounding_box_crop(image_bytes,
       area_range=area_range,
       max_attempts=max_attempts,
       use_image_if_no_bounding_boxes=True)
-  bbox_begin, bbox_size, _ = sample_distorted_bounding_box
 
   # Crop the image to the specified bounding box.
   offset_y, offset_x, _ = tf.unstack(bbox_begin)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -80,8 +80,6 @@ class BaseImagenetResNetWorkload(spec.Workload):
                          repeat_final_dataset: Optional[bool] = None,
                          num_batches: Optional[int] = None):
     del num_batches
-    if global_batch_size % jax.local_device_count() != 0:
-      raise ValueError('Batch size must be divisible by the number of devices')
     if split == 'test':
       if not cache:
         raise ValueError('cache must be True for split=test.')

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -1,8 +1,6 @@
 """ImageNet workload parent class."""
 from typing import Optional
 
-import jax
-
 from algorithmic_efficiency import spec
 
 

--- a/algorithmic_efficiency/workloads/imagenet_vit/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/workload.py
@@ -9,7 +9,6 @@ def decode_variant(variant):
   v, patch = variant.split('/')
 
   return {
-      # pylint:disable=line-too-long
       # Reference: Table 2 of https://arxiv.org/abs/2106.04560.
       'width': {
           'Ti': 192,
@@ -43,7 +42,7 @@ def decode_variant(variant):
       }[v],
       'num_heads': {
           'Ti': 3, 'S': 6, 'M': 8, 'B': 12, 'L': 16, 'H': 16, 'g': 16, 'G': 16
-      }[v],  # pylint:enable=line-too-long
+      }[v],
       'patch_size': (int(patch), int(patch))
   }
 

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
@@ -1,8 +1,8 @@
 """A flax layer to do data augmentation for audio signals as
 described in https://arxiv.org/abs/1904.08779.
 
-code based on
-https://github.com/tensorflow/lingvo/blob/master/lingvo/jax/layers/spectrum_augmenter.py.  # pylint: disable=line-too-long
+Code based on:
+github.com/tensorflow/lingvo/blob/master/lingvo/jax/layers/spectrum_augmenter.py
 """
 
 import flax.linen as nn
@@ -14,7 +14,7 @@ class SpecAug(nn.Module):
   """Layer performs masking prodecure along time and frequency axis.
 
   The procedure is detailed in https://arxiv.org/abs/1904.08779.
-  This is an essential component in speech recognition models that helps achieve  # pylint: disable=line-too-long
+  This is an essential component in speech recognition models that helps achieve
   better word error rates.
   """
   freq_mask_count: int = 1

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -215,7 +215,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       params: spec.ParameterContainer,
       batch: Dict[str, spec.Tensor],
       model_state: spec.ModelAuxiliaryState,
-      rng: spec.RandomState) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:  # pylint: disable=line-too-long
+      rng: spec.RandomState) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     (logits, logit_paddings), _ = self.model_fn(
         params,
         batch,

--- a/algorithmic_efficiency/workloads/librispeech_conformer/metrics.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/metrics.py
@@ -80,7 +80,7 @@ def edit_distance(source, target):
   return distance[num_source_words][num_target_words]
 
 
-def compute_wer(decoded, decoded_paddings, targets, target_paddings, tokenizer):  # pylint: disable=line-too-long
+def compute_wer(decoded, decoded_paddings, targets, target_paddings, tokenizer):
   word_errors = 0.0
   num_words = 0.0
 

--- a/algorithmic_efficiency/workloads/librispeech_conformer/prepare_data.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/prepare_data.py
@@ -186,7 +186,8 @@ def main():
   for subset in subset_list:
     print('processing split = ', subset)
     os.makedirs(save_dir + '/' + subset, exist_ok=True)
-    example_ids, num_entries = preprocess_data(f'{data_dir}/{subset}', tokenizer, subset)  # pylint: disable=line-too-long
+    example_ids, num_entries = preprocess_data(
+        f'{data_dir}/{subset}', tokenizer, subset)
 
     if num_entries != librispeech_example_counts[subset]:
       raise ValueError('preprocessed dataframe final count not equal to '

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -6,6 +6,7 @@ from typing import Dict, Tuple
 from absl import flags
 from flax import jax_utils
 import jax
+import torch
 import torch.distributed as dist
 
 from algorithmic_efficiency import spec
@@ -96,9 +97,10 @@ class BaseMnistWorkload(spec.Workload):
         'loss': 0.,
     }
     num_batches = int(math.ceil(num_examples / global_batch_size))
+    num_devices = max(torch.cuda.device_count(), jax.local_device_count())
     for _ in range(num_batches):
       batch = next(self._eval_iters[split])
-      per_device_model_rngs = prng.split(model_rng, jax.local_device_count())
+      per_device_model_rngs = prng.split(model_rng, num_devices)
       batch_metrics = self._eval_model(params,
                                        batch,
                                        model_state,

--- a/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
@@ -8,6 +8,7 @@ import jax
 import jraph
 import numpy as np
 import tensorflow_datasets as tfds
+import torch
 
 AVG_NODES_PER_GRAPH = 26
 AVG_EDGES_PER_GRAPH = 56
@@ -105,7 +106,7 @@ def _get_batch_iterator(dataset_iter, global_batch_size, num_shards=None):
     smaller batches.
   """
   if not num_shards:
-    num_shards = jax.local_device_count()
+    num_shards = max(torch.cuda.device_count(), jax.local_device_count())
 
   # We will construct num_shards smaller batches and then put them together.
   per_device_batch_size = global_batch_size // num_shards

--- a/algorithmic_efficiency/workloads/wmt/decode.py
+++ b/algorithmic_efficiency/workloads/wmt/decode.py
@@ -13,11 +13,8 @@ import numpy as np
 import torch
 
 from algorithmic_efficiency.interop_utils import jax_to_pytorch
-from algorithmic_efficiency.pytorch_utils import pytorch_setup
 
 # Constants
-RANK = pytorch_setup()[1]
-DEVICE = jax.devices()[RANK]
 # We assume the default End-of-Sentence token id is 2 (SentencePiece).
 EOS_ID = 2
 # "Effective negative infinity" constant for masking in beam search.
@@ -145,8 +142,7 @@ def beam_init(batch_size, beam_size, max_decode_len, cache):
   live_logprobs0 = jnp.tile(
       jnp.array([0.0] + [NEG_INF] * (beam_size - 1)), [batch_size, 1])
   finished_scores0 = jnp.ones((batch_size, beam_size)) * NEG_INF
-  live_seqs0 = jax.device_put(
-      jnp.zeros((batch_size, beam_size, max_decode_len), jnp.int32), DEVICE)
+  live_seqs0 = jnp.zeros((batch_size, beam_size, max_decode_len), jnp.int32)
   finished_seqs0 = jnp.zeros((batch_size, beam_size, max_decode_len), jnp.int32)
   finished_flags0 = jnp.zeros((batch_size, beam_size), jnp.bool_)
   # add beam dimension to attention cache pytree elements

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -13,7 +13,6 @@ from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import pytorch_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.interop_utils import jax_to_pytorch
-from algorithmic_efficiency.interop_utils import pytorch_to_jax
 from algorithmic_efficiency.workloads.wmt import bleu
 from algorithmic_efficiency.workloads.wmt import decode
 from algorithmic_efficiency.workloads.wmt.wmt_pytorch.models import Transformer
@@ -78,7 +77,7 @@ class WmtWorkload(BaseWmtWorkload):
     def tokens_ids_to_logits(flat_ids, flat_cache):
       """Token slice to logits from decoder model."""
       # --> [batch * beam, 1, vocab]
-      flat_ids = jax_to_pytorch(flat_ids)
+      flat_ids = jax_to_pytorch(flat_ids).to(DEVICE)
       flat_logits, new_flat_cache = decoder(
           flat_ids,
           encoded_inputs,
@@ -88,7 +87,7 @@ class WmtWorkload(BaseWmtWorkload):
           cache=flat_cache)
       # Remove singleton sequence-length dimension:
       # [batch * beam, 1, vocab] --> [batch * beam, vocab]
-      flat_logits = pytorch_to_jax(flat_logits).squeeze(axis=1)
+      flat_logits = flat_logits.cpu().numpy().squeeze(axis=1)
       return flat_logits, new_flat_cache
 
     # Using the above-defined single-step decoder function, run a

--- a/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_jax/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_jax/submission.py
@@ -163,9 +163,15 @@ def update_params(workload: spec.Workload,
   lr = get_learning_rate(global_step, hyperparameters)
   optimizer_state, opt_update_fn = optimizer_state
   per_device_rngs = jax.random.split(rng, jax.local_device_count())
-  outputs = pmapped_train_step(
-      workload, opt_update_fn, model_state, optimizer_state,
-      current_param_container, hyperparameters, batch, per_device_rngs, lr)
+  outputs = pmapped_train_step(workload,
+                               opt_update_fn,
+                               model_state,
+                               optimizer_state,
+                               current_param_container,
+                               hyperparameters,
+                               batch,
+                               per_device_rngs,
+                               lr)
   new_model_state, new_optimizer_state, new_params, loss, grad_norm = outputs
 
   if global_step <= 1000 or global_step % 100 == 0:

--- a/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_jax/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_jax/submission.py
@@ -163,9 +163,10 @@ def update_params(workload: spec.Workload,
   lr = get_learning_rate(global_step, hyperparameters)
   optimizer_state, opt_update_fn = optimizer_state
   per_device_rngs = jax.random.split(rng, jax.local_device_count())
-  new_model_state, new_optimizer_state, new_params, loss, grad_norm = pmapped_train_step(  # pylint: disable=line-too-long
+  outputs = pmapped_train_step(
       workload, opt_update_fn, model_state, optimizer_state,
       current_param_container, hyperparameters, batch, per_device_rngs, lr)
+  new_model_state, new_optimizer_state, new_params, loss, grad_norm = outputs
 
   if global_step <= 1000 or global_step % 100 == 0:
     logging.info('%d) loss = %0.3f, grad_norm = %0.3f lr = %0.6f',

--- a/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_jax/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_jax/submission.py
@@ -150,9 +150,15 @@ def update_params(workload: spec.Workload,
   lr = workload.get_learning_rate(global_step, hyperparameters)
   optimizer_state, opt_update_fn = optimizer_state
   per_device_rngs = jax.random.split(rng, jax.local_device_count())
-  outputs = pmapped_train_step(
-      workload, opt_update_fn, model_state, optimizer_state,
-      current_param_container, hyperparameters, batch, per_device_rngs, lr)
+  outputs = pmapped_train_step(workload,
+                               opt_update_fn,
+                               model_state,
+                               optimizer_state,
+                               current_param_container,
+                               hyperparameters,
+                               batch,
+                               per_device_rngs,
+                               lr)
   new_model_state, new_optimizer_state, new_params, loss, grad_norm = outputs
 
   if global_step <= 1000 or global_step % 100 == 0:

--- a/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_jax/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_jax/submission.py
@@ -150,9 +150,10 @@ def update_params(workload: spec.Workload,
   lr = workload.get_learning_rate(global_step, hyperparameters)
   optimizer_state, opt_update_fn = optimizer_state
   per_device_rngs = jax.random.split(rng, jax.local_device_count())
-  new_model_state, new_optimizer_state, new_params, loss, grad_norm = pmapped_train_step(  # pylint: disable=line-too-long
+  outputs = pmapped_train_step(
       workload, opt_update_fn, model_state, optimizer_state,
       current_param_container, hyperparameters, batch, per_device_rngs, lr)
+  new_model_state, new_optimizer_state, new_params, loss, grad_norm = outputs
 
   if global_step <= 1000 or global_step % 100 == 0:
     logging.info('%d) loss = %0.3f, grad_norm = %0.3f lr = %0.6f',

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -323,9 +323,8 @@ def train_once(
         except RuntimeError as e:
           logging.exception(f'Eval step {global_step} error.\n')
           if 'out of memory' in str(e):
-            logging.warning(
-                f'error: GPU out of memory during eval during step {global_step}, error : {str(e)}'  # pylint: disable=line-too-long
-            )
+            logging.warning('error: GPU out of memory during eval during step '
+                            f'{global_step}, error : {str(e)}')
             if torch.cuda.is_available():
               torch.cuda.empty_cache()
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -1,8 +1,8 @@
 r"""Run a submission on a single workload.
 
-# pylint: disable=line-too-long
 Example command:
 
+# pylint: disable=line-too-long
 python3 submission_runner.py \
     --workload=mnist \
     --framework=jax \
@@ -11,8 +11,6 @@ python3 submission_runner.py \
     --tuning_search_space=reference_algorithms/development_algorithms/mnist/tuning_search_space.json \
     --num_tuning_trials=3 \
     --experiment_dir=/home/username/codes/algorithmic-efficiency/experiment_dir
-
-# pylint: enable=line-too-long
 """
 import importlib
 import inspect

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -133,7 +133,7 @@ flags.DEFINE_boolean('use_wandb',
 flags.DEFINE_boolean('profile', False, 'Whether to produce profiling output.')
 
 FLAGS = flags.FLAGS
-USE_PYTORCH_DDP, RANK, DEVICE, _ = pytorch_setup()
+USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 
 
 def convert_filepath_to_module(path: str):
@@ -368,6 +368,9 @@ def score_submission_on_workload(workload: spec.Workload,
   update_params = submission_module.update_params
   data_selection = submission_module.data_selection
   global_batch_size = submission_module.get_batch_size(workload_name)
+  if global_batch_size % N_GPUS != 0:
+    raise ValueError(
+        'The global batch size has to be divisible by the number of GPUs.')
 
   if tuning_ruleset == 'external':
     # If the submission runner is responsible for hyperparameter tuning, load in

--- a/tests/reference_algorithm_tests.py
+++ b/tests/reference_algorithm_tests.py
@@ -6,12 +6,11 @@ iterator because it is not realistic to have all datasets available at testing
 time. For end-to-end tests of submission_runner.py see
 submission_runner_test.py.
 
-# pylint: disable=line-too-long
 Assumes that each reference submission is using the external tuning ruleset and
 that it is defined in:
+# pylint: disable=line-too-long
 "reference_algorithms/development_algorithms/{workload}/{workload}_{framework}/submission.py"
 "reference_algorithms/development_algorithms/{workload}/tuning_search_space.json".
-# pylint: enable=line-too-long
 """
 import copy
 import functools


### PR DESCRIPTION
I went with changing the config instead of writing a bash script for now, as this requires some more thought (still think it makes sense to do later on). Fixes #112 (only affected runnning the workload on GCP, not on my setup).

Also, I added a check `if global_batch_size % N_GPUS != 0`, addressing the first point in #119, and did some clean up of line-too-long exceptions (we might want to choose a better solution, see @pomonam's comment in #119).

**Important:** I didn't have time to mention it in our last meeting, but shifting all Jax operations to CPU will impact performance of the evaluation for the WMT PyTorch workload, as we used to do the beam search with Jax on GPU. I'm currently running a timing run to see how big the impact is. I think the only other workload affected by this is FastMRI, where we use Jax to compute an eval metric. Still wanted create this PR already now, to unblock running things.
Potential fix: Ideally, find out why we can't use Jax with GPU backend on GCP. Maybe more realistically, port the Jax code to PyTorch to execute everything on GPU.
_Update: WMT evaluation with Jax GPU 4909s, with Jax CPU 6140s (timed with 4xV100 32GB and bs 128)._

**Note:** The WMT workload currently fails during evalution on the test set, because the remainder batch size % N_GPUS != 0.