### PR TITLE
ImageNet Pytorch Workload Processing Fix

### DIFF
--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -200,10 +200,8 @@ class PrefetchedWrapper:
     self.dataloader = dataloader
     self.epoch = start_epoch
     self.device = device
-    self.data_mean = torch.tensor(mean,
-                                  device=device).view(1, 3, 1, 1)
-    self.data_std = torch.tensor(std,
-                                 device=device).view(1, 3, 1, 1)
+    self.data_mean = torch.tensor(mean, device=device).view(1, 3, 1, 1)
+    self.data_std = torch.tensor(std, device=device).view(1, 3, 1, 1)
 
   def __len__(self):
     return len(self.dataloader)

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -200,9 +200,9 @@ class PrefetchedWrapper:
     self.dataloader = dataloader
     self.epoch = start_epoch
     self.device = device
-    self.data_mean = torch.tensor([i / 255 for i in mean],
+    self.data_mean = torch.tensor(mean,
                                   device=device).view(1, 3, 1, 1)
-    self.data_std = torch.tensor([i / 255 for i in std],
+    self.data_std = torch.tensor(std,
                                  device=device).view(1, 3, 1, 1)
 
   def __len__(self):

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -214,13 +214,16 @@ def preprocess_for_eval(image_bytes,
 # image_preprocessing.py.
 def mixup_tf(key, inputs, targets, alpha=0.2):
   """Perform mixup https://arxiv.org/abs/1710.09412.
+
   NOTE: Code taken from https://github.com/google/big_vision with variables
   renamed to match `mixup` in this file and logic to synchronize globally.
+
   Args:
     key: The random key to use.
     inputs: inputs to mix.
     targets: targets to mix.
     alpha: the beta/dirichlet concentration parameter, typically 0.1 or 0.2.
+
   Returns:
     Mixed inputs and targets.
   """

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
@@ -411,15 +411,6 @@ def _rotate_level_to_arg(level):
   return (level,)
 
 
-def _shrink_level_to_arg(level):
-  """Converts level to ratio by which we shrink the image content."""
-  if level == 0:
-    return (1.0,)  # if level is zero, do not shrink the image
-  # Maximum shrinking ratio is 2.9.
-  level = 2. / (_MAX_LEVEL / level) + 0.9
-  return (level,)
-
-
 def _enhance_level_to_arg(level):
   return ((level / _MAX_LEVEL) * 1.8 + 0.1,)
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
@@ -16,22 +16,17 @@ from torchvision.transforms import InterpolationMode
 
 def cutout(img, pad_size, fill):
   image_width, image_height = img.size
-  cutout_center_width = np.random.uniform(image_width)
-  cutout_center_height = np.random.uniform(image_height)
+  x0 = np.random.uniform(image_width)
+  y0 = np.random.uniform(image_height)
 
-  lower_pad = max(0, cutout_center_height - pad_size)
-  upper_pad = max(0, image_height - cutout_center_height - pad_size)
-  left_pad = max(0, cutout_center_width - pad_size)
-  right_pad = max(0, image_width - cutout_center_width - pad_size)
-
-  x0 = right_pad
-  y0 = upper_pad
-  x1 = left_pad
-  y1 = lower_pad
-
+  pad_size = pad_size * 2
+  x0 = int(max(0, x0 - pad_size / 2.))
+  y0 = int(max(0, y0 - pad_size / 2.))
+  x1 = int(min(image_width, x0 + pad_size))
+  y1 = int(min(image_height, y0 + pad_size))
   xy = (x0, y0, x1, y1)
   img = img.copy()
-  PIL.ImageDraw.Draw(img).rectangle(xy, fill)
+  PIL.ImageDraw.Draw(img).rectangle(xy, (fill, fill, fill))
   return img
 
 
@@ -168,6 +163,7 @@ class RandAugment(torch.nn.Module):
         "SolarizeAdd": (torch.tensor(110), False),
         "AutoContrast": (torch.tensor(0.0), False),
         "Equalize": (torch.tensor(0.0), False),
+        "Invert": (torch.tensor(0.0), False),
         "Cutout": (torch.tensor(40.0), False),
     }
 
@@ -192,13 +188,3 @@ class RandAugment(torch.nn.Module):
           img, op_name, magnitude, interpolation=self.interpolation, fill=fill)
 
     return img
-
-  def __repr__(self) -> str:
-    s = (f"{self.__class__.__name__}("
-         f"num_ops={self.num_ops}"
-         f", magnitude={self.magnitude}"
-         f", num_magnitude_bins={self.num_magnitude_bins}"
-         f", interpolation={self.interpolation}"
-         f", fill={self.fill}"
-         f")")
-    return s

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py
@@ -52,7 +52,7 @@ def _apply_op(
     interpolation: InterpolationMode,
     fill: Optional[List[float]],
 ):
-  if op_name == "ShearX":
+  if op_name == 'ShearX':
     # magnitude should be arctan(magnitude)
     # official autoaug: (1, level, 0, 0, 1, 0)
     # https://github.com/tensorflow/models/blob/dd02069717128186b88afa8d857ce57d17957f03/research/autoaugment/augmentation_transforms.py#L290
@@ -69,7 +69,7 @@ def _apply_op(
         fill=fill,
         center=[0, 0],
     )
-  elif op_name == "ShearY":
+  elif op_name == 'ShearY':
     # magnitude should be arctan(magnitude)
     # See above
     img = F.affine(
@@ -82,7 +82,7 @@ def _apply_op(
         fill=fill,
         center=[0, 0],
     )
-  elif op_name == "TranslateX":
+  elif op_name == 'TranslateX':
     img = F.affine(
         img,
         angle=0.0,
@@ -92,7 +92,7 @@ def _apply_op(
         shear=[0.0, 0.0],
         fill=fill,
     )
-  elif op_name == "TranslateY":
+  elif op_name == 'TranslateY':
     img = F.affine(
         img,
         angle=0.0,
@@ -102,34 +102,34 @@ def _apply_op(
         shear=[0.0, 0.0],
         fill=fill,
     )
-  elif op_name == "Rotate":
+  elif op_name == 'Rotate':
     img = F.rotate(img, magnitude, interpolation=interpolation, fill=fill)
-  elif op_name == "Brightness":
+  elif op_name == 'Brightness':
     img = F.adjust_brightness(img, magnitude)
-  elif op_name == "Color":
+  elif op_name == 'Color':
     img = F.adjust_saturation(img, magnitude)
-  elif op_name == "Contrast":
+  elif op_name == 'Contrast':
     img = F.adjust_contrast(img, magnitude)
-  elif op_name == "Sharpness":
+  elif op_name == 'Sharpness':
     img = F.adjust_sharpness(img, magnitude)
-  elif op_name == "Posterize":
+  elif op_name == 'Posterize':
     img = F.posterize(img, int(magnitude))
-  elif op_name == "Cutout":
+  elif op_name == 'Cutout':
     img = cutout(img, magnitude, fill=fill)
-  elif op_name == "SolarizeAdd":
+  elif op_name == 'SolarizeAdd':
     img = solarize_add(img, int(magnitude))
-  elif op_name == "Solarize":
+  elif op_name == 'Solarize':
     img = solarize(img, magnitude)
-  elif op_name == "AutoContrast":
+  elif op_name == 'AutoContrast':
     img = F.autocontrast(img)
-  elif op_name == "Equalize":
+  elif op_name == 'Equalize':
     img = F.equalize(img)
-  elif op_name == "Invert":
+  elif op_name == 'Invert':
     img = F.invert(img)
-  elif op_name == "Identity":
+  elif op_name == 'Identity':
     pass
   else:
-    raise ValueError(f"The provided operator {op_name} is not recognized.")
+    raise ValueError(f'The provided operator {op_name} is not recognized.')
   return img
 
 
@@ -149,22 +149,22 @@ class RandAugment(torch.nn.Module):
   def _augmentation_space(self) -> Dict[str, Tuple[Tensor, bool]]:
     return {
         # op_name: (magnitudes, signed)
-        "ShearX": (torch.tensor(0.3), True),
-        "ShearY": (torch.tensor(0.3), True),
-        "TranslateX": (torch.tensor(100), True),
-        "TranslateY": (torch.tensor(100), True),
-        "Rotate": (torch.tensor(30), True),
-        "Brightness": (torch.tensor(1.9), False),
-        "Color": (torch.tensor(1.9), False),
-        "Contrast": (torch.tensor(1.9), False),
-        "Sharpness": (torch.tensor(1.9), False),
-        "Posterize": (torch.tensor(4), False),
-        "Solarize": (torch.tensor(256), False),
-        "SolarizeAdd": (torch.tensor(110), False),
-        "AutoContrast": (torch.tensor(0.0), False),
-        "Equalize": (torch.tensor(0.0), False),
-        "Invert": (torch.tensor(0.0), False),
-        "Cutout": (torch.tensor(40.0), False),
+        'ShearX': (torch.tensor(0.3), True),
+        'ShearY': (torch.tensor(0.3), True),
+        'TranslateX': (torch.tensor(100), True),
+        'TranslateY': (torch.tensor(100), True),
+        'Rotate': (torch.tensor(30), True),
+        'Brightness': (torch.tensor(1.9), False),
+        'Color': (torch.tensor(1.9), False),
+        'Contrast': (torch.tensor(1.9), False),
+        'Sharpness': (torch.tensor(1.9), False),
+        'Posterize': (torch.tensor(4), False),
+        'Solarize': (torch.tensor(256), False),
+        'SolarizeAdd': (torch.tensor(110), False),
+        'AutoContrast': (torch.tensor(0.0), False),
+        'Equalize': (torch.tensor(0.0), False),
+        'Invert': (torch.tensor(0.0), False),
+        'Cutout': (torch.tensor(40.0), False),
     }
 
   def forward(self, img: Tensor) -> Tensor:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -62,14 +62,12 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     del cache
     del repeat_final_dataset
     if split == 'test':
-      train_mean = [m / 255 for m in self.train_mean]
-      train_stddev = [s / 255 for s in self.train_stddev]
       np_iter = imagenet_v2.get_imagenet_v2_iter(
           data_dir,
           global_batch_size,
           shard_batch=USE_PYTORCH_DDP,
-          mean_rgb=train_mean,
-          stddev_rgb=train_stddev)
+          mean_rgb=self.train_mean,
+          stddev_rgb=self.train_stddev)
       return map(imagenet_v2_to_torch, itertools.cycle(np_iter))
 
     is_train = split == 'train'
@@ -120,7 +118,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=4,
+        num_workers=12,
         pin_memory=True,
         collate_fn=data_utils.fast_collate,
         drop_last=is_train)

--- a/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
@@ -2,7 +2,6 @@
 
 from typing import Dict, List, Tuple
 
-from absl import logging
 import torch
 
 from algorithmic_efficiency import spec

--- a/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
@@ -56,21 +56,4 @@ def update_params(workload: spec.Workload,
   optimizer_state['optimizer'].step()
   optimizer_state['scheduler'].step()
 
-  # Log training metrics - loss, grad_norm, batch_size.
-  if global_step <= 100 or global_step % 500 == 0:
-    with torch.no_grad():
-      parameters = [p for p in current_model.parameters() if p.grad is not None]
-      total_norm = torch.norm(
-          torch.stack([torch.norm(p.grad.detach(), 2) for p in parameters]), 2)
-    if workload.metrics_logger is not None:
-      workload.metrics_logger.append_scalar_metrics(
-          {
-              'loss': loss.item(),
-              'grad_norm': total_norm.item(),
-          }, global_step)
-    logging.info('%d) loss = %0.3f, grad_norm = %0.3f',
-                 global_step,
-                 loss.item(),
-                 total_norm.item())
-
   return (optimizer_state, current_param_container, new_model_state)


### PR DESCRIPTION
The aim of this PR is to match the performance with the ImageNet Jax workloads. Most importantly, the input normalization was fixed; I suspect the ResNet models were less impacted by this as it uses BatchNorm, but we should expect better results with the pre-selected LR and weight decay. Additionally, I added the followings.
- Fix RandAugment parameters for PyTorch and remove unnecessary functions.
- Match `eps` for LayerNorm with the Jax version.