### PR TITLE
moving dropout from model_fn to init_model_fn

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -84,7 +84,9 @@ def _build_input_queue(
 
 ```python
 def init_model_fn(
-    rng: RandomState
+    rng: RandomState,
+    dropout_rate: Optional[float] = None,
+    aux_dropout_rate: Optional[float] = None
 ) -> initial model parameters
 ```
 

--- a/algorithmic_efficiency/pytorch_utils.py
+++ b/algorithmic_efficiency/pytorch_utils.py
@@ -46,20 +46,3 @@ def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler) -> None:
       logging.info = logging_pass
     # initialize the process group
     dist.init_process_group('nccl')
-
-
-# torch.nn.functional.dropout will not be affected by this function.
-def maybe_update_dropout(model, dropout_rate):
-  if dropout_rate is None:
-    return
-  for child in list(model.modules()):
-    if isinstance(child, torch.nn.Dropout):
-      child.p = dropout_rate
-
-
-def update_attention_dropout(model, attention_dropout_rate):
-  if attention_dropout_rate is None:
-    return
-  for child in list(model.modules()):
-    if isinstance(child, torch.nn.MultiheadAttention):
-      child.dropout = attention_dropout_rate

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -222,8 +222,10 @@ class Workload(metaclass=abc.ABCMeta):
   # InitModelFn = Callable[
   #     Tuple[ParameterShapeTree, RandomState], ParameterContainer]
   @abc.abstractmethod
-  def init_model_fn(
-      self, rng: RandomState) -> Tuple[ParameterContainer, ModelAuxiliaryState]:
+  def init_model_fn(self,
+                    rng: RandomState,
+                    dropout_rate: Optional[float] = None,
+                    aux_dropout_rate: Optional[float] = None) -> ModelInitState:
     """Return (initial_params, initial_model_state)."""
 
   # ModelFn = Callable[
@@ -236,8 +238,6 @@ class Workload(metaclass=abc.ABCMeta):
                model_state: ModelAuxiliaryState,
                mode: ForwardPassMode,
                rng: RandomState,
-               dropout_rate: Optional[float],
-               aux_dropout_rate: Optional[float],
                update_batch_norm: bool) -> Tuple[Tensor, ModelAuxiliaryState]:
     """return logits_batch"""
     # Possible side effect of updating BN.

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -220,7 +220,8 @@ class Workload(metaclass=abc.ABCMeta):
     """Whether a key in ParameterContainer is the output layer parameters."""
 
   # InitModelFn = Callable[
-  #     Tuple[ParameterShapeTree, RandomState], ParameterContainer]
+  #     Tuple[RandomState, Optional[float], Optional[float]],
+  #     ParameterContainer]
   @abc.abstractmethod
   def init_model_fn(self,
                     rng: RandomState,
@@ -229,7 +230,13 @@ class Workload(metaclass=abc.ABCMeta):
     """Return (initial_params, initial_model_state)."""
 
   # ModelFn = Callable[
-  #     Tuple[ParameterContainer, Tensor, ForwardPassMode, RandomState, bool],
+  #     Tuple[
+  #         ParameterContainer,
+  #         Dict[str, Tensor],
+  #         ModelAuxiliaryState,
+  #         ForwardPassMode,
+  #         RandomState,
+  #         bool],
   #     Tensor]
   @abc.abstractmethod
   def model_fn(self,

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
@@ -74,7 +74,14 @@ class CifarWorkload(BaseCifarWorkload):
         {'batch_stats': avg_fn(model_state['batch_stats'])})
     return new_model_state
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Dropout is unused."""
+    del dropout_rate
+    del aux_dropout_rate
     model_cls = getattr(models, 'ResNet18')
     model = model_cls(num_classes=10, dtype=jnp.float32)
     self._model = model
@@ -108,8 +115,6 @@ class CifarWorkload(BaseCifarWorkload):
         model_state,
         spec.ForwardPassMode.EVAL,
         rng,
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=False)
     return self._compute_metrics(logits, batch['targets'])
 
@@ -120,13 +125,8 @@ class CifarWorkload(BaseCifarWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Dropout is unused."""
     del mode
-    del dropout_rate
-    del aux_dropout_rate
     del rng
     variables = {'params': params, **model_state}
     if update_batch_norm:

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -103,7 +103,14 @@ class CifarWorkload(BaseCifarWorkload):
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     return param_key in ['fc.weight', 'fc.bias']
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Dropout is unused."""
+    del dropout_rate
+    del aux_dropout_rate
     torch.random.manual_seed(rng[0])
     model = resnet18(num_classes=10)
     self._param_shapes = param_utils.pytorch_param_shapes(model)
@@ -134,14 +141,9 @@ class CifarWorkload(BaseCifarWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Dropout is unused."""
     del model_state
     del rng
-    del dropout_rate
-    del aux_dropout_rate
 
     model = params
 
@@ -219,8 +221,6 @@ class CifarWorkload(BaseCifarWorkload):
           model_state,
           spec.ForwardPassMode.EVAL,
           model_rng,
-          dropout_rate=None,
-          aux_dropout_rate=None,
           update_batch_norm=False)
       batch_metrics = self._eval_metric(logits, batch['targets'])
       total_metrics = {

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
@@ -29,7 +29,14 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
       per_example_losses *= mask_batch
     return per_example_losses
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Dropout is unused."""
+    del dropout_rate
+    del aux_dropout_rate
     self._model = models.DlrmSmall(
         vocab_sizes=self.vocab_sizes,
         total_vocab_sizes=sum(self.vocab_sizes),
@@ -63,15 +70,10 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Dropout is unused."""
     del model_state
     del mode
     del rng
-    del dropout_rate
-    del aux_dropout_rate
     del update_batch_norm
     inputs = augmented_and_preprocessed_input_batch['inputs']
     targets = augmented_and_preprocessed_input_batch['targets']
@@ -90,8 +92,6 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
         model_state=None,
         mode=spec.ForwardPassMode.EVAL,
         rng=None,
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=False)
     per_example_losses = metrics.per_example_sigmoid_binary_cross_entropy(
         logits, batch['targets'])

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
@@ -39,7 +39,14 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
     loss = self.loss_fn(logits, targets).sum()
     return {'loss': loss}
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Dropout is unused."""
+    del dropout_rate
+    del aux_dropout_rate
     torch.random.manual_seed(rng[0])
     model = DlrmSmall(
         vocab_sizes=self.vocab_sizes,
@@ -68,13 +75,9 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del rng
-    del dropout_rate
-    del aux_dropout_rate
     del update_batch_norm
 
     model = params
@@ -179,8 +182,6 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
         model_state=None,
         mode=spec.ForwardPassMode.EVAL,
         rng=None,
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=False)
     per_example_losses = metrics.per_example_sigmoid_binary_cross_entropy(
         logits, batch['targets'])

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -19,9 +19,16 @@ from algorithmic_efficiency.workloads.fastmri.workload import \
 
 class FastMRIWorkload(BaseFastMRIWorkload):
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """aux_dropout_rate is unused."""
+    del aux_dropout_rate
     fake_batch = jnp.zeros((13, 320, 320))
-    variables = jax.jit(models.UNet().init)({'params': rng}, fake_batch)
+    self._model = models.UNet(dropout_rate=dropout_rate)
+    variables = jax.jit(self._model.init)({'params': rng}, fake_batch)
     params = variables['params']
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
@@ -38,19 +45,14 @@ class FastMRIWorkload(BaseFastMRIWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """aux_dropout_rate is unused."""
     del model_state
-    del aux_dropout_rate
     del update_batch_norm
     train = mode == spec.ForwardPassMode.TRAIN
-    logits = models.UNet(dropout_rate=dropout_rate).apply(
-        {'params': params},
-        augmented_and_preprocessed_input_batch['inputs'],
-        rngs={'dropout': rng},
-        train=train)
+    logits = self._model.apply({'params': params},
+                               augmented_and_preprocessed_input_batch['inputs'],
+                               rngs={'dropout': rng},
+                               train=train)
     return logits, None
 
   # Does NOT apply regularization, which is left to the submitter to do in
@@ -82,8 +84,6 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         model_state=None,
         mode=spec.ForwardPassMode.EVAL,
         rng=rng,
-        dropout_rate=0.0,  # Not relevant for eval.
-        aux_dropout_rate=None,
         update_batch_norm=False)
     ssim_vals = ssim(
         batch['targets'],

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -14,7 +14,12 @@ from torch.nn import functional as F
 from algorithmic_efficiency import init_utils
 
 
-class Unet(nn.Module):
+class UNet(nn.Module):
+  r"""U-Net model from
+    `"U-net: Convolutional networks
+    for biomedical image segmentation"
+    <hhttps://arxiv.org/pdf/1505.04597.pdf>`_.
+    """
 
   def __init__(self,
                in_chans: int = 1,
@@ -137,12 +142,3 @@ class TransposeConvBlock(nn.Module):
 
   def forward(self, x: Tensor) -> Tensor:
     return self.layers(x)
-
-
-def unet(**kwargs: Any) -> Unet:
-  r"""U-Net model from
-    `"U-net: Convolutional networks
-    for biomedical image segmentation"
-    <hhttps://arxiv.org/pdf/1505.04597.pdf>`_.
-    """
-  return Unet(**kwargs)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -4,7 +4,7 @@ Adapted from fastMRI:
 https://github.com/facebookresearch/fastMRI/blob/main/fastmri/models/unet.py
 """
 
