### PR TITLE
ImageNet ResNet initialization to match with Jax

### DIFF
--- a/algorithmic_efficiency/init_utils.py
+++ b/algorithmic_efficiency/init_utils.py
@@ -1,9 +1,15 @@
+"""Utilities for initializing parameters.
+
+Note: Code adapted from
+https://github.com/google/jax/blob/main/jax/_src/nn/initializers.py
+"""
 import math
 
 from torch import nn
 
 
 def pytorch_default_init(module: nn.Module) -> None:
+  # Perform lecun_normal initialization.
   fan_in, _ = nn.init._calculate_fan_in_and_fan_out(module.weight)
   std = math.sqrt(1. / fan_in) / .87962566103423978
   nn.init.trunc_normal_(module.weight.data, std=std)

--- a/algorithmic_efficiency/init_utils.py
+++ b/algorithmic_efficiency/init_utils.py
@@ -1,0 +1,11 @@
+import math
+
+from torch import nn
+
+
+def pytorch_default_init(module: nn.Module) -> None:
+  fan_in, _ = nn.init._calculate_fan_in_and_fan_out(module.weight)
+  std = math.sqrt(1. / fan_in) / .87962566103423978
+  nn.init.trunc_normal_(module.weight.data, std=std)
+  if module.bias is not None:
+    nn.init.constant_(module.bias.data, 0.)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
@@ -6,6 +6,7 @@ https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
 
 import collections
 from typing import Any, Callable, List, Optional, Type, Union
+from algorithmic_efficiency.init_utils import pytorch_default_init
 
 import torch
 from torch import nn
@@ -151,7 +152,7 @@ class ResNet(nn.Module):
                block: Type[Union[BasicBlock, Bottleneck]],
                layers: List[int],
                num_classes: int = 1000,
-               zero_init_residual: bool = False,
+               zero_init_residual: bool = True,
                groups: int = 1,
                width_per_group: int = 64,
                replace_stride_with_dilation: Optional[List[bool]] = None,
@@ -189,8 +190,8 @@ class ResNet(nn.Module):
     self.fc = nn.Linear(512 * block.expansion, num_classes)
 
     for m in self.modules():
-      if isinstance(m, nn.Conv2d):
-        nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+      if isinstance(m, nn.Conv2d) or isinstance(m, nn.Linear):
+        pytorch_default_init(m)
       elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
         nn.init.constant_(m.weight, 1)
         nn.init.constant_(m.bias, 0)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
@@ -6,11 +6,12 @@ https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
 
 import collections
 from typing import Any, Callable, List, Optional, Type, Union
-from algorithmic_efficiency.init_utils import pytorch_default_init
 
 import torch
 from torch import nn
 from torch import Tensor
+
+from algorithmic_efficiency.init_utils import pytorch_default_init
 
 __all__ = ['ResNet', 'resnet50']
 


### PR DESCRIPTION
This PR modifies the Imagenet-Resnet workload so that the initialization scheme between Jax and Pytorch matches.

