### PR TITLE
ViT architecture updates

### DIFF
--- a/algorithmic_efficiency/init_utils.py
+++ b/algorithmic_efficiency/init_utils.py
@@ -4,7 +4,7 @@ from torch import nn
 
 
 def pytorch_default_init(module: nn.Module) -> None:
-  fan_in = module.in_features
+  fan_in, _ = nn.init._calculate_fan_in_and_fan_out(module.weight)
   std = math.sqrt(1. / fan_in) / .87962566103423978
   nn.init.trunc_normal_(module.weight.data, std=std)
   if module.bias is not None:

--- a/algorithmic_efficiency/init_utils.py
+++ b/algorithmic_efficiency/init_utils.py
@@ -1,0 +1,11 @@
+import math
+
+from torch import nn
+
+
+def pytorch_default_init(module: nn.Module) -> None:
+  fan_in = module.in_features
+  std = math.sqrt(1. / fan_in) / .87962566103423978
+  nn.init.trunc_normal_(module.weight.data, std=std)
+  if module.bias is not None:
+    nn.init.constant_(module.bias.data, 0.)

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
@@ -9,7 +9,6 @@ from typing import Optional, Sequence, Union
 
 from flax import linen as nn
 import jax.numpy as jnp
-import numpy as np
 
 from algorithmic_efficiency import spec
 

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
@@ -11,6 +11,8 @@ from flax import linen as nn
 import jax.numpy as jnp
 import numpy as np
 
+from algorithmic_efficiency import spec
+
 
 def posemb_sincos_2d(h, w, width, temperature=10_000., dtype=jnp.float32):
   """Follows the MoCo v3 logic."""
@@ -26,25 +28,13 @@ def posemb_sincos_2d(h, w, width, temperature=10_000., dtype=jnp.float32):
   return jnp.asarray(pe, dtype)[None, :, :]
 
 
-def get_posemb(self, emb_type, seqshape, width, name, dtype=jnp.float32):
-  if emb_type == 'learn':
-    return self.param(name,
-                      nn.initializers.normal(stddev=1 / np.sqrt(width)),
-                      (1, np.prod(seqshape), width),
-                      dtype)
-  elif emb_type == 'sincos2d':
-    return posemb_sincos_2d(*seqshape, width, dtype=dtype)
-  else:
-    raise ValueError(f'Unknown posemb type: {emb_type}')
-
-
 class MlpBlock(nn.Module):
   """Transformer MLP / feed-forward block."""
   mlp_dim: Optional[int] = None  # Defaults to 4x input dim
   dropout_rate: float = 0.0
 
   @nn.compact