-from typing import Any
+from typing import Optional
 
 import torch
 from torch import nn
@@ -26,14 +26,15 @@ class UNet(nn.Module):
                out_chans: int = 1,
                chans: int = 32,
                num_pool_layers: int = 4,
-               dropout: float = 0.0) -> None:
+               dropout: Optional[float] = 0.0) -> None:
     super().__init__()
 
     self.in_chans = in_chans
     self.out_chans = out_chans
     self.chans = chans
     self.num_pool_layers = num_pool_layers
-    self.dropout = dropout
+    if dropout is None:
+      dropout = 0.0
 
     self.down_sample_layers = nn.ModuleList(
         [ConvBlock(in_chans, chans, dropout)])

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -15,7 +15,7 @@ from algorithmic_efficiency import spec
 from algorithmic_efficiency.interop_utils import jax_to_pytorch
 import algorithmic_efficiency.random_utils as prng
 from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.models import \
-    unet
+    UNet
 from algorithmic_efficiency.workloads.fastmri.ssim import ssim
 from algorithmic_efficiency.workloads.fastmri.workload import \
     BaseFastMRIWorkload
@@ -98,9 +98,14 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         batch['volume_max'] = aux_tensors[2][RANK]
       yield batch
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    del aux_dropout_rate
     torch.random.manual_seed(rng[0])
-    model = unet()
+    model = UNet(dropout=dropout_rate)
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
@@ -121,16 +126,12 @@ class FastMRIWorkload(BaseFastMRIWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del rng
-    del aux_dropout_rate
     del update_batch_norm
 
     model = params
-    pytorch_utils.maybe_update_dropout(model, dropout_rate)
 
     if mode == spec.ForwardPassMode.EVAL:
       model.eval()
@@ -173,8 +174,6 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         None,
         spec.ForwardPassMode.EVAL,
         rng,
-        dropout_rate=0.0,
-        aux_dropout_rate=0.0,
         update_batch_norm=False)
     ssim_sum = jax_to_pytorch(
         ssim(

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -104,7 +104,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
       aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
     del aux_dropout_rate
     torch.random.manual_seed(rng[0])
-    model = UNet(dropout=dropout_rate)
+    model = UNet(dropout_rate=dropout_rate)
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -79,7 +79,14 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         {'batch_stats': avg_fn(model_state['batch_stats'])})
     return new_model_state
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Dropout is unused."""
+    del dropout_rate
+    del aux_dropout_rate
     model_cls = getattr(models, 'ResNet50')
     model = model_cls(num_classes=self._num_classes, dtype=jnp.float32)
     self._model = model
@@ -108,8 +115,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         state,
         spec.ForwardPassMode.EVAL,
         rng=rng,
-        dropout_rate=0.0,  # Default for ViT, unused in eval anyways.
-        aux_dropout_rate=None,
         update_batch_norm=False)
     return self._compute_metrics(logits, batch['targets'])
 
@@ -120,14 +125,9 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Dropout is unused."""
     del mode
     del rng
-    del dropout_rate
-    del aux_dropout_rate
     variables = {'params': params, **model_state}
     if update_batch_norm:
       logits, new_model_state = self._model.apply(

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -130,7 +130,14 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
     return dataloader
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Dropout is unused."""
+    del dropout_rate
+    del aux_dropout_rate
     torch.random.manual_seed(rng[0])
     model = resnet50()
     self._param_shapes = param_utils.pytorch_param_shapes(model)
@@ -166,14 +173,9 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Dropout is unused."""
     del model_state
     del rng
-    del dropout_rate
-    del aux_dropout_rate
 
     model = params
 
@@ -258,8 +260,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
           model_state,
           spec.ForwardPassMode.EVAL,
           model_rng,
-          dropout_rate=0.0,  # Default for ViT, unused in eval anyways.
-          aux_dropout_rate=None,
           update_batch_norm=False)
       batch_metrics = self._eval_metric(logits, batch['targets'])
       total_metrics = {

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
@@ -1,5 +1,4 @@
 """ImageNet workload implemented in Jax."""
-import copy
 from typing import Dict, Optional, Tuple
 
 from flax import jax_utils

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
@@ -26,12 +26,17 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     model_state, params = variables.pop('params')
     return params, model_state
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
-    self._model_kwargs = {
-        'num_classes': self._num_classes, **decode_variant('S/16')
-    }
-    model = models.ViT(**self._model_kwargs)
-    params, model_state = self.initialized(rng, model)
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    del aux_dropout_rate
+    self._model = models.ViT(
+        dropout_rate=dropout_rate,
+        num_classes=self._num_classes,
+        **decode_variant('S/16'))
+    params, model_state = self.initialized(rng, self._model)
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
     model_state = jax_utils.replicate(model_state)
@@ -48,20 +53,14 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
-    del aux_dropout_rate
     del update_batch_norm
-    model_kwargs = copy.deepcopy(self._model_kwargs)
-    model_kwargs['dropout_rate'] = dropout_rate
-    model = models.ViT(**model_kwargs)
     train = mode == spec.ForwardPassMode.TRAIN
-    logits = model.apply({'params': params},
-                         augmented_and_preprocessed_input_batch['inputs'],
-                         rngs={'dropout': rng},
-                         train=train)
+    logits = self._model.apply({'params': params},
+                               augmented_and_preprocessed_input_batch['inputs'],
+                               rngs={'dropout': rng},
+                               train=train)
     return logits, None
 
   def _eval_model_on_split(self,

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
@@ -200,10 +200,12 @@ class ViT(nn.Module):
       mlp_dim: Optional[int] = None,  # Defaults to 4x input dim
       num_heads: int = 12,
       rep_size: Union[int, bool] = True,
-      dropout_rate: float = 0.0,
+      dropout_rate: Optional[float] = 0.0,
       head_zeroinit: bool = True,
       dtype: Any = torch.float32) -> None:
     super().__init__()
+    if dropout_rate is None:
+      dropout_rate = 0.0
 
     self.num_classes = num_classes
     self.patch_size = patch_size

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
@@ -24,10 +24,17 @@ USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_utils.pytorch_setup()
 # Make sure we inherit from the ViT base workload first.
 class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+
     torch.random.manual_seed(rng[0])
-    model_kwargs = decode_variant('S/16')
-    model = models.ViT(num_classes=1000, **model_kwargs)
+    model = models.ViT(
+        dropout_rate=dropout_rate,
+        num_classes=self._num_classes,
+        **decode_variant('S/16'))
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
@@ -48,16 +55,12 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del rng
-    del aux_dropout_rate
     del update_batch_norm
 
     model = params
-    pytorch_utils.maybe_update_dropout(model, dropout_rate)
 
     if mode == spec.ForwardPassMode.EVAL:
       model.eval()

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/models.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/models.py
@@ -629,9 +629,9 @@ class Conformer(nn.Module):
     else:
       input_dropout_rate = config.input_dropout_rate
     outputs, output_paddings = Subsample(
-      encoder_dim=config.encoder_dim,
-      input_dropout_rate=input_dropout_rate)(
-      outputs, output_paddings, train)
+        encoder_dim=config.encoder_dim,
+        input_dropout_rate=input_dropout_rate)(
+        outputs, output_paddings, train)
 
     # Run the conformer encoder layers.
     for _ in range(config.num_encoder_layers):

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -25,12 +25,26 @@ FLAGS = flags.FLAGS
 
 class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
-    model = models.Conformer(models.ConformerConfig())
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Conformer model init function.
+
+    Here we use dropout_rate as *_residual_dropout_rate, and aux_dropout_rate as
+    input_dropout_rate.
+    """
+    model_config = models.ConformerConfig(
+        attention_residual_dropout_rate=dropout_rate,
+        conv_residual_dropout_rate=dropout_rate,
+        feed_forward_residual_dropout_rate=dropout_rate,
+        input_dropout_rate=aux_dropout_rate)
+    self._model = models.Conformer(model_config)
     input_shape = [(320000,), (320000,)]
     fake_input_batch = [np.zeros((2, *x), jnp.float32) for x in input_shape]
 
-    model_init_fn = jax.jit(functools.partial(model.init, train=False))
+    model_init_fn = jax.jit(functools.partial(self._model.init, train=False))
 
     params_rng, dropout_rng = jax.random.split(rng, 2)
     variables = model_init_fn({'params': params_rng, 'dropout': dropout_rng},
@@ -57,42 +71,12 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Conformer model function.
-
-    Here we use dropout_rate as *_residual_dropout_rate, and aux_dropout_rate as
-    input_dropout_rate.
-    """
-    model_config = models.ConformerConfig(
-        attention_residual_dropout_rate=dropout_rate,
-        conv_residual_dropout_rate=dropout_rate,
-        feed_forward_residual_dropout_rate=dropout_rate,
-        input_dropout_rate=aux_dropout_rate)
-    model = models.Conformer(model_config)
-    return self._model_fn(params,
-                          augmented_and_preprocessed_input_batch,
-                          model_state,
-                          mode,
-                          rng,
-                          update_batch_norm,
-                          model)
-
-  def _model_fn(
-      self,
-      params: spec.ParameterContainer,
-      augmented_and_preprocessed_input_batch: Dict[str, spec.Tensor],
-      model_state: spec.ModelAuxiliaryState,
-      mode: spec.ForwardPassMode,
-      rng: spec.RandomState,
-      update_batch_norm: bool,
-      model: nn.Module) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     variables = {'params': params, **model_state}
     inputs, input_paddings = augmented_and_preprocessed_input_batch['inputs']
     is_train_mode = mode == spec.ForwardPassMode.TRAIN
     if update_batch_norm or is_train_mode:
-      (logits, logit_paddings), new_model_state = model.apply(
+      (logits, logit_paddings), new_model_state = self._model.apply(
           variables,
           inputs,
           input_paddings,
@@ -101,7 +85,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
           mutable=['batch_stats'])
       return (logits, logit_paddings), new_model_state
     else:
-      logits, logit_paddings = model.apply(
+      logits, logit_paddings = self._model.apply(
           variables,
           inputs,
           input_paddings,
@@ -222,8 +206,6 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
         model_state,
         spec.ForwardPassMode.EVAL,
         rng,
-        dropout_rate=0.0,
-        aux_dropout_rate=0.0,
         update_batch_norm=False)
 
     decoded, decoded_paddings = self.greedy_decode(logits, logit_paddings)

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/model.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/model.py
@@ -188,7 +188,13 @@ class FeedForwardModule(nn.Module):
         bias=True)
     self.dropout1 = nn.Dropout(p=config.feed_forward_dropout_rate)
     self.linear2 = nn.LazyLinear(out_features=config.encoder_dim, bias=True)
-    self.dropout2 = nn.Dropout(p=config.feed_forward_residual_dropout_rate)
+
+    if config.feed_forward_residual_dropout_rate is None:
+      feed_forward_residual_dropout_rate = 0.1
+    else:
+      feed_forward_residual_dropout_rate = (
+          config.feed_forward_residual_dropout_rate)
+    self.dropout2 = nn.Dropout(p=feed_forward_residual_dropout_rate)
 
   def forward(self, inputs, padding_mask):
     inputs = self.ln(inputs)
@@ -453,7 +459,11 @@ class MultiHeadedSelfAttention(nn.Module):
 
     self.ln = LayerNorm(dim=config.encoder_dim)
     self.self_attention = MHSAwithQS(config)
-    self.dropout = nn.Dropout(p=config.attention_residual_dropout_rate)
+    if config.attention_residual_dropout_rate is None:
+      attention_residual_dropout_rate = 0.1
+    else:
+      attention_residual_dropout_rate = config.attention_residual_dropout_rate
+    self.dropout = nn.Dropout(p=attention_residual_dropout_rate)
 
   def forward(self, outputs, paddings):
     outputs = self.ln(outputs)
@@ -532,7 +542,11 @@ class ConvolutionBlock(nn.Module):
         groups=config.encoder_dim)
     self.bn = BatchNorm(config)
     self.lin3 = nn.Linear(config.encoder_dim, config.encoder_dim)
-    self.dropout = nn.Dropout(p=config.conv_residual_dropout_rate)
+    if config.conv_residual_dropout_rate is None:
+      conv_residual_dropout_rate = 0.0
+    else:
+      conv_residual_dropout_rate = config.conv_residual_dropout_rate
+    self.dropout = nn.Dropout(p=conv_residual_dropout_rate)
 
   def forward(self, inputs, input_paddings):
     inputs = self.ln(inputs)
@@ -592,9 +606,12 @@ class ConformerEncoderDecoder(nn.Module):
         time_masks_per_frame=config.time_masks_per_frame,
         use_dynamic_time_mask_max_frames=config.use_dynamic_time_mask_max_frames
     )
