### PR TITLE
Initalization Fixes

### DIFF
--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -5,7 +5,7 @@ https://github.com/facebookresearch/fastMRI/blob/main/fastmri/models/unet.py
 """
 
 from typing import Any
-
+from algorithmic_efficiency import init_utils
 import torch
 from torch import nn
 from torch import Tensor
@@ -49,6 +49,10 @@ class Unet(nn.Module):
             ConvBlock(ch * 2, ch, dropout),
             nn.Conv2d(ch, self.out_chans, kernel_size=1, stride=1),
         ))
+
+    for m in self.modules():
+      if isinstance(m, nn.Conv2d) or isinstance(m, nn.ConvTranspose2d):
+        init_utils.pytorch_default_init(m)
 
   def forward(self, x: Tensor) -> Tensor:
     stack = []

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -5,11 +5,13 @@ https://github.com/facebookresearch/fastMRI/blob/main/fastmri/models/unet.py
 """
 
 from typing import Any
-from algorithmic_efficiency import init_utils
+
 import torch
 from torch import nn
 from torch import Tensor
 from torch.nn import functional as F
+
+from algorithmic_efficiency import init_utils
 
 
 class Unet(nn.Module):

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/model.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/model.py
@@ -46,6 +46,8 @@ class ConformerConfig:
 def initialize(m):
   if isinstance(m, nn.Linear) or isinstance(m, nn.Conv1d):
     init.xavier_uniform_(m.weight)
+    if m.bias is not None:
+      init.constant_(m.bias, 0)
   elif isinstance(m, nn.MultiheadAttention):
     init.xavier_uniform_(m.in_proj_weight)
   for i in m.children():

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/model.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/model.py
@@ -121,7 +121,7 @@ class Conv2dSubsampling(nn.Module):
     self.filter_shape = (output_channels, input_channels, 3, 3)
 
     self.kernel = nn.Parameter(
-        torch.nn.init.xavier_uniform_(torch.empty(*self.filter_shape)))
+        nn.init.xavier_uniform_(torch.empty(*self.filter_shape)))
     self.bias = nn.Parameter(torch.zeros(output_channels))
 
   def get_same_padding(self, input_shape):

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -33,19 +33,6 @@ class _Model(nn.Module):
     return x
 
 
-def _param_types(param_tree):
-  param_types_dict = {}
-  for name, value in param_tree.items():
-    if isinstance(value, dict):
-      param_types_dict[name] = _param_types(value)
-    else:
-      if 'bias' in name:
-        param_types_dict[name] = spec.ParameterType.BIAS
-      else:
-        param_types_dict[name] = spec.ParameterType.WEIGHT
-  return param_types_dict
-
-
 class MnistWorkload(BaseMnistWorkload):
 
   def _normalize(self, image):

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -10,7 +10,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.utils.data as pytorch_data_utils
 from torchvision import transforms
 from torchvision.datasets import MNIST
-
+from algorithmic_efficiency import init_utils
 from algorithmic_efficiency import data_utils
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
@@ -34,7 +34,12 @@ class _Model(nn.Module):
                      ('layer2',
                       torch.nn.Linear(num_hidden, num_classes, bias=True))]))
 
-  def forward(self, x: spec.Tensor):
+  def reset_parameters(self) -> None:
+    for m in self.net.modules():
+      if isinstance(m, nn.Linear):
+        init_utils.pytorch_default_init(m)
+
+  def forward(self, x: spec.Tensor) -> spec.Tensor:
     x = x.view(x.size()[0], -1)
     return self.net(x)
 

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -10,8 +10,9 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.utils.data as pytorch_data_utils
 from torchvision import transforms
 from torchvision.datasets import MNIST
-from algorithmic_efficiency import init_utils
+
 from algorithmic_efficiency import data_utils