-  def __call__(self, x, train=True):
+  def __call__(self, x: spec.Tensor, train: bool = True) -> spec.Tensor:
     """Applies Transformer MlpBlock module."""
     inits = dict(
         kernel_init=nn.initializers.xavier_uniform(),
@@ -66,25 +56,24 @@ class Encoder1DBlock(nn.Module):
   dropout_rate: float = 0.0
 
   @nn.compact
-  def __call__(self, x, train=True):
-    out = {}
+  def __call__(self, x: spec.Tensor, train: bool = True) -> spec.Tensor:
     y = nn.LayerNorm(name='LayerNorm_0')(x)
-    y = out['sa'] = nn.SelfAttention(
+    y = nn.SelfAttention(
         num_heads=self.num_heads,
         kernel_init=nn.initializers.xavier_uniform(),
         deterministic=train,
         name='MultiHeadDotProductAttention_1')(
             y)
     y = nn.Dropout(rate=self.dropout_rate)(y, train)
-    x = out['+sa'] = x + y
+    x = x + y
 
     y = nn.LayerNorm(name='LayerNorm_2')(x)
-    y = out['mlp'] = MlpBlock(
+    y = MlpBlock(
         mlp_dim=self.mlp_dim, dropout_rate=self.dropout_rate,
         name='MlpBlock_3')(y, train)
     y = nn.Dropout(rate=self.dropout_rate)(y, train)
-    x = out['+mlp'] = x + y
-    return x, out
+    x = x + y
+    return x
 
 
 class Encoder(nn.Module):
@@ -95,9 +84,7 @@ class Encoder(nn.Module):
   dropout_rate: float = 0.0
 
   @nn.compact
-  def __call__(self, x, train=True):
-    out = {}
-
+  def __call__(self, x: spec.Tensor, train: bool = True) -> spec.Tensor:
     # Input Encoder
     for lyr in range(self.depth):
       block = Encoder1DBlock(
@@ -105,58 +92,41 @@ class Encoder(nn.Module):
           mlp_dim=self.mlp_dim,
           num_heads=self.num_heads,
           dropout_rate=self.dropout_rate)
-      x, out[f'block{lyr:02d}'] = block(x, train)
-    out['pre_ln'] = x  # Alias for last block, but without the number in it.
-
-    return nn.LayerNorm(name='encoder_norm')(x), out
-
-
-class MAPHead(nn.Module):
-  """Multihead Attention Pooling."""
-  mlp_dim: Optional[int] = None  # Defaults to 4x input dim
-  num_heads: int = 12
-
-  @nn.compact
-  def __call__(self, x):
-    # TODO(lbeyer): condition on GAP(x)
-    n, _, d = x.shape
-    probe = self.param('probe',
-                       nn.initializers.xavier_uniform(), (1, 1, d),
-                       x.dtype)
-    probe = jnp.tile(probe, [n, 1, 1])
-
-    x = nn.MultiHeadDotProductAttention(
-        num_heads=self.num_heads,
-        kernel_init=nn.initializers.xavier_uniform())(probe, x)
-
-    # TODO(lbeyer): dropout_rate on head?
-    y = nn.LayerNorm()(x)
-    x = x + MlpBlock(mlp_dim=self.mlp_dim)(y)
-    return x[:, 0]
+      x = block(x, train)
+    return nn.LayerNorm(name='encoder_norm')(x)
 
 
 class ViT(nn.Module):
   """ViT model."""
 
-  num_classes: int
+  num_classes: int = 1000
   patch_size: Sequence[int] = (16, 16)
   width: int = 768
   depth: int = 12
   mlp_dim: Optional[int] = None  # Defaults to 4x input dim
   num_heads: int = 12
-  posemb: str = 'sincos2d'  # Can also be "learn"
+  posemb: str = 'sincos2d'
   rep_size: Union[int, bool] = True
   dropout_rate: Optional[float] = 0.0  # If None, defaults to 0.0.
-  pool_type: str = 'gap'  # Can also be 'map' or 'tok'
+  pool_type: str = 'gap'  # Can also be 'tok'
   reinit: Optional[Sequence[str]] = None
   head_zeroinit: bool = True
 
-  @nn.compact
-  def __call__(self, x, *, train=False):
-    out = {}
+  def get_posemb(self, emb_type, seqshape, width, name, dtype=jnp.float32):
+    if emb_type == 'learn':
+      return self.param(name,
+                        nn.initializers.normal(stddev=1 / np.sqrt(width)),
+                        (1, np.prod(seqshape), width),
+                        dtype)
+    elif emb_type == 'sincos2d':
+      return posemb_sincos_2d(*seqshape, width, dtype=dtype)
+    else:
+      raise ValueError(f'Unknown posemb type: {emb_type}')
 
+  @nn.compact
+  def __call__(self, x: spec.Tensor, *, train: bool = False) -> spec.Tensor:
     # Patch extraction
-    x = out['stem'] = nn.Conv(
+    x = nn.Conv(
         self.width,
         self.patch_size,
         strides=self.patch_size,
@@ -168,59 +138,42 @@ class ViT(nn.Module):
     x = jnp.reshape(x, [n, h * w, c])
 
     # Add posemb before adding extra token.
-    x = out['with_posemb'] = x + get_posemb(
-        self, self.posemb, (h, w), c, 'pos_embedding', x.dtype)
+    x = x + self.get_posemb(self.posemb, (h, w), c, 'pos_embedding', x.dtype)
 
     if self.pool_type == 'tok':
       cls = self.param('cls', nn.initializers.zeros, (1, 1, c), x.dtype)
       x = jnp.concatenate([jnp.tile(cls, [n, 1, 1]), x], axis=1)
 
-    n, _, c = x.shape
     dropout_rate = self.dropout_rate
     if dropout_rate is None:
       dropout_rate = 0.0
     x = nn.Dropout(rate=dropout_rate)(x, not train)
 
-    x, out['encoder'] = Encoder(
+    x = Encoder(
         depth=self.depth,
         mlp_dim=self.mlp_dim,
         num_heads=self.num_heads,
         dropout_rate=dropout_rate,
         name='Transformer')(
             x, train=not train)
-    encoded = out['encoded'] = x
 
-    if self.pool_type == 'map':
-      x = out['head_input'] = MAPHead(
-          num_heads=self.num_heads, mlp_dim=self.mlp_dim)(
-              x)
-    elif self.pool_type == 'gap':
-      x = out['head_input'] = jnp.mean(x, axis=1)
+    if self.pool_type == 'gap':
+      x = jnp.mean(x, axis=1)
     elif self.pool_type == '0':
-      x = out['head_input'] = x[:, 0]
+      x = x[:, 0]
     elif self.pool_type == 'tok':
-      x = out['head_input'] = x[:, 0]
-      encoded = encoded[:, 1:]
+      x = x[:, 0]
     else:
       raise ValueError(f'Unknown pool type: "{self.pool_type}"')
-
-    x_2d = jnp.reshape(encoded, [n, h, w, -1])
 
     if self.rep_size:
       rep_size = self.width if self.rep_size is True else self.rep_size  # pylint: disable=g-bool-id-comparison
       hid = nn.Dense(rep_size, name='pre_logits')
-      # NOTE: In the past we did not include tanh in pre_logits.
-      # For few-shot, it should not matter much, as it whitens anyways.
-      x_2d = nn.tanh(hid(x_2d))
       x = nn.tanh(hid(x))
-
-    out['pre_logits_2d'] = x_2d
-    out['pre_logits'] = x
 
     if self.num_classes:
       kw = {'kernel_init': nn.initializers.zeros} if self.head_zeroinit else {}
       head = nn.Dense(self.num_classes, name='head', **kw)
-      x_2d = out['logits_2d'] = head(x_2d)
-      x = out['logits'] = head(x)
+      x = head(x)
 
     return x

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
@@ -28,7 +28,7 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
 
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     self._model_kwargs = {
-        'num_classes': self._num_classes, **decode_variant('B/32')
+        'num_classes': self._num_classes, **decode_variant('S/16')
     }
     model = models.ViT(**self._model_kwargs)
     params, model_state = self.initialized(rng, model)
@@ -39,7 +39,7 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     return params, model_state
 
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
-    return param_key == 'pre_logits'
+    return param_key == 'head'
 
   def model_fn(
       self,

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
@@ -163,7 +163,7 @@ class Encoder(nn.Module):
                width: int,
                mlp_dim: Optional[int] = None,
                num_heads: int = 12,
-               dropout: float = 0.0) -> None:
+               dropout_rate: float = 0.0) -> None:
     super().__init__()
 
     self.depth = depth
@@ -172,14 +172,14 @@ class Encoder(nn.Module):
     self.num_heads = num_heads
 
     self.net = nn.ModuleList([
-        Encoder1DBlock(self.width, self.mlp_dim, self.num_heads, dropout)
+        Encoder1DBlock(self.width, self.mlp_dim, self.num_heads, dropout_rate)
         for _ in range(depth)
     ])
     self.encoder_norm = nn.LayerNorm(self.width)
 
   def forward(self, x: spec.Tensor) -> spec.Tensor:
     # Input Encoder
-    for lyr, block in enumerate(self.net):
+    for block in self.net:
       x = block(x)
     return self.encoder_norm(x)
 
@@ -252,10 +252,9 @@ class ViT(nn.Module):
       self.head = nn.Linear(self.width, self.num_classes)
     if self.head_zeroinit:
       self.head.weight.data.zero_()
-
     self.reset_parameters()
 
-  def reset_parameters(self):
+  def reset_parameters(self) -> None:
     init_utils.pytorch_default_init(self.embed)
 
     if self.rep_size:

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
@@ -253,6 +253,8 @@ class ViT(nn.Module):
     if self.head_zeroinit:
       self.head.weight.data.zero_()
 
+    self.reset_parameters()
+
   def reset_parameters(self):
     init_utils.pytorch_default_init(self.embed)
 

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
@@ -1,6 +1,6 @@
 """A refactored and simplified ViT.
 
-Adapted from:
+NOTE: Adapted from
 https://github.com/huggingface/transformers/tree/main/src/transformers/models/vit
 https://github.com/lucidrains/vit-pytorch
 """
@@ -10,8 +10,10 @@ from typing import Any, Optional, Tuple, Union
 
 import torch
 from torch import nn
-from torch import Tensor
 import torch.nn.functional as F
+
+from algorithmic_efficiency import init_utils
+from algorithmic_efficiency import spec
 
 
 def posemb_sincos_2d(patches, temperature=10_000.):
@@ -30,18 +32,6 @@ def posemb_sincos_2d(patches, temperature=10_000.):
   return pe[None, :, :]
 
 
-def init_weights(module) -> None:
-  if isinstance(module, (nn.Linear, nn.Conv2d)):
-    # Slightly different from the TF version which uses truncated_normal
-    # for initialization, cf https://github.com/pytorch/pytorch/pull/5617
-    module.weight.data.normal_(mean=0.0, std=0.02)
-    if module.bias is not None:
-      module.bias.data.zero_()
-  elif isinstance(module, nn.LayerNorm):
-    module.bias.data.zero_()
-    module.weight.data.fill_(1.0)
-
-
 class MlpBlock(nn.Module):
   """Transformer MLP / feed-forward block."""
 
@@ -49,28 +39,28 @@ class MlpBlock(nn.Module):
       self,
       width: int,
       mlp_dim: Optional[int] = None,  # Defaults to 4x input dim
-      dropout: float = 0.0) -> None:
+      dropout_rate: float = 0.0) -> None:
     super().__init__()
 
     self.width = width
     self.mlp_dim = mlp_dim or 4 * width
-    self.dropout = dropout
+    self.dropout_rate = dropout_rate
 
     self.net = nn.Sequential(
         nn.Linear(self.width, self.mlp_dim),
         nn.GELU(),
-        nn.Dropout(self.dropout),
+        nn.Dropout(self.dropout_rate),
         nn.Linear(self.mlp_dim, self.width))
-    self._init_weights()
+    self.reset_parameters()
 
-  def _init_weights(self) -> None:
+  def reset_parameters(self) -> None:
     for module in self.modules():
       if isinstance(module, nn.Linear):
-        torch.nn.init.xavier_uniform_(module.weight)
+        nn.init.xavier_uniform_(module.weight)
         if module.bias is not None:
           module.bias.data.normal_(std=1e-6)
 
-  def forward(self, x: Tensor) -> Tensor:
+  def forward(self, x: spec.Tensor) -> spec.Tensor:
     return self.net(x)
 
 
@@ -80,7 +70,7 @@ class SelfAttention(nn.Module):
   def __init__(self,
                width: int,
                num_heads: int = 8,
-               dropout: float = 0.0) -> None:
+               dropout_rate: float = 0.0) -> None:
     super().__init__()
 
     self.width = width
@@ -93,26 +83,25 @@ class SelfAttention(nn.Module):
     self.all_head_dim = self.num_heads * self.head_dim
 
     self.query = nn.Linear(self.width, self.all_head_dim)
-    torch.nn.init.xavier_uniform_(self.query.weight)
-    self.query.bias.data.zero_()
     self.key = nn.Linear(self.width, self.all_head_dim)
-    torch.nn.init.xavier_uniform_(self.key.weight)
-    self.key.bias.data.zero_()
     self.value = nn.Linear(self.width, self.all_head_dim)
-    torch.nn.init.xavier_uniform_(self.value.weight)
-    self.value.bias.data.zero_()
-
-    self.dropout = nn.Dropout(dropout)
+    self.dropout = nn.Dropout(dropout_rate)
     self.out = nn.Linear(self.width, self.width)
-    torch.nn.init.xavier_uniform_(self.out.weight)
-    self.out.bias.data.zero_()
+    self.reset_parameters()
 
-  def transpose_for_scores(self, x: Tensor) -> Tensor:
+  def reset_parameters(self) -> None:
+    for module in self.modules():
+      if isinstance(module, nn.Linear):
+        nn.init.xavier_uniform_(module.weight)
+        if module.bias is not None:
+          nn.init.constant_(module.bias, 0.)
+
+  def transpose_for_scores(self, x: spec.Tensor) -> spec.Tensor:
     new_x_shape = x.size()[:-1] + (self.num_heads, self.head_dim)
     x = x.view(new_x_shape)
     return x.permute(0, 2, 1, 3)
 
-  def forward(self, x: Tensor) -> Tensor:
+  def forward(self, x: spec.Tensor) -> spec.Tensor:
     mixed_query_layer = self.query(x)
 
     key_layer = self.transpose_for_scores(self.key(x))
@@ -140,7 +129,7 @@ class Encoder1DBlock(nn.Module):
                width: int,
                mlp_dim: Optional[int] = None,
                num_heads: int = 12,
-               dropout: float = 0.0) -> None:
+               dropout_rate: float = 0.0) -> None:
     super().__init__()
 
     self.width = width