+    if config.input_dropout_rate is None:
+      input_dropout_rate = 0.1
+    else:
+      input_dropout_rate = config.input_dropout_rate
     self.subsample = Subsample(
-        encoder_dim=config.encoder_dim,
-        input_dropout_rate=config.input_dropout_rate)
+        encoder_dim=config.encoder_dim, input_dropout_rate=input_dropout_rate)
     self.conformers = nn.ModuleList(
         [ConformerBlock(config) for _ in range(config.num_encoder_layers)])
 

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -40,9 +40,11 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     torch.random.manual_seed(rng[0])
     # Disable cudnn benchmark to avoid OOM errors.
     torch.backends.cudnn.benchmark = False
-    self._model = conformer_model.ConformerEncoderDecoder(
+    model = conformer_model.ConformerEncoderDecoder(
         conformer_model.ConformerConfig(
-            residual_dropout_rate=dropout_rate,
+            attention_residual_dropout_rate=dropout_rate,
+            feed_forward_residual_dropout_rate=dropout_rate,
+            conv_residual_dropout_rate=dropout_rate,
             input_dropout_rate=aux_dropout_rate))
     self.ctc_loss = torch.nn.CTCLoss(blank=0, reduction='none')
     # Run model once to initialize lazy layers.

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -25,35 +25,25 @@ USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_utils.pytorch_setup()
 MAX_INPUT_LENGTH = 320000
 
 
-def _maybe_update_model_dropout(model,
-                                residual_dropout_rate,
-                                input_dropout_rate):
-  for child in list(model.modules()):
-    # Residual dropout.
-    if (isinstance(child, conformer_model.MultiHeadedSelfAttention) and
-        residual_dropout_rate is not None):
-      child.dropout.p = residual_dropout_rate
-    elif (isinstance(child, conformer_model.ConvolutionBlock) and
-          residual_dropout_rate is not None):
-      child.dropout.p = residual_dropout_rate
-    elif (isinstance(child, conformer_model.FeedForwardModule) and
-          residual_dropout_rate is not None):
-      child.dropout2.p = residual_dropout_rate
-    # Input dropout.
-    elif (isinstance(child, conformer_model.Subsample) and
-          input_dropout_rate is not None):
-      child.dropout.p = input_dropout_rate
-
-
 class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Conformer model init function.
+
+    Here we use dropout_rate as residual_dropout_rate, and aux_dropout_rate as
+    input_dropout_rate.
+    """
     torch.random.manual_seed(rng[0])
     # Disable cudnn benchmark to avoid OOM errors.
     torch.backends.cudnn.benchmark = False
-    model = conformer_model.ConformerEncoderDecoder(
-        conformer_model.ConformerConfig())
-    self._model = model
+    self._model = conformer_model.ConformerEncoderDecoder(
+        conformer_model.ConformerConfig(
+            residual_dropout_rate=dropout_rate,
+            input_dropout_rate=aux_dropout_rate))
     self.ctc_loss = torch.nn.CTCLoss(blank=0, reduction='none')
     # Run model once to initialize lazy layers.
     # Run the initialization in eval mode to disable BN tracking.
@@ -87,23 +77,12 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Conformer model function.
-
-    Here we use dropout_rate as residual_dropout_rate, and aux_dropout_rate as
-    input_dropout_rate.
-    """
     del model_state
     del rng
     del update_batch_norm
 
     model = params
-    _maybe_update_model_dropout(
-        model,
-        residual_dropout_rate=dropout_rate,
-        input_dropout_rate=aux_dropout_rate)
 
     if mode == spec.ForwardPassMode.EVAL:
       model.eval()
@@ -264,7 +243,8 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
         'num_words': torch.tensor(0., device=DEVICE),
     }
     num_batches = int(math.ceil(num_examples / global_batch_size))