+from algorithmic_efficiency import init_utils
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.pytorch_utils import pytorch_setup

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/models.py
@@ -1,6 +1,7 @@
 # Ported to PyTorch from
 # https://github.com/google/init2winit/blob/master/init2winit/model_lib/gnn.py.
 from typing import Callable, Optional, Tuple
+from algorithmic_efficiency import init_utils
 
 import jax.tree_util as tree
 from jraph import GraphsTuple
@@ -63,6 +64,10 @@ class GNN(nn.Module):
 
     self.decoder = nn.Linear(
         in_features=self.hidden_dims[-1], out_features=self.num_outputs)
+
+    for m in self.modules():
+      if isinstance(m, nn.Linear):
+        init_utils.pytorch_default_init(m)
 
   def forward(self, graph: GraphsTuple) -> torch.Tensor:
     graph = graph._replace(

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/models.py
@@ -1,12 +1,13 @@
 # Ported to PyTorch from
 # https://github.com/google/init2winit/blob/master/init2winit/model_lib/gnn.py.
 from typing import Callable, Optional, Tuple
-from algorithmic_efficiency import init_utils
 
 import jax.tree_util as tree
 from jraph import GraphsTuple
 import torch
 from torch import nn
+
+from algorithmic_efficiency import init_utils
 
 
 def _make_mlp(in_dim, hidden_dims, dropout_rate):

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -734,20 +734,20 @@ class MultiheadAttention(nn.MultiheadAttention):
     self._reset_parameters()
 
   def _reset_parameters(self):
-      if self._qkv_same_embed_dim:
-          xavier_uniform_(self.in_proj_weight)
-      else:
-          xavier_uniform_(self.q_proj_weight)
-          xavier_uniform_(self.k_proj_weight)
-          xavier_uniform_(self.v_proj_weight)
+    if self._qkv_same_embed_dim:
+      xavier_uniform_(self.in_proj_weight)
+    else:
+      xavier_uniform_(self.q_proj_weight)
+      xavier_uniform_(self.k_proj_weight)
+      xavier_uniform_(self.v_proj_weight)
 
-      if self.in_proj_bias is not None:
-          normal_(self.in_proj_bias, std=1e-6)
-          normal_(self.out_proj.bias, std=1e-6)
-      if self.bias_k is not None:
-          normal_(self.bias_k, std=1e-6)
-      if self.bias_v is not None:
-          normal_(self.bias_v, std=1e-6)
+    if self.in_proj_bias is not None:
+      normal_(self.in_proj_bias, std=1e-6)
+      normal_(self.out_proj.bias, std=1e-6)
+    if self.bias_k is not None:
+      normal_(self.bias_k, std=1e-6)
+    if self.bias_v is not None:
+      normal_(self.bias_v, std=1e-6)
 
   def forward(self,
               query: Tensor,

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -733,6 +733,22 @@ class MultiheadAttention(nn.MultiheadAttention):
 
     self._reset_parameters()
 
+  def _reset_parameters(self):
+      if self._qkv_same_embed_dim:
+          xavier_uniform_(self.in_proj_weight)
+      else:
+          xavier_uniform_(self.q_proj_weight)
+          xavier_uniform_(self.k_proj_weight)
+          xavier_uniform_(self.v_proj_weight)
+
+      if self.in_proj_bias is not None:
+          normal_(self.in_proj_bias, std=1e-6)
+          normal_(self.out_proj.bias, std=1e-6)
+      if self.bias_k is not None:
+          normal_(self.bias_k, std=1e-6)
+      if self.bias_v is not None:
+          normal_(self.bias_v, std=1e-6)
+
   def forward(self,
               query: Tensor,
               key: Tensor,


### PR DESCRIPTION
This PR addresses issues that appeared at #189. 

After this PR, the initialization scheme for Jax and Pytorch should be identical except for librispeech workload. Librispeech PyTorch workload might require a larger change as it is difficult to set the initialization for LazyLinear. We might need to define our own version of LazyLinear and use Xavier initialization. 