@@ -148,25 +137,22 @@ class Encoder1DBlock(nn.Module):
     self.num_heads = num_heads
 
     self.layer_norm0 = nn.LayerNorm(self.width)
-    init_weights(self.layer_norm0)
     self.self_attention1 = SelfAttention(self.width, self.num_heads)
-    self.dropout = nn.Dropout(dropout)
+    self.dropout = nn.Dropout(dropout_rate)
     self.layer_norm2 = nn.LayerNorm(self.width)
-    init_weights(self.layer_norm2)
-    self.mlp3 = MlpBlock(self.width, self.mlp_dim, dropout)
+    self.mlp3 = MlpBlock(self.width, self.mlp_dim, dropout_rate)
 
-  def forward(self, x: Tensor) -> Tuple[Tensor, dict]:
-    out = {}
+  def forward(self, x: spec.Tensor) -> spec.Tensor:
     y = self.layer_norm0(x)
-    y = out['sa'] = self.self_attention1(y)
+    y = self.self_attention1(y)
     y = self.dropout(y)
-    x = out['+sa'] = x + y
+    x = x + y
 
     y = self.layer_norm2(x)
-    y = out['mlp'] = self.mlp3(y)
+    y = self.mlp3(y)
     y = self.dropout(y)
-    x = out['+mlp'] = x + y
-    return x, out
+    x = x + y
+    return x
 
 
 class Encoder(nn.Module):
