### PR TITLE
RandAug Implementation for ViT

### DIFF
--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -278,7 +278,7 @@ class PassThroughMetricLogger(object):
   def append_scalar_metrics(self,
                             metrics: dict,
                             global_step: int,
-                            preemption_count: int) -> None:
+                            preemption_count: int = None) -> None:
     pass
 
   def finish(self) -> None:

--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -236,7 +236,7 @@ class MetricLogger(object):
   def append_scalar_metrics(self,
                             metrics: dict,
                             global_step: int,
-                            preemption_count: int = None) -> None:
+                            preemption_count: Optional[int] = None) -> None:
     metrics['global_step'] = global_step
     if preemption_count is not None:
       metrics['preemption_count'] = preemption_count
@@ -278,7 +278,7 @@ class PassThroughMetricLogger(object):
   def append_scalar_metrics(self,
                             metrics: dict,
                             global_step: int,
-                            preemption_count: int = None) -> None:
+                            preemption_count: Optional[int] = None) -> None:
     pass
 
   def finish(self) -> None:

--- a/algorithmic_efficiency/pytorch_utils.py
+++ b/algorithmic_efficiency/pytorch_utils.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from typing import Tuple
 
@@ -45,7 +46,7 @@ def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler) -> None:
 
       logging.info = logging_pass
     # initialize the process group
-    dist.init_process_group('nccl')
+    dist.init_process_group('nccl', timeout=datetime.timedelta(seconds=3600))
 
 
 # torch.nn.functional.dropout will not be affected by this function.

--- a/algorithmic_efficiency/pytorch_utils.py
+++ b/algorithmic_efficiency/pytorch_utils.py
@@ -18,8 +18,7 @@ def pytorch_setup() -> Tuple[bool, int, torch.device, int]:
   return use_pytorch_ddp, rank, device, n_gpus
 
 
-def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler,
-                 device) -> None:
+def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler) -> None:
   # Make sure no GPU memory is preallocated to Jax.
   os.environ['XLA_PYTHON_CLIENT_PREALLOCATE'] = 'false'
   # Only use CPU for Jax to avoid memory issues.
@@ -36,7 +35,7 @@ def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler,
       tf.config.threading.set_intra_op_parallelism_threads(1)
       tf.config.threading.set_inter_op_parallelism_threads(1)
 
-    torch.cuda.set_device(device)
+    torch.cuda.set_device(rank)
     profiler.set_local_rank(rank)
     # only log once (for local rank == 0)
     if rank != 0:

--- a/algorithmic_efficiency/pytorch_utils.py
+++ b/algorithmic_efficiency/pytorch_utils.py
@@ -18,7 +18,7 @@ def pytorch_setup() -> Tuple[bool, int, torch.device, int]:
   return use_pytorch_ddp, rank, device, n_gpus
 
 
-def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler) -> None:
+def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler, device) -> None:
   # Make sure no GPU memory is preallocated to Jax.
   os.environ['XLA_PYTHON_CLIENT_PREALLOCATE'] = 'false'
   # Only use CPU for Jax to avoid memory issues.
@@ -35,7 +35,7 @@ def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler) -> None:
       tf.config.threading.set_intra_op_parallelism_threads(1)
       tf.config.threading.set_inter_op_parallelism_threads(1)
 
-    torch.cuda.set_device(rank)
+    torch.cuda.set_device(device)
     profiler.set_local_rank(rank)
     # only log once (for local rank == 0)
     if rank != 0:

--- a/algorithmic_efficiency/pytorch_utils.py
+++ b/algorithmic_efficiency/pytorch_utils.py
@@ -18,7 +18,8 @@ def pytorch_setup() -> Tuple[bool, int, torch.device, int]:
   return use_pytorch_ddp, rank, device, n_gpus
 
 
-def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler, device) -> None:
+def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler,
+                 device) -> None:
   # Make sure no GPU memory is preallocated to Jax.
   os.environ['XLA_PYTHON_CLIENT_PREALLOCATE'] = 'false'
   # Only use CPU for Jax to avoid memory issues.

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 import tensorflow_probability as tfp
 
-from algorithmic_efficiency import autoaugment_utils
+from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax import randaugment
 from algorithmic_efficiency import data_utils
 
 IMAGE_SIZE = 224
