### PR TITLE
Fix wrong eval metrics for FastMRI with PyTorch DDP

### DIFF
--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -128,7 +128,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
     eval_rngs = prng.split(model_rng, jax.local_device_count())
     for _ in range(num_batches):
       batch = next(self._eval_iters[split])
-      # We already sum these metrics across devices inside _compute_metrics.
+      # We already sum these metrics across devices inside _eval_model.
       synced_metrics = self._eval_model(params, batch, eval_rngs)
       total_metrics = {
           k: v + synced_metrics[k][0] for k, v in total_metrics.items()

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -83,7 +83,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
                                 dtype=torch.float64,
                                 device=DEVICE)
           dist.broadcast(weights, src=0)
-          batch['weights'] = weights
+          batch['weights'] = weights[RANK]
         tensors = torch.empty((2, N_GPUS, per_device_batch_size, 320, 320),
                               device=DEVICE)
         dist.broadcast(tensors, src=0)


### PR DESCRIPTION
The weights on all devices but the first one were not sliced, i.e. the denominator in the calculation of the eval metrics was wrong for all devices but the first. The bug didn't cause any other issues since we only sum over the weights, which is agnostic to the number of dimensions. Addresses part of #182, but don't see how it would be related to the OOM issue.