### PR TITLE
Fix normalization for PyTorch ImageNet test split

### DIFF
--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -59,12 +59,14 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     del cache
     del repeat_final_dataset
     if split == 'test':
+      train_mean = [m / 255 for m in self.train_mean]
+      train_stddev = [s / 255 for s in self.train_stddev]
       np_iter = imagenet_v2.get_imagenet_v2_iter(
           data_dir,
           global_batch_size,
           shard_batch=USE_PYTORCH_DDP,
-          mean_rgb=self.train_mean,
-          stddev_rgb=self.train_stddev)
+          mean_rgb=train_mean,
+          stddev_rgb=train_stddev)
       return map(imagenet_v2_to_torch, itertools.cycle(np_iter))
 
     is_train = split == 'train'


### PR DESCRIPTION
Fixes #192. I haven't checked yet if this indeed fixes the issue, but seems highly likely to me.