@@ -175,7 +175,7 @@ def preprocess_for_train(image_bytes,
 
   if use_randaug:
     image = tf.cast(tf.clip_by_value(image, 0, 255), tf.uint8)
-    image = autoaugment_utils.distort_image_with_randaugment(
+    image = randaugment.distort_image_with_randaugment(
         image, randaug_num_layers, randaug_magnitude, rngs[2])
   image = tf.cast(image, tf.float32)
   image = normalize_image(image, mean_rgb, stddev_rgb)
@@ -343,7 +343,8 @@ def create_input_iter(split,
                       cache,
                       repeat_final_dataset,
                       use_mixup,
-                      mixup_alpha):
+                      mixup_alpha,
+                      use_randaug):
   ds = create_split(
       split,
       dataset_builder,
@@ -359,7 +360,8 @@ def create_input_iter(split,
       aspect_ratio_range=aspect_ratio_range,
       area_range=area_range,
       use_mixup=use_mixup,
-      mixup_alpha=mixup_alpha)
+      mixup_alpha=mixup_alpha,
+      use_randaug=use_randaug)
   it = map(data_utils.shard_numpy_ds, ds)
 
   # Note(Dan S): On a Nvidia 2080 Ti GPU, this increased GPU utilization by 10%.

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -10,8 +10,9 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 import tensorflow_probability as tfp
 
-from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax import randaugment
 from algorithmic_efficiency import data_utils
+from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax import \
+    randaugment
 
 IMAGE_SIZE = 224
 RESIZE_SIZE = 256
@@ -175,8 +176,10 @@ def preprocess_for_train(image_bytes,
 
   if use_randaug:
     image = tf.cast(tf.clip_by_value(image, 0, 255), tf.uint8)
-    image = randaugment.distort_image_with_randaugment(
-        image, randaug_num_layers, randaug_magnitude, rngs[2])
+    image = randaugment.distort_image_with_randaugment(image,
+                                                       randaug_num_layers,
+                                                       randaug_magnitude,
+                                                       rngs[2])
   image = tf.cast(image, tf.float32)
   image = normalize_image(image, mean_rgb, stddev_rgb)
   image = tf.image.convert_image_dtype(image, dtype=dtype)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
@@ -1,5 +1,4 @@
 """Utilities for RandAugmentation.
-
 Adapted from:
 https://github.com/google/init2winit/blob/master/init2winit/dataset_lib/autoaugment.py
 """
@@ -105,17 +104,12 @@ def cutout(image, pad_size, replace=0):
 
 
 def solarize(image, threshold=128):
-  # For each pixel in the image, select the pixel
-  # if the value is less than the threshold.
-  # Otherwise, subtract 255 from the pixel.
+  """Solarize the input image(s)."""
   return tf.where(image < threshold, image, 255 - image)
 
 
 def solarize_add(image, addition=0, threshold=128):
-  # For each pixel in the image less than threshold
-  # we add 'addition' amount to it and then clip the
-  # pixel value to be between 0 and 255. The value
-  # of 'addition' is between -128 and 128.
+  """Additive solarize the input image(s)."""
   added_image = tf.cast(image, tf.int64) + addition
   added_image = tf.cast(tf.clip_by_value(added_image, 0, 255), tf.uint8)
   return tf.where(image < threshold, added_image, image)
@@ -267,7 +261,7 @@ def sharpness(image, factor):
     # Some augmentation that uses depth-wise conv will cause crashing when
     # training on GPU.
     degenerate = tf.nn.depthwise_conv2d(
-        image, kernel, strides, padding='VALID', rate=[1, 1])
+        image, kernel, strides, padding='VALID', dilations=[1, 1])
   degenerate = tf.clip_by_value(degenerate, 0.0, 255.0)
   degenerate = tf.squeeze(tf.cast(degenerate, tf.uint8), [0])
 
@@ -357,7 +351,7 @@ def unwrap(image, replace):
   flattened_image = tf.reshape(image, [-1, image_shape[2]])
 
   # Find all pixels where the last channel is zero.
-  alpha_channel = flattened_image[:, 3]
+  alpha_channel = tf.expand_dims(flattened_image[..., 3], axis=-1)
 
   replace = tf.concat([replace, tf.ones([1], image.dtype)], 0)
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
@@ -17,16 +17,19 @@ _MAX_LEVEL = 10.
 
 def blend(image1, image2, factor):
   """Blend image1 and image2 using 'factor'.
+
   Factor can be above 0.0.  A value of 0.0 means only image1 is used.
   A value of 1.0 means only image2 is used.  A value between 0.0 and
   1.0 means we linearly interpolate the pixel values between the two
   images.  A value greater than 1.0 "extrapolates" the difference
   between the two pixel values, and we clip the results to values
   between 0 and 255.
+
   Args:
     image1: An image Tensor of type uint8.
     image2: An image Tensor of type uint8.
     factor: A floating point value above 0.0.
+
   Returns:
     A blended image Tensor of type uint8.
   """
@@ -49,18 +52,18 @@ def blend(image1, image2, factor):
     # Interpolation means we always stay within 0 and 255.
     return tf.cast(temp, tf.uint8)
 
-  # Extrapolate:
-  #
-  # We need to clip and then cast.
+  # Extrapolate
   return tf.cast(tf.clip_by_value(temp, 0.0, 255.0), tf.uint8)
 
 
 def cutout(image, pad_size, replace=0):
   """Apply cutout (https://arxiv.org/abs/1708.04552) to image.
+
   This operation applies a (2*pad_size x 2*pad_size) mask of zeros to
   a random location within `img`. The pixel values filled in will be of the
   value `replace`. The located where the mask will be applied is randomly
   chosen uniformly over the whole image.
+
   Args:
     image: An image Tensor of type uint8.
     pad_size: Specifies how big the zero mask that will be generated is that
@@ -68,6 +71,7 @@ def cutout(image, pad_size, replace=0):
       (2*pad_size x 2*pad_size).
     replace: What pixel value to fill in the image in the area that has
       the cutout mask applied to it.
+
   Returns:
     An image Tensor that is of type uint8.
   """
@@ -153,6 +157,7 @@ def posterize(image, bits):
 
 def rotate(image, degrees, replace):
   """Rotates the image by degrees either clockwise or counterclockwise.
+
   Args:
     image: An image Tensor of type uint8.
     degrees: Float, a scalar angle in degrees to rotate all images by. If
@@ -160,6 +165,7 @@ def rotate(image, degrees, replace):
       be rotated counterclockwise.
     replace: A one or three value 1D tensor to fill empty pixels caused by
       the rotate operation.
+
   Returns:
     The rotated version of image.
   """
@@ -210,8 +216,10 @@ def shear_y(image, level, replace):
 
 def autocontrast(image):
   """Implements Autocontrast function from PIL using TF ops.
+
   Args:
     image: A 3D uint8 tensor.
+
   Returns:
     The image after it has had autocontrast applied to it and will be of type
     uint8.
@@ -335,15 +343,18 @@ def wrap(image):
 
 def unwrap(image, replace):
   """Unwraps an image produced by wrap.
+
   Where there is a 0 in the last channel for every spatial position,
   the rest of the three channels in that spatial dimension are grayed
   (set to 128).  Operations like translate and shear on a wrapped
   Tensor will leave 0s in empty locations.  Some transformations look
   at the intensity of values to do preprocessing, and we want these
   empty pixels to assume the 'average' value, rather than pure black.
+
   Args:
     image: A 3D Image Tensor with 4 channels.
     replace: A one or three value 1D tensor to fill empty pixels.
+
   Returns:
     image: A 3D image Tensor with 3 channels.
   """
@@ -496,6 +507,7 @@ def _parse_policy_info(name,
 
 def distort_image_with_randaugment(image, num_layers, magnitude, key):
   """Applies the RandAugment policy to `image`.
+
   RandAugment is from the paper https://arxiv.org/abs/1909.13719,
   Args:
     image: `Tensor` of shape [height, width, 3] representing an image.
@@ -506,6 +518,7 @@ def distort_image_with_randaugment(image, num_layers, magnitude, key):
       Represented as (M) in the paper. Usually best values are in the range
       [5, 30].
     key: an rng key from tf.random.experimental.stateless_fold_in.
+
   Returns:
     The augmented version of `image`.
   """

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
@@ -1,4 +1,5 @@
-"""Utilities for RandAugmentation.
+"""Code for RandAugmentation.
+
 Adapted from:
 https://github.com/google/init2winit/blob/master/init2winit/dataset_lib/autoaugment.py
 """

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -36,7 +36,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
                      global_batch_size: int,
                      cache: Optional[bool] = None,
                      repeat_final_dataset: Optional[bool] = None,
-                     use_mixup: bool = False):
+                     use_mixup: bool = False,
+                     use_randaug: bool = False):
     if split == 'test':
       np_iter = imagenet_v2.get_imagenet_v2_iter(
           data_dir,
@@ -66,7 +67,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         cache=not train if cache is None else cache,
         repeat_final_dataset=repeat_final_dataset,
         use_mixup=use_mixup,
-        mixup_alpha=0.2)
+        mixup_alpha=0.2,
+        use_randaug=use_randaug)
     return ds
 
   def sync_batch_stats(self, model_state):

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
@@ -132,25 +132,24 @@ class RandAugment(torch.nn.Module):
     self.interpolation = interpolation
     self.fill = fill
 
