### PR TITLE
More ResNet Diff Checking

### DIFF
--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/models.py
@@ -30,7 +30,7 @@ class ResNetBlock(nn.Module):
     y = self.conv(self.filters, (3, 3))(y)
     y = self.norm(scale_init=nn.initializers.zeros)(y)
 
-    if residual.shape != y.shape:
+    if residual.shape != y.shape or self.strides != (1, 1):
       residual = self.conv(
           self.filters, (1, 1), self.strides, name='Conv_proj')(
               residual)
@@ -59,7 +59,7 @@ class BottleneckResNetBlock(nn.Module):
     y = self.conv(self.filters * 4, (1, 1))(y)
     y = self.norm(scale_init=nn.initializers.zeros)(y)
 
-    if residual.shape != y.shape:
+    if residual.shape != y.shape or self.strides != (1, 1):
       residual = self.conv(
           self.filters * 4, (1, 1), self.strides, name='Conv_proj')(
               residual)
@@ -106,9 +106,8 @@ class ResNet(nn.Module):
             act=self.act)(
                 x)
     x = jnp.mean(x, axis=(1, 2))
-    x = nn.Dense(self.num_classes, dtype=self.dtype)(x)
-    x = jnp.asarray(x, self.dtype)
-    x = nn.log_softmax(x)
+    x = nn.Dense(self.num_classes, kernel_init=nn.initializers.normal(),
+                 dtype=self.dtype)(x)
     return x
 
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/models.py
@@ -106,8 +106,11 @@ class ResNet(nn.Module):
             act=self.act)(
                 x)
     x = jnp.mean(x, axis=(1, 2))
-    x = nn.Dense(self.num_classes, kernel_init=nn.initializers.normal(),
-                 dtype=self.dtype)(x)
+    x = nn.Dense(
+        self.num_classes,
+        kernel_init=nn.initializers.normal(),
+        dtype=self.dtype)(
+            x)
     return x
 
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
@@ -191,11 +191,13 @@ class ResNet(nn.Module):
     self.fc = nn.Linear(512 * block.expansion, num_classes)
 
     for m in self.modules():
-      if isinstance(m, nn.Conv2d) or isinstance(m, nn.Linear):
+      if isinstance(m, nn.Conv2d):
         pytorch_default_init(m)
       elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
         nn.init.constant_(m.weight, 1)
         nn.init.constant_(m.bias, 0)
+    nn.init.normal_(self.fc.weight, std=1e-2)
+    nn.init.constant_(self.fc.bias, 0.)
 
     # Zero-initialize the last BN in each residual branch,
     # so that the residual branch starts with zeros,


### PR DESCRIPTION
I believe that we can run the target-setting for ImageNet ResNet after this PR. Basically, this PR attempts to close the gap with the code from target-setting runs.

- Fix final dense layer initialization to normal with `stddev=1e-2` (for both Jax and PyTorch).
- Remove `log_softmax` inside ResNet and let it apply `log_softmax` in the loss function. 