-    self.sync_sd(params)
+    if USE_PYTORCH_DDP:
+      self.sync_sd(params)
     for _ in range(num_batches):
       batch = next(self._eval_iters[split])
 
@@ -274,8 +254,6 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
           model_state,
           spec.ForwardPassMode.EVAL,
           model_rng,
-          dropout_rate=0.1,  # Default, unused for eval.
-          aux_dropout_rate=0.1,  # Default, unused for eval.
           update_batch_norm=False)
       decoded, decoded_paddings = self.greedy_decode(logits, logits_padding)
       targets, target_paddings = batch['targets']

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_jax/workload.py
@@ -22,14 +22,24 @@ FLAGS = flags.FLAGS
 class LibriSpeechDeepSpeechWorkload(LibriSpeechConformerWorkload,
                                     BaseDeepspeechLibrispeechWorkload):
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
-    model_cls = getattr(models, 'Deepspeech')
-    model = model_cls(models.DeepspeechConfig())
-    self._model = model
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Deepspeech model init function.
+
+    Here we use dropout_rate as feed_forward_dropout_rate, and aux_dropout_rate
+    as input_dropout_rate.
+    """
+    model_config = models.DeepspeechConfig(
+        feed_forward_dropout_rate=dropout_rate,
+        input_dropout_rate=aux_dropout_rate)
+    self._model = models.Deepspeech(model_config)
     input_shape = [(320000,), (320000,)]
     fake_input_batch = [np.zeros((2, *x), jnp.float32) for x in input_shape]
 
-    model_init_fn = jax.jit(functools.partial(model.init, train=False))
+    model_init_fn = jax.jit(functools.partial(self._model.init, train=False))
 
     params_rng, dropout_rng = jax.random.split(rng, 2)
     variables = model_init_fn({'params': params_rng, 'dropout': dropout_rng},
@@ -45,30 +55,3 @@ class LibriSpeechDeepSpeechWorkload(LibriSpeechConformerWorkload,
 
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     pass
-
-  def model_fn(
-      self,
-      params: spec.ParameterContainer,
-      augmented_and_preprocessed_input_batch: Dict[str, spec.Tensor],
-      model_state: spec.ModelAuxiliaryState,
-      mode: spec.ForwardPassMode,
-      rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
-      update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Deepspeech model function.
-
-    Here we use dropout_rate as feed_forward_dropout_rate, and aux_dropout_rate
-    as input_dropout_rate.
-    """
-    model_config = models.DeepspeechConfig(
-        feed_forward_dropout_rate=dropout_rate,
-        input_dropout_rate=aux_dropout_rate)
-    model = models.Deepspeech(model_config)
-    return self._model_fn(params,
-                          augmented_and_preprocessed_input_batch,
-                          model_state,
-                          mode,
-                          rng,
-                          update_batch_norm,
-                          model)

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/model.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/model.py
@@ -5,7 +5,7 @@ https://github.com/google/init2winit/blob/master/init2winit/model_lib/conformer.
 
 from dataclasses import dataclass
 import functools
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 from torch import nn
@@ -37,8 +37,10 @@ class DeepspeechConfig:
   use_dynamic_time_mask_max_frames: bool = True
   batch_norm_momentum: float = 0.999
   batch_norm_epsilon: float = 0.001
-  input_dropout_rate: float = 0.1
-  feed_forward_dropout_rate: float = 0.1
+  # If None, defaults to 0.1.
+  input_dropout_rate: Optional[float] = 0.1
+  # If None, defaults to 0.1.
+  feed_forward_dropout_rate: Optional[float] = 0.1
   enable_residual_connections: bool = True
   enable_decoder_layer_norm: bool = True
   bidirectional: bool = True
@@ -70,10 +72,8 @@ class Subsample(nn.Module):
   def __init__(self, config: DeepspeechConfig):
     super().__init__()
     encoder_dim = config.encoder_dim
-    input_dropout_rate = config.input_dropout_rate
 
     self.encoder_dim = encoder_dim
-    self.input_dropout_rate = input_dropout_rate
 
     self.conv1 = Conv2dSubsampling(
         input_channels=1, output_channels=encoder_dim)
@@ -82,7 +82,11 @@ class Subsample(nn.Module):
 
     self.lin = nn.LazyLinear(out_features=self.encoder_dim, bias=True)
 
-    self.dropout = nn.Dropout(p=self.input_dropout_rate)
+    if config.input_dropout_rate is None:
+      input_dropout_rate = 0.1
+    else:
+      input_dropout_rate = config.input_dropout_rate
+    self.dropout = nn.Dropout(p=input_dropout_rate)
 
   def forward(self, inputs, input_paddings):
     output_paddings = input_paddings
@@ -186,7 +190,11 @@ class FeedForwardModule(nn.Module):
         batch_norm_momentum=config.batch_norm_momentum,
         batch_norm_epsilon=config.batch_norm_epsilon)
     self.lin = nn.LazyLinear(out_features=config.encoder_dim, bias=True)
-    self.dropout = nn.Dropout(p=config.feed_forward_dropout_rate)
+    if config.feed_forward_dropout_rate is None:
+      feed_forward_dropout_rate = 0.1
+    else:
+      feed_forward_dropout_rate = config.feed_forward_dropout_rate
+    self.dropout = nn.Dropout(p=feed_forward_dropout_rate)
 
   def forward(self, inputs, input_paddings):
     padding_mask = (1 - input_paddings)[:, :, None]

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/workload.py
@@ -34,7 +34,7 @@ class LibriSpeechDeepSpeechWorkload(LibriSpeechConformerWorkload):
     """
     torch.random.manual_seed(rng[0])
     torch.backends.cudnn.benchmark = False
-    self._model = DeepspeechEncoderDecoder(
+    model = DeepspeechEncoderDecoder(
         DeepspeechConfig(
             feed_forward_dropout_rate=dropout_rate,
             input_dropout_rate=aux_dropout_rate))
@@ -43,16 +43,16 @@ class LibriSpeechDeepSpeechWorkload(LibriSpeechConformerWorkload):
     t = MAX_INPUT_LENGTH
     wave = torch.randn((2, t))
     pad = torch.zeros_like(wave)
-    _ = self._model(wave, pad)
-    initialize(self._model)
+    _ = model(wave, pad)
+    initialize(model)
 
-    self._param_shapes = param_utils.pytorch_param_shapes(self._model)
+    self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
-    self._model.to(DEVICE)
+    model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
-        self._model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(self._model)
-        self._model = DDP(self._model, device_ids=[RANK], output_device=RANK)
+        model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+        model = DDP(model, device_ids=[RANK], output_device=RANK)
       else:
-        self._model = torch.nn.DataParallel(self._model)
-    return self._model, None
+        model = torch.nn.DataParallel(model)
+    return model, None

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -115,7 +115,14 @@ class MnistWorkload(BaseMnistWorkload):
           'targets': batch['targets'].to(DEVICE, non_blocking=True),
       }
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """Dropout is unused."""
+    del dropout_rate
+    del aux_dropout_rate
     torch.random.manual_seed(rng[0])
     model = _Model()
     self._param_shapes = param_utils.pytorch_param_shapes(model)
@@ -135,14 +142,9 @@ class MnistWorkload(BaseMnistWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Dropout is unused."""
     del model_state
     del rng
-    del dropout_rate
-    del aux_dropout_rate
     del update_batch_norm
 
     model = params
@@ -190,8 +192,6 @@ class MnistWorkload(BaseMnistWorkload):
         model_state,
         spec.ForwardPassMode.EVAL,
         rng,
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=False)
     _, predicted = torch.max(logits.data, 1)
     # Number of correct predictions.

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_jax/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_jax/workload.py
@@ -17,10 +17,16 @@ from algorithmic_efficiency.workloads.ogbg.workload import BaseOgbgWorkload
 
 class OgbgWorkload(BaseOgbgWorkload):
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """aux_dropout_rate is unused."""
+    del aux_dropout_rate
     rng, params_rng, dropout_rng = jax.random.split(rng, 3)