@@ -190,17 +176,12 @@ class Encoder(nn.Module):
         for _ in range(depth)
     ])
     self.encoder_norm = nn.LayerNorm(self.width)
-    init_weights(self.encoder_norm)
 
-  def forward(self, x: Tensor) -> Tuple[Tensor, dict]:
-    out = {}
-
+  def forward(self, x: spec.Tensor) -> spec.Tensor:
     # Input Encoder
     for lyr, block in enumerate(self.net):
-      x, out[f'block{lyr:02d}'] = block(x)
-    out['pre_ln'] = x  # Alias for last block, but without the number in it.
-
-    return self.encoder_norm(x), out
+      x = block(x)
+    return self.encoder_norm(x)
 
 
 class ViT(nn.Module):
@@ -218,7 +199,7 @@ class ViT(nn.Module):
       depth: int = 12,
       mlp_dim: Optional[int] = None,  # Defaults to 4x input dim
       num_heads: int = 12,
-      posemb: str = 'sincos2d',  # Can also be 'learn'
+      posemb: str = 'sincos2d',
       rep_size: Union[int, bool] = True,
       dropout: float = 0.0,
       pool_type: str = 'gap',  # Can also be 'tok'
@@ -242,16 +223,15 @@ class ViT(nn.Module):
                   (self.image_width // self.patch_size[1])
     if self.posemb == 'learn':
       self.pos_embed = nn.Parameter(torch.randn(1, num_patches, width))
-      self.pos_embed.data.normal_(std=1 / math.sqrt(self.width))
+      nn.init.normal_(self.pos_embed.data, std=1 / math.sqrt(self.width))
 
     if self.pool_type == 'tok':
       self.cls = nn.Parameter(torch.randn(1, 1, width)).type(self.dtype)
-      self.cls.data.zero_()
+      nn.init.constant_(self.cls.data, 0.)
 
     if self.rep_size:
       rep_size = self.width if self.rep_size is True else self.rep_size  # pylint: disable=g-bool-id-comparison
       self.pre_logits = nn.Linear(self.width, rep_size)
-      init_weights(self.pre_logits)
 
     self.embed = nn.Conv2d(
         self.channels,
@@ -259,7 +239,6 @@ class ViT(nn.Module):
         self.patch_size,
         stride=self.patch_size,
         padding='valid')
-    init_weights(self.embed)
     self.dropout = nn.Dropout(p=dropout)
 
     self.encoder = Encoder(
@@ -271,11 +250,23 @@ class ViT(nn.Module):
 
     if self.num_classes:
       self.head = nn.Linear(self.width, self.num_classes)
-      init_weights(self.head)
     if self.head_zeroinit:
       self.head.weight.data.zero_()
 
-  def get_posemb(self, x: Tensor) -> Tensor:
+  def reset_parameters(self):
+    init_utils.pytorch_default_init(self.embed)
+
+    if self.rep_size:
+      init_utils.pytorch_default_init(self.pre_logits)
+
+    if self.num_classes:
+      if self.head_zeroinit:
+        nn.init.constant_(self.head.weight.data, 0.)
+        nn.init.constant_(self.head.bias.data, 0.)
+      else:
+        init_utils.pytorch_default_init(self.head)
+
+  def get_posemb(self, x: spec.Tensor) -> spec.Tensor:
     if self.posemb == 'learn':
       return self.pos_embed.type(self.dtype)
     elif self.posemb == 'sincos2d':
@@ -283,11 +274,9 @@ class ViT(nn.Module):
     else:
       raise ValueError(f'Unknown posemb type: {self.posemb}')
 
-  def forward(self, x: Tensor) -> Tensor:
-    out = {}
-
+  def forward(self, x: spec.Tensor) -> spec.Tensor:
     # Patch extraction
-    x = out['stem'] = self.embed(x)
+    x = self.embed(x)
 
     # Add posemb before adding extra token.
     n, c, h, w = x.shape
@@ -295,37 +284,26 @@ class ViT(nn.Module):
 
     # Reshape to match Jax's ViT implementation.
     x = torch.transpose(torch.reshape(x, (n, c, h * w)), 1, 2)
-    x = out['with_posemb'] = x + pes
+    x = x + pes
 
     if self.pool_type == 'tok':
       x = torch.cat((torch.tile(self.cls, [n, 1, 1]), x), dim=1)
 
-    n, l, c = x.shape  # pylint: disable=unused-variable
     x = self.dropout(x)
-
-    x, out['encoder'] = self.encoder(x)
-    encoded = out['encoded'] = x
-
+    x = self.encoder(x)
     if self.pool_type == 'gap':
-      x = out['head_input'] = torch.mean(x, dim=1)
+      x = torch.mean(x, dim=1)
     elif self.pool_type == '0':
-      x = out['head_input'] = x[:, 0]
+      x = x[:, 0]
     elif self.pool_type == 'tok':
-      x = out['head_input'] = x[:, 0]
-      encoded = encoded[:, 1:]
+      x = x[:, 0]
     else:
       raise ValueError(f'Unknown pool type: "{self.pool_type}"')
 
-    x_2d = torch.reshape(encoded, [n, h, w, -1])
-
     if self.rep_size:
-      x_2d = torch.tanh(self.pre_logits(x_2d))
       x = torch.tanh(self.pre_logits(x))
 
-    out['pre_logits_2d'] = x_2d
-    out['pre_logits'] = x
-
     if self.num_classes:
-      x_2d = out['logits_2d'] = self.head(x_2d)
-      x = out['logits'] = self.head(x)
+      x = self.head(x)
+
     return x

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
@@ -201,7 +201,7 @@ class ViT(nn.Module):
       num_heads: int = 12,
       posemb: str = 'sincos2d',
       rep_size: Union[int, bool] = True,
-      dropout: float = 0.0,
+      dropout_rate: float = 0.0,
       pool_type: str = 'gap',  # Can also be 'tok'
       head_zeroinit: bool = True,
       dtype: Any = torch.float32) -> None:
@@ -239,14 +239,14 @@ class ViT(nn.Module):
         self.patch_size,
         stride=self.patch_size,
         padding='valid')