-  def _augmentation_space(self,
-                          num_bins: int) -> Dict[str, Tuple[Tensor, bool]]:
+  def _augmentation_space(self) -> Dict[str, Tuple[Tensor, bool]]:
     return {
         # op_name: (magnitudes, signed)
-        "ShearX": (torch.linspace(0.3, 0.3, num_bins), True),
-        "ShearY": (torch.linspace(0.3, 0.3, num_bins), True),
-        "TranslateX": (torch.linspace(100, 100, num_bins), True),
-        "TranslateY": (torch.linspace(100, 100, num_bins), True),
-        "Rotate": (torch.linspace(30.0, 30.0, num_bins), True),
-        "Brightness": (torch.linspace(0.1, 0.1, num_bins), True),
-        "Color": (torch.linspace(0.1, 0.1, num_bins), True),
-        "Contrast": (torch.linspace(0.1, 0.1, num_bins), True),
-        "Sharpness": (torch.linspace(0.1, 0.1, num_bins), True),
-        "Posterize": (torch.linspace(4, 4, num_bins).int(), False),
-        "Solarize": (torch.linspace(255.0, 255.0, num_bins), False),
-        "SolarizeAdd": (torch.linspace(110.0, 110.0, num_bins), False),
+        "ShearX": (torch.tensor(0.3), True),
+        "ShearY": (torch.tensor(0.3), True),
+        "TranslateX": (torch.tensor(100), True),
+        "TranslateY": (torch.tensor(100), True),
+        "Rotate": (torch.tensor(30), True),
+        "Brightness": (torch.tensor(0.1), True),
+        "Color": (torch.tensor(0.1), True),
+        "Contrast": (torch.tensor(0.1), True),
+        "Sharpness": (torch.tensor(0.1), True),
+        "Posterize": (torch.tensor(4), False),
+        "Solarize": (torch.tensor(255), False),
+        "SolarizeAdd": (torch.tensor(111), False),
         "AutoContrast": (torch.tensor(0.0), False),
         "Equalize": (torch.tensor(0.0), False),
-        "Cutout": (torch.linspace(0.0, 40.0, num_bins), False),
+        "Cutout": (torch.tensor(40.0), False),
     }
 
   def forward(self, img: Tensor) -> Tensor:
@@ -162,13 +161,12 @@ class RandAugment(torch.nn.Module):
       elif fill is not None:
         fill = [float(f) for f in fill]
 
-    op_meta = self._augmentation_space(1)
+    op_meta = self._augmentation_space()
     for _ in range(self.num_ops):
       op_index = int(torch.randint(len(op_meta), (1,)).item())
       op_name = list(op_meta.keys())[op_index]
