### PR TITLE
timing fix

### DIFF
--- a/algorithmic_efficiency/checkpoint_utils.py
+++ b/algorithmic_efficiency/checkpoint_utils.py
@@ -160,7 +160,8 @@ def save_checkpoint(framework: str,
     else:
       save_path = os.path.join(checkpoint_dir, 'checkpoint')
       torch.save(checkpoint_state, save_path)
-    logging.info('Saved checkpoint to %s', save_path)
 
   if USE_PYTORCH_DDP:
     dist.barrier()
+  if RANK == 0:
+    logging.info('Saved checkpoint to %s', save_path)

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -320,11 +320,10 @@ def train_once(
                                                    data_dir,
                                                    imagenet_v2_data_dir,
                                                    global_step)
-          logging.info('%.2fs \t%d \t%s',
+          logging.info('Time since start: %.2fs, \tStep: %d, \t%s',
                        current_time - global_start_time,
                        global_step,
                        latest_eval_result)
-          train_state['last_eval_time'] = current_time
           eval_results.append((global_step, latest_eval_result))
           train_state['goal_reached'] = workload.has_reached_goal(
               latest_eval_result)
@@ -344,6 +343,7 @@ def train_once(
                 global_step=global_step,
                 preemption_count=preemption_count,
                 checkpoint_dir=log_dir)
+          train_state['last_eval_time'] = time.time()
 
         except RuntimeError as e:
           logging.exception(f'Eval step {global_step} error.\n')


### PR DESCRIPTION
Setting `last_eval_time` to be the current time at the end of an eval, after the eval, checkpointing, and logging has finished. Previously we were setting `last_eval_time` to be the time the eval started at, which meant that the "time since last eval" calculations were counting the time spent in eval/checkpointing/logging as part of trianing.