-    model = models.GNN(self._num_outputs)
-    init_fn = jax.jit(functools.partial(model.init, train=False))
+    self._model = models.GNN(self._num_outputs, dropout_rate=dropout_rate)
+    init_fn = jax.jit(functools.partial(self._model.init, train=False))
     fake_batch = jraph.GraphsTuple(
         n_node=jnp.asarray([1]),
         n_edge=jnp.asarray([1]),
@@ -45,24 +51,18 @@ class OgbgWorkload(BaseOgbgWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Get predicted logits from the network for input graphs.
-
-    aux_dropout_rate is unused.
-    """
-    del aux_dropout_rate
+    """Get predicted logits from the network for input graphs."""
     del update_batch_norm  # No BN in the GNN model.
     if model_state is not None:
       raise ValueError(
           f'Expected model_state to be None, received {model_state}.')
     train = mode == spec.ForwardPassMode.TRAIN
-    model = models.GNN(self._num_outputs, dropout_rate=dropout_rate)
-    logits = model.apply({'params': params},
-                         augmented_and_preprocessed_input_batch['inputs'],
-                         rngs={'dropout': rng},
-                         train=train)
+
+    logits = self._model.apply({'params': params},
+                               augmented_and_preprocessed_input_batch['inputs'],
+                               rngs={'dropout': rng},
+                               train=train)
     return logits, None
 
   def _binary_cross_entropy_with_mask(

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
@@ -114,9 +114,15 @@ class OgbgWorkload(BaseOgbgWorkload):
 
       yield batch
 
-  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
+  def init_model_fn(
+      self,
+      rng: spec.RandomState,
+      dropout_rate: Optional[float] = None,
+      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+    """aux_dropout_rate is unused."""
+    del aux_dropout_rate
     torch.random.manual_seed(rng[0])
-    model = GNN(self._num_outputs)
+    model = GNN(num_outputs=self._num_outputs, dropout_rate=dropout_rate)
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
@@ -137,21 +143,14 @@ class OgbgWorkload(BaseOgbgWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      dropout_rate: Optional[float],
-      aux_dropout_rate: Optional[float],
       update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
-    """Get predicted logits from the network for input graphs.
-
-    aux_dropout_rate is unused.
-    """
+    """Get predicted logits from the network for input graphs."""
     del rng
-    del aux_dropout_rate
     del update_batch_norm  # No BN in the GNN model.
     if model_state is not None:
       raise ValueError(
           f'Expected model_state to be None, received {model_state}.')
     model = params
-    pytorch_utils.maybe_update_dropout(model, dropout_rate)
 
     if mode == spec.ForwardPassMode.TRAIN:
       model.train()

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -105,8 +105,6 @@ class BaseOgbgWorkload(spec.Workload):
         model_state,
         spec.ForwardPassMode.EVAL,
         rng,
-        dropout_rate=0.1,  # Unused for eval.
-        aux_dropout_rate=None,
         update_batch_norm=False)
     return self._eval_metric(batch['targets'], logits, batch['weights'])
 

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -131,10 +131,14 @@ class Transformer(nn.Module):
                nhead: int = 16,
                d_hid: int = 4096,
                nlayers: int = 6,
-               dropout_rate: float = 0.1,
-               attention_dropout_rate: float = 0.1,
+               dropout_rate: Optional[float] = 0.1,
+               attention_dropout_rate: Optional[float] = 0.1,
                layer_norm_eps: float = 1e-6):
     super().__init__()
+    if dropout_rate is None:
+      dropout_rate = 0.1
+    if attention_dropout_rate is None:
+      attention_dropout_rate = 0.1
     self.pos_encoder = PositionalEncoding(d_model, dropout_rate)
     self.shared_embedding = nn.Embedding(ntoken, d_model)
     self.encoder = Encoder(d_model,

--- a/reference_algorithms/development_algorithms/cifar/cifar_jax/submission.py
+++ b/reference_algorithms/development_algorithms/cifar/cifar_jax/submission.py
@@ -90,11 +90,9 @@ def pmapped_train_step(workload,
         model_state,
         spec.ForwardPassMode.TRAIN,
         rng,
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=True)
     loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
-    weight_penalty_params = jax.tree_leaves(params)
+    weight_penalty_params = jax.tree_util.tree_leaves(params)
     weight_l2 = sum(jnp.sum(x**2) for x in weight_penalty_params if x.ndim > 1)
     weight_penalty = hyperparameters.l2 * 0.5 * weight_l2
     loss = loss + weight_penalty

--- a/reference_algorithms/development_algorithms/cifar/cifar_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/cifar/cifar_pytorch/submission.py
@@ -79,8 +79,6 @@ def update_params(workload: spec.Workload,
       model_state=model_state,
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
-      dropout_rate=None,
-      aux_dropout_rate=None,
       update_batch_norm=True)
 
   loss = workload.loss_fn(

--- a/reference_algorithms/development_algorithms/criteo1tb/criteo1tb_jax/submission.py
+++ b/reference_algorithms/development_algorithms/criteo1tb/criteo1tb_jax/submission.py
@@ -73,8 +73,6 @@ def pmapped_train_step(workload,
         model_state,
         spec.ForwardPassMode.TRAIN,
         rng,
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=False)
     loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
     return loss, new_model_state

--- a/reference_algorithms/development_algorithms/fastmri/fastmri_jax/submission.py
+++ b/reference_algorithms/development_algorithms/fastmri/fastmri_jax/submission.py
@@ -70,11 +70,6 @@ def pmapped_train_step(workload,
                        batch,
                        rng):
 
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.dropout_rate
-  else:
-    dropout_rate = 0.0
-
   def _loss_fn(params):
     """loss function used for training."""
     logits, _ = workload.model_fn(
@@ -83,11 +78,9 @@ def pmapped_train_step(workload,
         model_state=None,
         mode=spec.ForwardPassMode.TRAIN,
         rng=rng,
-        dropout_rate=dropout_rate,
-        aux_dropout_rate=None,
         update_batch_norm=True)
     loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
-    weight_penalty_params = jax.tree_leaves(params)
+    weight_penalty_params = jax.tree_util.tree_leaves(params)
     weight_l2 = sum(jnp.sum(x**2) for x in weight_penalty_params if x.ndim > 1)
     weight_penalty = hyperparameters.l2 * 0.5 * weight_l2
     loss = loss + weight_penalty

--- a/reference_algorithms/development_algorithms/fastmri/fastmri_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/fastmri/fastmri_pytorch/submission.py
@@ -59,10 +59,6 @@ def update_params(workload: spec.Workload,
   current_model = current_param_container
   current_param_container.train()
   optimizer_state['optimizer'].zero_grad()
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.dropout_rate
-  else:
-    dropout_rate = 0.0
 
   outputs_batch, new_model_state = workload.model_fn(
       params=current_model,
@@ -70,8 +66,6 @@ def update_params(workload: spec.Workload,
       model_state=model_state,
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
-      dropout_rate=dropout_rate,
-      aux_dropout_rate=None,
       update_batch_norm=True)
 
   loss = workload.loss_fn(

--- a/reference_algorithms/development_algorithms/imagenet_resnet/imagenet_jax/submission.py
+++ b/reference_algorithms/development_algorithms/imagenet_resnet/imagenet_jax/submission.py
@@ -86,11 +86,9 @@ def pmapped_train_step(workload,
         model_state,
         spec.ForwardPassMode.TRAIN,
         rng,
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=True)
     loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
-    weight_penalty_params = jax.tree_leaves(variables['params'])
+    weight_penalty_params = jax.tree_util.tree_leaves(variables['params'])
     weight_l2 = sum(jnp.sum(x**2) for x in weight_penalty_params if x.ndim > 1)
     weight_penalty = hyperparameters.l2 * 0.5 * weight_l2
     loss = loss + weight_penalty

--- a/reference_algorithms/development_algorithms/imagenet_resnet/imagenet_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/imagenet_resnet/imagenet_pytorch/submission.py
@@ -82,8 +82,6 @@ def update_params(workload: spec.Workload,
       model_state=model_state,
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
-      dropout_rate=None,
-      aux_dropout_rate=None,
       update_batch_norm=True)
 
   loss = workload.loss_fn(

--- a/reference_algorithms/development_algorithms/imagenet_vit/imagenet_jax/submission.py
+++ b/reference_algorithms/development_algorithms/imagenet_vit/imagenet_jax/submission.py
@@ -78,11 +78,6 @@ def pmapped_train_step(workload,
                        batch,
                        rng):
 
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.input_dropout_rate
-  else:
-    dropout_rate = 0.0  # Default.
-
   def _loss_fn(params):
     """loss function used for training."""
     logits, new_model_state = workload.model_fn(
@@ -91,11 +86,9 @@ def pmapped_train_step(workload,
         model_state,
         spec.ForwardPassMode.TRAIN,
         rng,
-        dropout_rate=dropout_rate,
-        aux_dropout_rate=None,
         update_batch_norm=True)
     loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
-    weight_penalty_params = jax.tree_leaves(params)
+    weight_penalty_params = jax.tree_util.tree_leaves(params)
     weight_l2 = sum(jnp.sum(x**2) for x in weight_penalty_params if x.ndim > 1)
     weight_penalty = hyperparameters.l2 * 0.5 * weight_l2
     loss = loss + weight_penalty

--- a/reference_algorithms/development_algorithms/imagenet_vit/imagenet_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/imagenet_vit/imagenet_pytorch/submission.py
@@ -70,11 +70,6 @@ def update_params(workload: spec.Workload,
   del eval_results
   del global_step
 
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.input_dropout_rate
-  else:
-    dropout_rate = 0.0  # Default.
-
   current_model = current_param_container
   current_param_container.train()
   optimizer_state['optimizer'].zero_grad()
@@ -85,8 +80,6 @@ def update_params(workload: spec.Workload,
       model_state=model_state,
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
-      dropout_rate=dropout_rate,
-      aux_dropout_rate=None,
       update_batch_norm=True)
 
   loss = workload.loss_fn(

--- a/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_jax/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_jax/submission.py
@@ -75,7 +75,7 @@ def l2_regularization(params, l2_decay_rank_threshold):
   Returns:
     weight_l2: the squared l2 norm of all params matching the threshold.
   """
-  weight_penalty_params = jax.tree_leaves(params)
+  weight_penalty_params = jax.tree_util.tree_leaves(params)
   weight_l2 = sum(
       jnp.sum(x**2)
       for x in weight_penalty_params
@@ -99,15 +99,6 @@ def pmapped_train_step(workload,
                        lr):
   optimizer_state.hyperparams['learning_rate'] = lr
 
-  if hasattr(hyperparameters, 'input_dropout_rate'):
-    input_dropout_rate = hyperparameters.input_dropout_rate
-  else:
-    input_dropout_rate = 0.1
-  if hasattr(hyperparameters, 'residual_dropout_rate'):
-    residual_dropout_rate = hyperparameters.residual_dropout_rate
-  else:
-    residual_dropout_rate = 0.1
-
   def _loss_fn(params):
     """loss function used for training."""
     params_rng, dropout_rng = jax.random.split(rng, 2)
@@ -117,8 +108,6 @@ def pmapped_train_step(workload,
         model_state,
         mode=spec.ForwardPassMode.TRAIN,
         rng={'params' : params_rng, 'dropout' : dropout_rng},
-        dropout_rate=residual_dropout_rate,
-        aux_dropout_rate=input_dropout_rate,
         update_batch_norm=True)
 
     loss = workload.loss_fn(batch['targets'], (logits, logit_paddings))

--- a/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_pytorch/submission.py
@@ -60,15 +60,6 @@ def update_params(workload: spec.Workload,
   del model_state
   del loss_type
 
-  if hasattr(hyperparameters, 'input_dropout_rate'):
-    input_dropout_rate = hyperparameters.input_dropout_rate
-  else:
-    input_dropout_rate = 0.1
-  if hasattr(hyperparameters, 'residual_dropout_rate'):
-    residual_dropout_rate = hyperparameters.residual_dropout_rate
-  else:
-    residual_dropout_rate = 0.1
-
   optimizer_state.zero_grad()
   current_model = current_param_container
   (logits, logits_padding), _ = workload.model_fn(
@@ -77,8 +68,6 @@ def update_params(workload: spec.Workload,
       None,
       spec.ForwardPassMode.TRAIN,
       rng,
-      dropout_rate=residual_dropout_rate,
-      aux_dropout_rate=input_dropout_rate,
       update_batch_norm=True)
 
   train_ctc_loss = workload.loss_fn(batch['targets'], (logits, logits_padding))

--- a/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_jax/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_jax/submission.py
@@ -7,6 +7,7 @@ from flax import jax_utils
 import jax
 from jax import lax
 import jax.numpy as jnp
+import numpy as np
 import optax
 
 from algorithmic_efficiency import spec
@@ -18,6 +19,16 @@ def get_batch_size(workload_name):
   # Return the global batch size.
   del workload_name
   return 256
+
+
+def get_learning_rate(step, hyperparams):
+  warmup_steps = hyperparams.warmup_steps
+  if step < warmup_steps:
+    current_lr = (step * hyperparams.base_lr) / warmup_steps
+  else:
+    decay_factor = (1 + np.cos(step / hyperparams.training_steps * np.pi)) * 0.5
+    current_lr = hyperparams.base_lr * decay_factor
+  return current_lr
 
 
 def optimizer(hyperparameters: spec.Hyperparameters, num_train_examples: int):
@@ -64,7 +75,7 @@ def l2_regularization(params, l2_decay_rank_threshold):
   Returns:
     weight_l2: the squared l2 norm of all params matching the threshold.
   """
-  weight_penalty_params = jax.tree_leaves(params)
+  weight_penalty_params = jax.tree_util.tree_leaves(params)
   weight_l2 = sum(
       jnp.sum(x**2)
       for x in weight_penalty_params
@@ -88,15 +99,6 @@ def pmapped_train_step(workload,
                        lr):
   optimizer_state.hyperparams['learning_rate'] = lr
 
-  if hasattr(hyperparameters, 'input_dropout_rate'):
-    input_dropout_rate = hyperparameters.input_dropout_rate
-  else:
-    input_dropout_rate = 0.1
-  if hasattr(hyperparameters, 'feed_forward_dropout_rate'):
-    feed_forward_dropout_rate = hyperparameters.feed_forward_dropout_rate
-  else:
-    feed_forward_dropout_rate = 0.1
-
   def _loss_fn(params):
     """loss function used for training."""
     params_rng, dropout_rng = jax.random.split(rng, 2)
@@ -106,8 +108,6 @@ def pmapped_train_step(workload,
         model_state,
         spec.ForwardPassMode.TRAIN,
         {'params' : params_rng, 'dropout' : dropout_rng},
-        dropout_rate=feed_forward_dropout_rate,
-        aux_dropout_rate=input_dropout_rate,
         update_batch_norm=True)
 
     loss = workload.loss_fn(batch['targets'], (logits, logit_paddings))
@@ -147,7 +147,7 @@ def update_params(workload: spec.Workload,
   del eval_results
   del loss_type
 
-  lr = workload.get_learning_rate(global_step, hyperparameters)
+  lr = get_learning_rate(global_step, hyperparameters)
   optimizer_state, opt_update_fn = optimizer_state
   per_device_rngs = jax.random.split(rng, jax.local_device_count())
   outputs = pmapped_train_step(workload,

--- a/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_pytorch/submission.py
@@ -1,14 +1,29 @@
+"""Training algorithm track submission functions for LibriSpeech."""
 from typing import Dict, Iterator, List, Tuple
 
+import numpy as np
 import torch
 
 from algorithmic_efficiency import spec
 
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+ctc_loss = torch.nn.CTCLoss(blank=0, reduction="none")
+
 
 def get_batch_size(workload_name):
   # Return the global batch size.
-  batch_sizes = {'ogbg': 32768}
-  return batch_sizes[workload_name]
+  del workload_name
+  return 256
+
+
+def get_learning_rate(step, hyperparams):
+  warmup_steps = hyperparams.warmup_steps
+  if step < warmup_steps:
+    current_lr = (step * hyperparams.base_lr) / warmup_steps
+  else:
+    decay_factor = (1 + np.cos(step / hyperparams.training_steps * np.pi)) * 0.5
+    current_lr = hyperparams.base_lr * decay_factor
+  return current_lr
 
 
 def init_optimizer_state(workload: spec.Workload,
@@ -16,16 +31,16 @@ def init_optimizer_state(workload: spec.Workload,
                          model_state: spec.ModelAuxiliaryState,
                          hyperparameters: spec.Hyperparameters,
                          rng: spec.RandomState) -> spec.OptimizerState:
-  """Creates an Adam optimizer."""
   del workload
   del model_state
   del rng
-  optimizer_state = {
-      'optimizer':
-          torch.optim.Adam(
-              model_params.parameters(), lr=hyperparameters.learning_rate)
-  }
-  return optimizer_state
+  optimizer = torch.optim.AdamW(
+      params=model_params.parameters(),
+      lr=0.0,
+      betas=(hyperparameters.beta1, hyperparameters.beta2),
+      eps=hyperparameters.epsilon,
+      weight_decay=hyperparameters.weight_decay)
+  return optimizer
 
 
 def update_params(workload: spec.Workload,
@@ -39,34 +54,34 @@ def update_params(workload: spec.Workload,
                   eval_results: List[Tuple[int, float]],
                   global_step: int,
                   rng: spec.RandomState) -> spec.UpdateReturn:
-  """Return (updated_optimizer_state, updated_params, updated_model_state)."""
+  """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
-  del loss_type
   del eval_results
-  del global_step
+  del model_state
+  del loss_type
 
+  optimizer_state.zero_grad()
   current_model = current_param_container
-  current_model.train()
-  optimizer_state['optimizer'].zero_grad()
-
-  logits, new_model_state = workload.model_fn(
-      params=current_model,
-      augmented_and_preprocessed_input_batch=batch,
-      model_state=model_state,
-      mode=spec.ForwardPassMode.TRAIN,
-      rng=rng,
+  (logits, logits_padding), _ = workload.model_fn(
+      current_model,
+      batch,
+      None,
+      spec.ForwardPassMode.TRAIN,
+      rng,
       update_batch_norm=True)
 
-  mask = batch['weights']
-  per_example_losses = workload.loss_fn(batch['targets'], logits, mask)
-  loss = torch.where(mask, per_example_losses, 0).sum() / mask.sum()
+  train_ctc_loss = workload.loss_fn(batch['targets'], (logits, logits_padding))
+  train_ctc_loss.backward()
+  grad_clip = hyperparameters.grad_clip
+  for g in optimizer_state.param_groups:
+    g['lr'] = get_learning_rate(global_step, hyperparameters)
+  torch.nn.utils.clip_grad_norm_(current_model.parameters(), max_norm=grad_clip)
+  optimizer_state.step()
+  return optimizer_state, current_param_container, None
 
-  loss.backward()
-  optimizer_state['optimizer'].step()
 
-  return optimizer_state, current_param_container, new_model_state
-
-
+# Not allowed to update the model parameters, hyperparameters, global step, or
+# optimzier state.
 def data_selection(workload: spec.Workload,
                    input_queue: Iterator[Dict[str, spec.Tensor]],
                    optimizer_state: spec.OptimizerState,
@@ -77,7 +92,7 @@ def data_selection(workload: spec.Workload,
                    rng: spec.RandomState) -> Dict[str, spec.Tensor]:
   """Select data from the infinitely repeating, pre-shuffled input queue.
 
-  Each element of the queue is a batch of training examples and labels.
+    Each element of the queue is a batch of training examples and labels.
   """
   del workload
   del optimizer_state

--- a/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_pytorch/submission.py
@@ -6,9 +6,6 @@ import torch
 
 from algorithmic_efficiency import spec
 
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-ctc_loss = torch.nn.CTCLoss(blank=0, reduction="none")
-
 
 def get_batch_size(workload_name):
   # Return the global batch size.

--- a/reference_algorithms/development_algorithms/mnist/mnist_jax/submission.py
+++ b/reference_algorithms/development_algorithms/mnist/mnist_jax/submission.py
@@ -61,8 +61,6 @@ def pmapped_update_params(workload: spec.Workload,
         model_state,
         spec.ForwardPassMode.TRAIN,
         rng,
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=True)
     loss = workload.loss_fn(batch['targets'], logits_batch)
     return jnp.mean(loss), new_model_state

--- a/reference_algorithms/development_algorithms/mnist/mnist_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/mnist/mnist_pytorch/submission.py
@@ -57,8 +57,6 @@ def update_params(workload: spec.Workload,
       model_state=model_state,
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
-      dropout_rate=None,
-      aux_dropout_rate=None,
       update_batch_norm=True)
 
   loss = workload.loss_fn(

--- a/reference_algorithms/development_algorithms/ogbg/ogbg_jax/submission.py
+++ b/reference_algorithms/development_algorithms/ogbg/ogbg_jax/submission.py
@@ -40,10 +40,6 @@ def train_step(workload,
                hyperparameters,
                batch,
                rng):
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.dropout_rate
-  else:
-    dropout_rate = 0.1
 
   def loss_fn(params):
     logits_batch, new_model_state  = workload.model_fn(
@@ -52,8 +48,6 @@ def train_step(workload,
         model_state,
         spec.ForwardPassMode.TRAIN,
         rng,
-        dropout_rate=dropout_rate,
-        aux_dropout_rate=None,
         update_batch_norm=True)
     mask_batch = batch['weights']
     per_example_losses = workload.loss_fn(batch['targets'],

--- a/reference_algorithms/development_algorithms/wmt/tuning_search_space.json
+++ b/reference_algorithms/development_algorithms/wmt/tuning_search_space.json
@@ -2,7 +2,7 @@
     "learning_rate": {"feasible_points": [0.0625]},
     "one_minus_beta_1": {"feasible_points": [0.1]},
     "dropout_rate": {"feasible_points": [0.1]},
-    "attention_dropout_rate": {"feasible_points": [0.1]},
+    "aux_dropout_rate": {"feasible_points": [0.1]},
     "epsilon": {"feasible_points": [1e-9]}
 }
 

--- a/reference_algorithms/development_algorithms/wmt/wmt_jax/submission.py
+++ b/reference_algorithms/development_algorithms/wmt/wmt_jax/submission.py
@@ -108,14 +108,6 @@ def pmapped_train_step(workload,
                        dropout_rng,
                        hyperparameters):
   """Perform a single training step."""
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.dropout_rate
-  else:
-    dropout_rate = 0.1
-  if hasattr(hyperparameters, 'attention_dropout_rate'):
-    attention_dropout_rate = hyperparameters.attention_dropout_rate
-  else:
-    attention_dropout_rate = 0.1
 
   def _loss_fn(params):
     """Loss function used for training."""
@@ -125,8 +117,6 @@ def pmapped_train_step(workload,
         model_state=None,
         mode=spec.ForwardPassMode.TRAIN,
         rng=dropout_rng,
-        dropout_rate=dropout_rate,
-        aux_dropout_rate=attention_dropout_rate,
         update_batch_norm=False)
     targets = batch['targets']
     weights = jnp.where(targets > 0, 1.0, 0.0)

--- a/reference_algorithms/development_algorithms/wmt/wmt_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/wmt/wmt_pytorch/submission.py
@@ -104,15 +104,6 @@ def update_params(workload: spec.Workload,
   del eval_results
   del loss_type
 
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.dropout_rate
-  else:
-    dropout_rate = 0.1
-  if hasattr(hyperparameters, 'attention_dropout_rate'):
-    attention_dropout_rate = hyperparameters.attention_dropout_rate
-  else:
-    attention_dropout_rate = 0.1
-
   current_model = current_param_container
   current_param_container.train()
   optimizer = optimizer_state['optimizer']
@@ -124,8 +115,6 @@ def update_params(workload: spec.Workload,
       model_state=model_state,
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
-      dropout_rate=dropout_rate,
-      aux_dropout_rate=attention_dropout_rate,
       update_batch_norm=False)
 
   targets = batch['targets']

--- a/reference_algorithms/target_setting_algorithms/jax_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/jax_submission_base.py
@@ -35,9 +35,6 @@ def pmapped_train_step(workload,
         model_state,
         spec.ForwardPassMode.TRAIN,
         rng,
-        # There was no dropout rate tuning in the target setting runs.
-        dropout_rate=None,
-        aux_dropout_rate=None,
         update_batch_norm=True)
     loss = jnp.mean(
         workload.loss_fn(
@@ -53,7 +50,7 @@ def pmapped_train_step(workload,
   grad = lax.pmean(grad, axis_name='batch')
 
   if grad_clip is not None:
-    grad_norm = jnp.sqrt(sum(jnp.sum(g**2) for g in jax.tree_leaves(grad)))
+    grad_norm = jnp.sqrt(sum(jnp.sum(g**2) for g in jax.tree_util.tree_leaves(grad)))
     grad_scaling_factor = grad_clip / (grad_norm + _GRAD_CLIP_EPS)
     grad_scaling_factor = jax.lax.clamp(min=0.0, x=grad_scaling_factor, max=1.0)
     grad = jax.tree_map(lambda x: x * grad_scaling_factor, grad)

--- a/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
@@ -34,9 +34,6 @@ def update_params(workload: spec.Workload,
       model_state=model_state,
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
-      # There was no dropout rate tuning in the target setting runs.
-      dropout_rate=None,
-      aux_dropout_rate=None,
       update_batch_norm=True)
 
   label_smoothing = (

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -211,7 +211,14 @@ def train_once(
         global_batch_size=global_batch_size)
   logging.info('Initializing model.')
   with profiler.profile('Initializing model'):
-    model_params, model_state = workload.init_model_fn(model_init_rng)
+    dropout_rate = None
+    aux_dropout_rate = None
+    if hasattr(hyperparameters, 'dropout_rate'):
+      dropout_rate = hyperparameters.dropout_rate
+    if hasattr(hyperparameters, 'aux_dropout_rate'):
+      aux_dropout_rate = hyperparameters.aux_dropout_rate
+    model_params, model_state = workload.init_model_fn(
+        model_init_rng, dropout_rate, aux_dropout_rate)
   logging.info('Initializing optimizer.')
   with profiler.profile('Initializing optimizer'):
     optimizer_state = init_optimizer_state(workload,

--- a/tests/reference_algorithm_tests.py
+++ b/tests/reference_algorithm_tests.py
@@ -128,6 +128,7 @@ def _make_one_batch_workload(workload_class,
     def __init__(self):
       super().__init__()
       self.summary_writer = None
+      self.metrics_logger = None
       if 'librispeech' in workload_name:
         self.metrics_bundle = _FakeMetricsBundle()
         self.tokenizer = _FakeTokenizer()
@@ -398,9 +399,21 @@ class ReferenceSubmissionTest(absltest.TestCase):
       references_dir = (
           f'{repo_location}/reference_algorithms/development_algorithms')
       for workload_name in os.listdir(references_dir):
+        if workload_name in [
+            'imagenet_resnet',
+            'criteo1tb',
+            'imagenet_vit',
+            'cifar',
+            'mnist',
+            'librispeech_deepspeech',
+            'ogbg'
+        ]:  # DO NOT SUBMIT
+          continue
         for framework in ['jax', 'pytorch']:
           if framework == 'pytorch':
             pytorch_utils.pytorch_init(USE_PYTORCH_DDP, RANK, profiler)
+          elif workload_name == 'wmt':
+            continue
           search_space_path, submission_path = _make_paths(
               repo_location, framework, workload_name)
           if search_space_path is None:

--- a/tests/reference_algorithm_tests.py
+++ b/tests/reference_algorithm_tests.py
@@ -399,21 +399,9 @@ class ReferenceSubmissionTest(absltest.TestCase):
       references_dir = (
           f'{repo_location}/reference_algorithms/development_algorithms')
       for workload_name in os.listdir(references_dir):
-        if workload_name in [
-            'imagenet_resnet',
-            'criteo1tb',
-            'imagenet_vit',
-            'cifar',
-            'mnist',
-            'librispeech_deepspeech',
-            'ogbg'
-        ]:  # DO NOT SUBMIT
-          continue
         for framework in ['jax', 'pytorch']:
           if framework == 'pytorch':
             pytorch_utils.pytorch_init(USE_PYTORCH_DDP, RANK, profiler)
-          elif workload_name == 'wmt':
-            continue
           search_space_path, submission_path = _make_paths(
               repo_location, framework, workload_name)
           if search_space_path is None:

--- a/tests/test_num_params.py
+++ b/tests/test_num_params.py
@@ -59,7 +59,7 @@ WORKLOADS = [
 def test_matching_num_params(workload):
   jax_model, pytorch_model = get_models(workload)
   # Count parameters of both models.
-  num_jax_params = sum(x.size for x in jax.tree_leaves(jax_model))
+  num_jax_params = sum(x.size for x in jax.tree_util.tree_leaves(jax_model))
   num_pytorch_params = sum(
       p.numel() for p in pytorch_model.parameters() if p.requires_grad)
   assert num_jax_params == num_pytorch_params

--- a/tests/test_param_shapes.py
+++ b/tests/test_param_shapes.py
@@ -55,8 +55,10 @@ WORKLOADS = [
 def test_param_shapes(workload):
   jax_workload, pytorch_workload = get_workload(workload)
   # Compare number of parameter tensors of both models.
-  jax_param_shapes = jax.tree_leaves(jax_workload.param_shapes.unfreeze())
-  pytorch_param_shapes = jax.tree_leaves(pytorch_workload.param_shapes)
+  jax_param_shapes = jax.tree_util.tree_leaves(
+      jax_workload.param_shapes.unfreeze())
+  pytorch_param_shapes = jax.tree_util.tree_leaves(
+      pytorch_workload.param_shapes)
   assert len(jax_param_shapes) == len(pytorch_param_shapes)
   # Check if total number of params deduced from shapes match.
   num_jax_params = 0

--- a/tests/test_param_types.py
+++ b/tests/test_param_types.py
@@ -50,8 +50,9 @@ WORKLOADS = [
 def test_param_types(workload):
   jax_workload, pytorch_workload = get_workload(workload)
   # Compare number of parameter tensors of both models.
-  jax_param_types = jax.tree_leaves(jax_workload.model_params_types)
-  pytorch_param_types = jax.tree_leaves(pytorch_workload.model_params_types)
+  jax_param_types = jax.tree_util.tree_leaves(jax_workload.model_params_types)
+  pytorch_param_types = jax.tree_util.tree_leaves(
+      pytorch_workload.model_params_types)
   assert len(jax_param_types) == len(pytorch_param_types)
 
   def count_param_types(param_types):

--- a/tests/workloads/imagenet_resnet/imagenet_jax/workload_test.py
+++ b/tests/workloads/imagenet_resnet/imagenet_jax/workload_test.py
@@ -28,22 +28,20 @@ class ModelsTest(absltest.TestCase):
     first_input_batch = jax.random.normal(data_rngs[0], shape=input_shape)
     expected_logits_shape = (jax.local_device_count(), batch_size, 1000)
 
-    # static_broadcasted_argnums=(3, 7) will recompile each time we call it in
-    # this file because we call it with a different combination of those two
+    # static_broadcasted_argnums=(3, 5) will recompile each time we call it in
+    # this function because we call it with a different combination of those two
     # args each time. Can't call with kwargs.
     pmapped_model_fn = jax.pmap(
         workload.model_fn,
         axis_name='batch',
-        in_axes=(0, 0, 0, None, None, None, None, None),
-        static_broadcasted_argnums=(3, 7))
+        in_axes=(0, 0, 0, None, None, None),
+        static_broadcasted_argnums=(3, 5))
     logits, updated_batch_stats = pmapped_model_fn(
         model_params,
         {'inputs': first_input_batch},
         batch_stats,
         spec.ForwardPassMode.TRAIN,
         rng,
-        None,
-        None,
         True)
     self.assertEqual(logits.shape, expected_logits_shape)
     # Test that batch stats are updated.
@@ -58,8 +56,6 @@ class ModelsTest(absltest.TestCase):
         updated_batch_stats,
         spec.ForwardPassMode.TRAIN,
         rng,
-        None,
-        None,
         False)
     self.assertEqual(
         _pytree_total_diff(same_batch_stats, updated_batch_stats), 0.0)
@@ -71,8 +67,6 @@ class ModelsTest(absltest.TestCase):
         batch_stats,
         spec.ForwardPassMode.EVAL,
         rng,
-        None,
-        None,
         False)
     self.assertEqual(logits.shape, expected_logits_shape)
 

--- a/tests/workloads/imagenet_resnet/imagenet_jax/workload_test.py
+++ b/tests/workloads/imagenet_resnet/imagenet_jax/workload_test.py
@@ -11,7 +11,7 @@ from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax.workload impo
 
 def _pytree_total_diff(pytree_a, pytree_b):
   pytree_diff = jax.tree_map(lambda a, b: jnp.sum(a - b), pytree_a, pytree_b)
-  pytree_diff = jax.tree_leaves(pytree_diff)
+  pytree_diff = jax.tree_util.tree_leaves(pytree_diff)
   return jnp.sum(jnp.array(pytree_diff))
 
 


### PR DESCRIPTION
- Cleans up a lot of dropout related pains, including the slowdowns from having it in `model_fn`.
- Adds support for setting dropout to None in speech pytorch models
- Copies conformer pytorch reference submission into a deepspeech one for use in `tests/reference_algorithm_tests.py`.