-    self.dropout = nn.Dropout(p=dropout)
+    self.dropout = nn.Dropout(p=dropout_rate)
 
     self.encoder = Encoder(
         depth=self.depth,
         width=self.width,
         mlp_dim=self.mlp_dim,
         num_heads=self.num_heads,
-        dropout=dropout)
+        dropout_rate=dropout_rate)
 
     if self.num_classes:
       self.head = nn.Linear(self.width, self.num_classes)

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
@@ -26,7 +26,7 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
 
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     torch.random.manual_seed(rng[0])
-    model_kwargs = decode_variant('B/32')
+    model_kwargs = decode_variant('S/16')
     model = models.ViT(num_classes=1000, **model_kwargs)
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
@@ -39,7 +39,7 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     return model, None
 
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
-    return param_key in ['pre_logits.weight', 'pre_logits.bias']
+    return param_key in ['head.weight', 'head.bias']
 
   def model_fn(
       self,

--- a/reference_algorithms/target_setting_algorithms/imagenet_vit/tuning_search_space.json
+++ b/reference_algorithms/target_setting_algorithms/imagenet_vit/tuning_search_space.json
@@ -23,5 +23,10 @@
         "feasible_points": [
             0.026595
         ]
+    },
+    "grad_clip": {
+        "feasible_points": [
+            1.0
+        ]
     }
 }