-      magnitudes, signed = op_meta[op_name]
-      magnitude = float(
-          magnitudes[self.magnitude].item()) if magnitudes.ndim > 0 else 0.0
+      magnitude, signed = op_meta[op_name]
+      magnitude = float(magnitude)
       if signed and torch.randint(2, (1,)):
         magnitude *= -1.0
       img = _apply_op(

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
@@ -1,0 +1,220 @@
+import math
+from enum import Enum
+from typing import List, Tuple, Optional, Dict
+from PIL import Image
+import PIL
+import torch
+from torch import Tensor
+import numpy as np
+
+from torchvision.transforms import functional as F, InterpolationMode
+
+
+def Cutout(img, v):  # [0, 60] => percentage: [0, 0.2]
+    assert 0.0 <= v <= 0.2
+    if v <= 0.:
+        return img
+
+    v = v * img.size[0]
+    return CutoutAbs(img, v)
+
+
+def CutoutAbs(img, v):  # [0, 60] => percentage: [0, 0.2]
+    # assert 0 <= v <= 20
+    if v < 0:
+        return img
+    w, h = img.size
+    x0 = np.random.uniform(w)
+    y0 = np.random.uniform(h)
+
+    x0 = int(max(0, x0 - v / 2.))
+    y0 = int(max(0, y0 - v / 2.))
+    x1 = min(w, x0 + v)
+    y1 = min(h, y0 + v)
+
+    xy = (x0, y0, x1, y1)
+    color = (125, 123, 114)
+    # color = (0, 0, 0)
+    img = img.copy()
+    PIL.ImageDraw.Draw(img).rectangle(xy, color)
+    return img
+
+
+def _apply_op(
+    img: Tensor, op_name: str, magnitude: float,
+        interpolation: InterpolationMode, fill: Optional[List[float]],
+        addition=0
+):
+    if op_name == "ShearX":
+        # magnitude should be arctan(magnitude)
+        # official autoaug: (1, level, 0, 0, 1, 0)
+        # https://github.com/tensorflow/models/blob/dd02069717128186b88afa8d857ce57d17957f03/research/autoaugment/augmentation_transforms.py#L290
+        # compared to
+        # torchvision:      (1, tan(level), 0, 0, 1, 0)
+        # https://github.com/pytorch/vision/blob/0c2373d0bba3499e95776e7936e207d8a1676e65/torchvision/transforms/functional.py#L976
+        img = F.affine(
+            img,
+            angle=0.0,
+            translate=[0, 0],
+            scale=1.0,
+            shear=[math.degrees(math.atan(magnitude)), 0.0],
+            interpolation=interpolation,
+            fill=fill,
+            center=[0, 0],
+        )
+    elif op_name == "ShearY":
+        # magnitude should be arctan(magnitude)
+        # See above
+        img = F.affine(
+            img,
+            angle=0.0,
+            translate=[0, 0],
+            scale=1.0,
+            shear=[0.0, math.degrees(math.atan(magnitude))],
+            interpolation=interpolation,
+            fill=fill,
+            center=[0, 0],
+        )
+    elif op_name == "TranslateX":
+        img = F.affine(
+            img,
+            angle=0.0,
+            translate=[int(magnitude), 0],
+            scale=1.0,
+            interpolation=interpolation,
+            shear=[0.0, 0.0],
+            fill=fill,
+        )
+    elif op_name == "TranslateY":
+        img = F.affine(
+            img,
+            angle=0.0,
+            translate=[0, int(magnitude)],
+            scale=1.0,
+            interpolation=interpolation,
+            shear=[0.0, 0.0],
+            fill=fill,
+        )
+    elif op_name == "Rotate":
+        img = F.rotate(img, magnitude, interpolation=interpolation, fill=fill)
+    elif op_name == "Brightness":
+        img = F.adjust_brightness(img, 1.0 + magnitude)
+    elif op_name == "Color":
+        img = F.adjust_saturation(img, 1.0 + magnitude)
+    elif op_name == "Contrast":
+        img = F.adjust_contrast(img, 1.0 + magnitude)
+    elif op_name == "Sharpness":
+        img = F.adjust_sharpness(img, 1.0 + magnitude)
+    elif op_name == "Posterize":
+        img = F.posterize(img, int(magnitude))
+    # elif op_name == "SolarizeAdd":
+    #     img = np.array(img).astype(np.int64) + addition
+    #     img = np.clip(img, a_min=0, a_max=255)
+    #     img = Image.fromarray(img.astype(np.uint8))
+    #     img = F.solarize(img, magnitude)
+    elif op_name == "Solarize":
+        img = F.solarize(img, magnitude)
+    elif op_name == "AutoContrast":
+        img = F.autocontrast(img)
+    elif op_name == "Equalize":
+        img = F.equalize(img)
+    elif op_name == "Invert":
+        img = F.invert(img)
+    elif op_name == "Identity":
+        pass
+    else:
+        raise ValueError(f"The provided operator {op_name} is not recognized.")
+    return img
+
+
+class RandAugment(torch.nn.Module):
+    r"""RandAugment data augmentation method based on
+    `"RandAugment: Practical automated data augmentation with a reduced search space"
+    <https://arxiv.org/abs/1909.13719>`_.
+    If the image is torch Tensor, it should be of type torch.uint8, and it is expected
+    to have [..., 1 or 3, H, W] shape, where ... means an arbitrary number of leading dimensions.
+    If img is PIL Image, it is expected to be in mode "L" or "RGB".
+
+    Args:
+        num_ops (int): Number of augmentation transformations to apply sequentially.
+        magnitude (int): Magnitude for all the transformations.
+        num_magnitude_bins (int): The number of different magnitude values.
+        interpolation (InterpolationMode): Desired interpolation enum defined by
+            :class:`torchvision.transforms.InterpolationMode`. Default is ``InterpolationMode.NEAREST``.
+            If input is Tensor, only ``InterpolationMode.NEAREST``, ``InterpolationMode.BILINEAR`` are supported.
+        fill (sequence or number, optional): Pixel fill value for the area outside the transformed
+            image. If given a number, the value is used for all bands respectively.
+    """
+
+    def __init__(
+        self,
+        num_ops: int = 2,
+        magnitude: int = 9,
+        num_magnitude_bins: int = 31,
+        interpolation: InterpolationMode = InterpolationMode.NEAREST,
+        fill: Optional[List[float]] = None,
+    ) -> None:
+        super().__init__()
+        self.num_ops = num_ops
+        self.magnitude = magnitude
+        self.num_magnitude_bins = num_magnitude_bins
+        self.interpolation = interpolation
+        self.fill = fill
+
+    def _augmentation_space(self, num_bins: int, image_size: Tuple[int, int]) -> Dict[str, Tuple[Tensor, bool]]:
+        return {
+            # op_name: (magnitudes, signed)
+            # "Identity": (torch.tensor(0.0), False),
+            "ShearX": (torch.linspace(0.0, 0.3, num_bins), True),
+            "ShearY": (torch.linspace(0.0, 0.3, num_bins), True),
+            "TranslateX": (torch.linspace(0.0, 150.0 / 331.0 * image_size[1], num_bins), True),
+            "TranslateY": (torch.linspace(0.0, 150.0 / 331.0 * image_size[0], num_bins), True),
+            "Rotate": (torch.linspace(0.0, 30.0, num_bins), True),
+            "Brightness": (torch.linspace(0.0, 0.9, num_bins), True),
+            "Color": (torch.linspace(0.0, 0.9, num_bins), True),
+            "Contrast": (torch.linspace(0.0, 0.9, num_bins), True),
+            "Sharpness": (torch.linspace(0.0, 0.9, num_bins), True),
+            "Posterize": (8 - (torch.arange(num_bins) / ((num_bins - 1) / 4)).round().int(), False),
+            "Solarize": (torch.linspace(255.0, 0.0, num_bins), False),
+            "AutoContrast": (torch.tensor(0.0), False),
+            "Equalize": (torch.tensor(0.0), False),
+        }
+
+    def forward(self, img: Tensor) -> Tensor:
+        """
+            img (PIL Image or Tensor): Image to be transformed.
+
+        Returns:
+            PIL Image or Tensor: Transformed image.
+        """
+        fill = self.fill
+        channels, height, width = F.get_dimensions(img)
+        if isinstance(img, Tensor):
+            if isinstance(fill, (int, float)):
+                fill = [float(fill)] * channels
+            elif fill is not None:
+                fill = [float(f) for f in fill]
+
+        op_meta = self._augmentation_space(self.num_magnitude_bins, (height, width))
+        for _ in range(self.num_ops):
+            op_index = int(torch.randint(len(op_meta), (1,)).item())
+            op_name = list(op_meta.keys())[op_index]
+            magnitudes, signed = op_meta[op_name]
+            magnitude = float(magnitudes[self.magnitude].item()) if magnitudes.ndim > 0 else 0.0
+            if signed and torch.randint(2, (1,)):
+                magnitude *= -1.0
+            img = _apply_op(img, op_name, magnitude, interpolation=self.interpolation, fill=fill)
+
+        return img
+
+    def __repr__(self) -> str:
+        s = (
+            f"{self.__class__.__name__}("
+            f"num_ops={self.num_ops}"
+            f", magnitude={self.magnitude}"
+            f", num_magnitude_bins={self.num_magnitude_bins}"
+            f", interpolation={self.interpolation}"
+            f", fill={self.fill}"
+            f")"
+        )
+        return s

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
@@ -91,13 +91,13 @@ def _apply_op(
   elif op_name == "Rotate":
     img = F.rotate(img, magnitude, interpolation=interpolation, fill=fill)
   elif op_name == "Brightness":
-    img = F.adjust_brightness(img, 1.0 + magnitude)
+    img = F.adjust_brightness(img, magnitude)
   elif op_name == "Color":
-    img = F.adjust_saturation(img, 1.0 + magnitude)
+    img = F.adjust_saturation(img, magnitude)
   elif op_name == "Contrast":
-    img = F.adjust_contrast(img, 1.0 + magnitude)
+    img = F.adjust_contrast(img, magnitude)
   elif op_name == "Sharpness":
-    img = F.adjust_sharpness(img, 1.0 + magnitude)
+    img = F.adjust_sharpness(img, magnitude)
   elif op_name == "Posterize":
     img = F.posterize(img, int(magnitude))
   elif op_name == "Cutout":
@@ -140,10 +140,10 @@ class RandAugment(torch.nn.Module):
         "TranslateX": (torch.tensor(100), True),
         "TranslateY": (torch.tensor(100), True),
         "Rotate": (torch.tensor(30), True),
-        "Brightness": (torch.tensor(0.1), True),
-        "Color": (torch.tensor(0.1), True),
-        "Contrast": (torch.tensor(0.1), True),
-        "Sharpness": (torch.tensor(0.1), True),
+        "Brightness": (torch.tensor(0.1), False),
+        "Color": (torch.tensor(0.1), False),
+        "Contrast": (torch.tensor(0.1), False),
+        "Sharpness": (torch.tensor(0.1), False),
         "Posterize": (torch.tensor(4), False),
         "Solarize": (torch.tensor(255), False),
         "SolarizeAdd": (torch.tensor(111), False),

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
@@ -1,220 +1,187 @@
 import math
-from enum import Enum
-from typing import List, Tuple, Optional, Dict
-from PIL import Image
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
 import PIL
 import torch
 from torch import Tensor
-import numpy as np
-
-from torchvision.transforms import functional as F, InterpolationMode
-
-
-def Cutout(img, v):  # [0, 60] => percentage: [0, 0.2]
-    assert 0.0 <= v <= 0.2
-    if v <= 0.:
-        return img
-
-    v = v * img.size[0]
-    return CutoutAbs(img, v)
+from torchvision.transforms import functional as F
+from torchvision.transforms import InterpolationMode
 
 
-def CutoutAbs(img, v):  # [0, 60] => percentage: [0, 0.2]
-    # assert 0 <= v <= 20
-    if v < 0:
-        return img
-    w, h = img.size
-    x0 = np.random.uniform(w)
-    y0 = np.random.uniform(h)
+def cutout(img, pad_size):
+  image_width, image_height = img.size
+  cutout_center_width = np.random.uniform(image_width)
+  cutout_center_height = np.random.uniform(image_height)
 
-    x0 = int(max(0, x0 - v / 2.))
-    y0 = int(max(0, y0 - v / 2.))
-    x1 = min(w, x0 + v)
-    y1 = min(h, y0 + v)
+  lower_pad = max(0, cutout_center_height - pad_size)
+  upper_pad = max(0, image_height - cutout_center_height - pad_size)
+  left_pad = max(0, cutout_center_width - pad_size)
+  right_pad = max(0, image_width - cutout_center_width - pad_size)
 
-    xy = (x0, y0, x1, y1)
-    color = (125, 123, 114)
-    # color = (0, 0, 0)
-    img = img.copy()
-    PIL.ImageDraw.Draw(img).rectangle(xy, color)
-    return img
+  x0 = right_pad
+  y0 = upper_pad
+  x1 = left_pad
+  y1 = lower_pad
+
+  xy = (x0, y0, x1, y1)
+  color = (128, 128, 128)
+  img = img.copy()
+  PIL.ImageDraw.Draw(img).rectangle(xy, color)
+  return img
 
 
 def _apply_op(
-    img: Tensor, op_name: str, magnitude: float,
-        interpolation: InterpolationMode, fill: Optional[List[float]],
-        addition=0
+    img: Tensor,
+    op_name: str,
+    magnitude: float,
+    interpolation: InterpolationMode,
+    fill: Optional[List[float]],
 ):
-    if op_name == "ShearX":
-        # magnitude should be arctan(magnitude)
-        # official autoaug: (1, level, 0, 0, 1, 0)
-        # https://github.com/tensorflow/models/blob/dd02069717128186b88afa8d857ce57d17957f03/research/autoaugment/augmentation_transforms.py#L290
-        # compared to
-        # torchvision:      (1, tan(level), 0, 0, 1, 0)
-        # https://github.com/pytorch/vision/blob/0c2373d0bba3499e95776e7936e207d8a1676e65/torchvision/transforms/functional.py#L976
-        img = F.affine(
-            img,
-            angle=0.0,
-            translate=[0, 0],
-            scale=1.0,
-            shear=[math.degrees(math.atan(magnitude)), 0.0],
-            interpolation=interpolation,
-            fill=fill,
-            center=[0, 0],
-        )
-    elif op_name == "ShearY":
-        # magnitude should be arctan(magnitude)
-        # See above
-        img = F.affine(
-            img,
-            angle=0.0,
-            translate=[0, 0],
-            scale=1.0,
-            shear=[0.0, math.degrees(math.atan(magnitude))],
-            interpolation=interpolation,
-            fill=fill,
-            center=[0, 0],
-        )
-    elif op_name == "TranslateX":
-        img = F.affine(
-            img,
-            angle=0.0,
-            translate=[int(magnitude), 0],
-            scale=1.0,
-            interpolation=interpolation,
-            shear=[0.0, 0.0],
-            fill=fill,
-        )
-    elif op_name == "TranslateY":
-        img = F.affine(
-            img,
-            angle=0.0,
-            translate=[0, int(magnitude)],
-            scale=1.0,
-            interpolation=interpolation,
-            shear=[0.0, 0.0],
-            fill=fill,
-        )
-    elif op_name == "Rotate":
-        img = F.rotate(img, magnitude, interpolation=interpolation, fill=fill)
-    elif op_name == "Brightness":
-        img = F.adjust_brightness(img, 1.0 + magnitude)
-    elif op_name == "Color":
-        img = F.adjust_saturation(img, 1.0 + magnitude)
-    elif op_name == "Contrast":
-        img = F.adjust_contrast(img, 1.0 + magnitude)
-    elif op_name == "Sharpness":
-        img = F.adjust_sharpness(img, 1.0 + magnitude)
-    elif op_name == "Posterize":
-        img = F.posterize(img, int(magnitude))
-    # elif op_name == "SolarizeAdd":
-    #     img = np.array(img).astype(np.int64) + addition
-    #     img = np.clip(img, a_min=0, a_max=255)
-    #     img = Image.fromarray(img.astype(np.uint8))
-    #     img = F.solarize(img, magnitude)
-    elif op_name == "Solarize":
-        img = F.solarize(img, magnitude)
-    elif op_name == "AutoContrast":
-        img = F.autocontrast(img)
-    elif op_name == "Equalize":
-        img = F.equalize(img)
-    elif op_name == "Invert":
-        img = F.invert(img)
-    elif op_name == "Identity":
-        pass
-    else:
-        raise ValueError(f"The provided operator {op_name} is not recognized.")
-    return img
+  if op_name == "ShearX":
+    # magnitude should be arctan(magnitude)
+    # official autoaug: (1, level, 0, 0, 1, 0)
+    # https://github.com/tensorflow/models/blob/dd02069717128186b88afa8d857ce57d17957f03/research/autoaugment/augmentation_transforms.py#L290
+    # compared to
+    # torchvision:      (1, tan(level), 0, 0, 1, 0)
+    # https://github.com/pytorch/vision/blob/0c2373d0bba3499e95776e7936e207d8a1676e65/torchvision/transforms/functional.py#L976
+    img = F.affine(
+        img,
+        angle=0.0,
+        translate=[0, 0],
+        scale=1.0,
+        shear=[math.degrees(math.atan(magnitude)), 0.0],
+        interpolation=interpolation,
+        fill=fill,
+        center=[0, 0],
+    )
+  elif op_name == "ShearY":
+    # magnitude should be arctan(magnitude)
+    # See above
+    img = F.affine(
+        img,
+        angle=0.0,
+        translate=[0, 0],
+        scale=1.0,
+        shear=[0.0, math.degrees(math.atan(magnitude))],
+        interpolation=interpolation,
+        fill=fill,
+        center=[0, 0],
+    )
+  elif op_name == "TranslateX":
+    img = F.affine(
+        img,
+        angle=0.0,
+        translate=[int(magnitude), 0],
+        scale=1.0,
+        interpolation=interpolation,
+        shear=[0.0, 0.0],
+        fill=fill,
+    )
+  elif op_name == "TranslateY":
+    img = F.affine(
+        img,
+        angle=0.0,
+        translate=[0, int(magnitude)],
+        scale=1.0,
+        interpolation=interpolation,
+        shear=[0.0, 0.0],
+        fill=fill,
+    )
+  elif op_name == "Rotate":
+    img = F.rotate(img, magnitude, interpolation=interpolation, fill=fill)
+  elif op_name == "Brightness":
+    img = F.adjust_brightness(img, 1.0 + magnitude)
+  elif op_name == "Color":
+    img = F.adjust_saturation(img, 1.0 + magnitude)
+  elif op_name == "Contrast":
+    img = F.adjust_contrast(img, 1.0 + magnitude)
+  elif op_name == "Sharpness":
+    img = F.adjust_sharpness(img, 1.0 + magnitude)
+  elif op_name == "Posterize":
+    img = F.posterize(img, int(magnitude))
+  elif op_name == "Cutout":
+    img = cutout(img, magnitude)
+  elif op_name == "SolarizeAdd":
+    img = F.solarize(img, 255 - magnitude)
+  elif op_name == "Solarize":
+    img = F.solarize(img, magnitude)
+  elif op_name == "AutoContrast":
+    img = F.autocontrast(img)
+  elif op_name == "Equalize":
+    img = F.equalize(img)
+  elif op_name == "Invert":
+    img = F.invert(img)
+  elif op_name == "Identity":
+    pass
+  else:
+    raise ValueError(f"The provided operator {op_name} is not recognized.")
+  return img
 
 
 class RandAugment(torch.nn.Module):
-    r"""RandAugment data augmentation method based on
-    `"RandAugment: Practical automated data augmentation with a reduced search space"
-    <https://arxiv.org/abs/1909.13719>`_.
-    If the image is torch Tensor, it should be of type torch.uint8, and it is expected
-    to have [..., 1 or 3, H, W] shape, where ... means an arbitrary number of leading dimensions.
-    If img is PIL Image, it is expected to be in mode "L" or "RGB".
 
-    Args:
-        num_ops (int): Number of augmentation transformations to apply sequentially.
-        magnitude (int): Magnitude for all the transformations.
-        num_magnitude_bins (int): The number of different magnitude values.
-        interpolation (InterpolationMode): Desired interpolation enum defined by
-            :class:`torchvision.transforms.InterpolationMode`. Default is ``InterpolationMode.NEAREST``.
-            If input is Tensor, only ``InterpolationMode.NEAREST``, ``InterpolationMode.BILINEAR`` are supported.
-        fill (sequence or number, optional): Pixel fill value for the area outside the transformed
-            image. If given a number, the value is used for all bands respectively.
-    """
+  def __init__(
+      self,
+      num_ops: int = 2,
+      interpolation: InterpolationMode = InterpolationMode.NEAREST,
+      fill: Optional[List[float]] = None,
+  ) -> None:
+    super().__init__()
+    self.num_ops = num_ops
+    self.interpolation = interpolation
+    self.fill = fill
 
-    def __init__(
-        self,
-        num_ops: int = 2,
-        magnitude: int = 9,
-        num_magnitude_bins: int = 31,
-        interpolation: InterpolationMode = InterpolationMode.NEAREST,
-        fill: Optional[List[float]] = None,
-    ) -> None:
-        super().__init__()
-        self.num_ops = num_ops
-        self.magnitude = magnitude
-        self.num_magnitude_bins = num_magnitude_bins
-        self.interpolation = interpolation
-        self.fill = fill
+  def _augmentation_space(self,
+                          num_bins: int) -> Dict[str, Tuple[Tensor, bool]]:
+    return {
+        # op_name: (magnitudes, signed)
+        "ShearX": (torch.linspace(0.3, 0.3, num_bins), True),
+        "ShearY": (torch.linspace(0.3, 0.3, num_bins), True),
+        "TranslateX": (torch.linspace(100, 100, num_bins), True),
+        "TranslateY": (torch.linspace(100, 100, num_bins), True),
+        "Rotate": (torch.linspace(30.0, 30.0, num_bins), True),
+        "Brightness": (torch.linspace(0.1, 0.1, num_bins), True),
+        "Color": (torch.linspace(0.1, 0.1, num_bins), True),
+        "Contrast": (torch.linspace(0.1, 0.1, num_bins), True),
+        "Sharpness": (torch.linspace(0.1, 0.1, num_bins), True),
+        "Posterize": (torch.linspace(4, 4, num_bins).int(), False),
+        "Solarize": (torch.linspace(255.0, 255.0, num_bins), False),
+        "SolarizeAdd": (torch.linspace(110.0, 110.0, num_bins), False),
+        "AutoContrast": (torch.tensor(0.0), False),
+        "Equalize": (torch.tensor(0.0), False),
+        "Cutout": (torch.linspace(0.0, 40.0, num_bins), False),
+    }
 
-    def _augmentation_space(self, num_bins: int, image_size: Tuple[int, int]) -> Dict[str, Tuple[Tensor, bool]]:
-        return {
-            # op_name: (magnitudes, signed)
-            # "Identity": (torch.tensor(0.0), False),
-            "ShearX": (torch.linspace(0.0, 0.3, num_bins), True),
-            "ShearY": (torch.linspace(0.0, 0.3, num_bins), True),
-            "TranslateX": (torch.linspace(0.0, 150.0 / 331.0 * image_size[1], num_bins), True),
-            "TranslateY": (torch.linspace(0.0, 150.0 / 331.0 * image_size[0], num_bins), True),
-            "Rotate": (torch.linspace(0.0, 30.0, num_bins), True),
-            "Brightness": (torch.linspace(0.0, 0.9, num_bins), True),
-            "Color": (torch.linspace(0.0, 0.9, num_bins), True),
-            "Contrast": (torch.linspace(0.0, 0.9, num_bins), True),
-            "Sharpness": (torch.linspace(0.0, 0.9, num_bins), True),
-            "Posterize": (8 - (torch.arange(num_bins) / ((num_bins - 1) / 4)).round().int(), False),
-            "Solarize": (torch.linspace(255.0, 0.0, num_bins), False),
-            "AutoContrast": (torch.tensor(0.0), False),
-            "Equalize": (torch.tensor(0.0), False),
-        }
+  def forward(self, img: Tensor) -> Tensor:
+    fill = self.fill
+    channels, _, _ = F.get_dimensions(img)
+    if isinstance(img, Tensor):
+      if isinstance(fill, (int, float)):
+        fill = [float(fill)] * channels
+      elif fill is not None:
+        fill = [float(f) for f in fill]
 
-    def forward(self, img: Tensor) -> Tensor:
-        """
-            img (PIL Image or Tensor): Image to be transformed.
+    op_meta = self._augmentation_space(1)
+    for _ in range(self.num_ops):
+      op_index = int(torch.randint(len(op_meta), (1,)).item())
+      op_name = list(op_meta.keys())[op_index]
+      magnitudes, signed = op_meta[op_name]
+      magnitude = float(
+          magnitudes[self.magnitude].item()) if magnitudes.ndim > 0 else 0.0
+      if signed and torch.randint(2, (1,)):
+        magnitude *= -1.0
+      img = _apply_op(
+          img, op_name, magnitude, interpolation=self.interpolation, fill=fill)
 
-        Returns:
-            PIL Image or Tensor: Transformed image.
-        """
-        fill = self.fill
-        channels, height, width = F.get_dimensions(img)
-        if isinstance(img, Tensor):
-            if isinstance(fill, (int, float)):
-                fill = [float(fill)] * channels
-            elif fill is not None:
-                fill = [float(f) for f in fill]
+    return img
 
-        op_meta = self._augmentation_space(self.num_magnitude_bins, (height, width))
-        for _ in range(self.num_ops):
-            op_index = int(torch.randint(len(op_meta), (1,)).item())
-            op_name = list(op_meta.keys())[op_index]
-            magnitudes, signed = op_meta[op_name]
-            magnitude = float(magnitudes[self.magnitude].item()) if magnitudes.ndim > 0 else 0.0
-            if signed and torch.randint(2, (1,)):
-                magnitude *= -1.0
-            img = _apply_op(img, op_name, magnitude, interpolation=self.interpolation, fill=fill)
-
-        return img
-
-    def __repr__(self) -> str:
-        s = (
-            f"{self.__class__.__name__}("
-            f"num_ops={self.num_ops}"
-            f", magnitude={self.magnitude}"
-            f", num_magnitude_bins={self.num_magnitude_bins}"
-            f", interpolation={self.interpolation}"
-            f", fill={self.fill}"
-            f")"
-        )
-        return s
+  def __repr__(self) -> str:
+    s = (f"{self.__class__.__name__}("
+         f"num_ops={self.num_ops}"
+         f", magnitude={self.magnitude}"
+         f", num_magnitude_bins={self.num_magnitude_bins}"
+         f", interpolation={self.interpolation}"
+         f", fill={self.fill}"
+         f")")
+    return s

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
@@ -39,7 +39,7 @@ def cutout(img, pad_size):
 def solarize(img: Tensor, threshold: float) -> Tensor:
   img = np.array(img)
   new_img = np.where(img < threshold, img, 255. - img)
-  return PIL.Image.fromarray(new_img)
+  return PIL.Image.fromarray(new_img.astype(np.uint8))
 
 
 def solarize_add(img: Tensor, addition: int = 0) -> Tensor:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -25,6 +25,7 @@ from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_pytorch.models im
     resnet50
 from algorithmic_efficiency.workloads.imagenet_resnet.workload import \
     BaseImagenetResNetWorkload
+from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_pytorch import randaugment
 
 USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 
@@ -83,7 +84,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
           transforms.RandomHorizontalFlip(),
       ]
       if use_randaug:
-        transform_config.append(transforms.RandAugment(magnitude=10))
+        transform_config.append(randaugment.RandAugment(magnitude=10))
       transform_config = transforms.Compose(transform_config)
     else:
       transform_config = transforms.Compose([

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -21,11 +21,12 @@ from algorithmic_efficiency import spec
 from algorithmic_efficiency.pytorch_utils import pytorch_setup
 import algorithmic_efficiency.random_utils as prng
 from algorithmic_efficiency.workloads.imagenet_resnet import imagenet_v2
+from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_pytorch import \
+    randaugment
 from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_pytorch.models import \
     resnet50
 from algorithmic_efficiency.workloads.imagenet_resnet.workload import \
     BaseImagenetResNetWorkload
-from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_pytorch import randaugment
 
 USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 
@@ -84,7 +85,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
           transforms.RandomHorizontalFlip(),
       ]
       if use_randaug:
-        transform_config.append(randaugment.RandAugment(magnitude=10))
+        transform_config.append(randaugment.RandAugment())
       transform_config = transforms.Compose(transform_config)
     else:
       transform_config = transforms.Compose([

--- a/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, List, Tuple
 
+from absl import logging
 import torch
 
 from algorithmic_efficiency import spec
@@ -22,7 +23,6 @@ def update_params(workload: spec.Workload,
   del current_params_types
   del loss_type
   del eval_results
-  del global_step
 
   current_model = current_param_container
   current_model.train()
@@ -58,5 +58,22 @@ def update_params(workload: spec.Workload,
         current_model.parameters(), max_norm=grad_clip)
   optimizer_state['optimizer'].step()
   optimizer_state['scheduler'].step()
+
+  # Log training metrics - loss, grad_norm, batch_size.
+  if global_step <= 100 or global_step % 500 == 0:
+    with torch.no_grad():
+      parameters = [p for p in current_model.parameters() if p.grad is not None]
+      total_norm = torch.norm(
+          torch.stack([torch.norm(p.grad.detach(), 2) for p in parameters]), 2)
+    if workload.metrics_logger is not None:
+      workload.metrics_logger.append_scalar_metrics(
+          {
+              'loss': loss.item(),
+              'grad_norm': total_norm.item(),
+          }, global_step)
+    logging.info('%d) loss = %0.3f, grad_norm = %0.3f',
+                 global_step,
+                 loss.item(),
+                 total_norm.item())
 
   return (optimizer_state, current_param_container, new_model_state)

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -104,7 +104,7 @@ flags.DEFINE_string(
 flags.DEFINE_integer('num_tuning_trials',
                      1,
                      'The number of external hyperparameter trials to run.')
-flags.DEFINE_string('data_dir', '~/datasets/', 'Dataset location.')
+flags.DEFINE_string('data_dir', '~/tensorflow_datasets/', 'Dataset location.')
 flags.DEFINE_string('imagenet_v2_data_dir',
                     '~/tensorflow_datasets/',
                     'Dataset location for ImageNet-v2.')
@@ -495,7 +495,7 @@ def main(_):
     profiler = PassThroughProfiler()
 
   if FLAGS.framework == 'pytorch':
-    pytorch_init(USE_PYTORCH_DDP, RANK, profiler, DEVICE)
+    pytorch_init(USE_PYTORCH_DDP, RANK, profiler)
 
   workload_metadata = WORKLOADS[FLAGS.workload]
   # Extend path according to framework.

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -495,7 +495,7 @@ def main(_):
     profiler = PassThroughProfiler()
 
   if FLAGS.framework == 'pytorch':
-    pytorch_init(USE_PYTORCH_DDP, RANK, profiler)
+    pytorch_init(USE_PYTORCH_DDP, RANK, profiler, DEVICE)
 
   workload_metadata = WORKLOADS[FLAGS.workload]
   # Extend path according to framework.

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -104,7 +104,7 @@ flags.DEFINE_string(
 flags.DEFINE_integer('num_tuning_trials',
                      1,
                      'The number of external hyperparameter trials to run.')
-flags.DEFINE_string('data_dir', '~/tensorflow_datasets/', 'Dataset location.')
+flags.DEFINE_string('data_dir', '~/datasets/', 'Dataset location.')
 flags.DEFINE_string('imagenet_v2_data_dir',
                     '~/tensorflow_datasets/',
                     'Dataset location for ImageNet-v2.')


### PR DESCRIPTION
This PR implements RandAug for both Jax and PyTorch workloads. Previous bugs are fixed and PyTorch RandAugment code is manually modified so that it matches that of Jax. 

Note: I also noticed one additional difference with the target-setting run; the target-setting run uses an 'inception' crop, whereas we are using a 'random' crop.