--- a/reference_algorithms/target_setting_algorithms/jax_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/jax_submission_base.py
@@ -53,7 +53,7 @@ def pmapped_train_step(workload,
   grad = lax.pmean(grad, axis_name='batch')
 
   if grad_clip is not None:
-    grad_norm = sum(jnp.sum(g**2) for g in jax.tree_leaves(grad))
+    grad_norm = jnp.sqrt(sum(jnp.sum(g**2) for g in jax.tree_leaves(grad)))
     grad_scaling_factor = grad_clip / (grad_norm + _GRAD_CLIP_EPS)
     grad_scaling_factor = jax.lax.clamp(min=0.0, x=grad_scaling_factor, max=1.0)
     grad = jax.tree_map(lambda x: x * grad_scaling_factor, grad)

--- a/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
@@ -55,7 +55,6 @@ def update_params(workload: spec.Workload,
   loss.backward()
   if grad_clip is not None:
     torch.nn.utils.clip_grad_norm_(current_model, grad_clip)
-
   optimizer_state['optimizer'].step()
   optimizer_state['scheduler'].step()
 

--- a/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, List, Tuple
 
+import torch
+
 from algorithmic_efficiency import spec
 
 
@@ -40,6 +42,10 @@ def update_params(workload: spec.Workload,
   label_smoothing = (
       hyperparameters.label_smoothing if hasattr(hyperparameters,
                                                  'label_smoothing') else 0.0)
+  if hasattr(hyperparameters, 'grad_clip'):
+    grad_clip = hyperparameters.grad_clip
+  else:
+    grad_clip = None
   loss = workload.loss_fn(
       label_batch=batch['targets'],
       logits_batch=logits_batch,
@@ -47,6 +53,9 @@ def update_params(workload: spec.Workload,
       label_smoothing=label_smoothing).mean()
 
   loss.backward()
+  if grad_clip is not None:
+    torch.nn.utils.clip_grad_norm_(current_model, grad_clip)
+
   optimizer_state['optimizer'].step()
   optimizer_state['scheduler'].step()
 


### PR DESCRIPTION
This PR attempts to address #184 and #189.

To match the configuration from target-setting runs:
1. Change architecture configuration to `S/16` from `B/32`.
2. Use identical parameter initialization methods for both Jax and PyTorch workloads.
3. Clean up the code by removing any intermediate unused variables.
4. Add gradient clipping for PyTorch and use gradient clipping of 1.0 in the target-setting run.
5. Fix gradient clipping for Jax (I suspect there is a missing `sqrt` if I am not mistaken).

However, there are still some differences:
1. The way we are applying weight decay (e.g., apply to tensors with above or equal to 2 dimensions vs. apply to all tensors) -- which can change the optimal LR and WD.
2. Data augmentation (e.g., using RandAugment) -- which can change the optimal LR due to the implicit regularization effect. 