### PR TITLE
Fix usage of weights in WMT workloads + clean-up

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -119,12 +119,13 @@ def loss_fn(
     label_batch: Union[Tuple[Tensor, Tensor], Tensor],
     logits_batch: Union[Tuple[Tensor, Tensor], Tensor],
     mask_batch: Optional[Tensor] = None,
-    label_smoothing: float = 0.0) -> 1d array of losses per example  # differentiable
+    label_smoothing: float = 0.0) -> Tuple[Tensor, Tensor]  # differentiable
 ```
 
 - Unlike in the [Model Track](#model-track), we will specify the loss function name in order to let training algorithms depend on the loss function. It will be one of {**mean squared error**, **cross-entropy**, **CTC**, or **L1 reconstruction error**}.
   - The optimizer must work with all values of the enum, which will be provided via a property on the workload object that is provided to all submissions functions.
-- The loss function does **not** include regularization. Instead, regularization can be added by the submissions in the `update_variables` function.
+- The loss function does **not** include regularization. Instead, regularization can be added by the submissions in the `update_params` function.
+- The loss function returns a tuple (correct scalar average loss, 1-d array of per-example losses).
 
 ##### Submission functions
 
@@ -172,21 +173,21 @@ def update_params(
 ```
 
 - `current_param_container` is the same kind of nested structure as used by `model_fn` which constitutes a nested collection of `float32` arrays, each endowed with information about what kind of parameter that array represents stored in a parallel structure of `current_params_types`.
-  - Parameter kind is one of {"weights", "biases", "embeddings", "conv", "batch norm"}
-- `model_state` holds auxiliary state necessary for some models, such as the current batch norm statistics
+  - Parameter kind is one of {"weights", "biases", "embeddings", "conv", "batch norm"}.
+- `model_state` holds auxiliary state necessary for some models, such as the current batch norm statistics.
 - The loss function will be one of a small set of known possibilities and the update function is allowed to branch on the `loss_type` enum/name.
-- The `loss_fn` produces a loss per example, so the submission code is responsible for summing or averaging
-- Allowed to update state for the optimizer
-- Uses the `model_fn` of the `workload` in order to decouple the loss from the model so that model outputs (forward passes) can be reused (by storing them in the optimizer state)
+- The `loss_fn` produces a loss per example and a correct average loss, which both can be used.
+- Allowed to update state for the optimizer.
+- Uses the `model_fn` of the `workload` in order to decouple the loss from the model so that model outputs (forward passes) can be reused (by storing them in the optimizer state).
 - The submission can access the target evaluation metric via the `workload` variable.
 - **A call to this function will be considered a step**
-  - The time between a call to this function and the next call to this function will be considered the per-step time
+  - The time between a call to this function and the next call to this function will be considered the per-step time.
 - Cannot modify the given hyperparameters in a workload-conditional way (please see the [Valid submission](#valid-submissions) section). This rule is intended to prohibit circumventing the tuning rules by looking up a pre-tuned optimal set of hyperparameters for each workload. It is not intended to prohibit line searches and other similar techniques.
-  - This will be checked by the spirit jury
+  - This will be checked by the spirit jury.
 - The fixed `init_model_fn` can optionally be called during training, for example, to reinitialize the model after a failed training effort.
 - Cannot replace the model parameters with pre-trained ones.
   - This will be checked by the spirit jury.
-- This API supports Polyak averaging and similar methods that implement moving averages of model parameters
+- This API supports Polyak averaging and similar methods that implement moving averages of model parameters.
 - Batch norm should work here because the `model_fn` will return updated batch norm moving averages when it is told to with `update_batch_norm`.
 
 ###### Data selection

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional, Tuple
 
 import jax
 import numpy as np
@@ -14,12 +14,13 @@ from algorithmic_efficiency import spec
 
 def shard_and_maybe_pad_np(
     batch: Dict[str, spec.Tensor],
+    padding_value: int = 0,
     global_batch_size: Optional[int] = None) -> Dict[str, spec.Tensor]:
   """Prepare tf data for JAX or PyTorch DDP.
 
-  Convert an input batch from tf Tensors to numpy arrays, pad it with zeros if
-  the batch size is not divisible by the number of devices, create the
-  corresponding mask, and reshape it to be sharded across devices.
+  Convert an input batch from tf Tensors to numpy arrays, pad it with
+  padding_value if the batch size is not divisible by the number of devices,
+  create the corresponding mask, and reshape it to be sharded across devices.
   """
   local_device_count = max(torch.cuda.device_count(), jax.local_device_count())
   current_batch_size = batch['inputs'].shape[0]
@@ -32,7 +33,7 @@ def shard_and_maybe_pad_np(
     targets_shape = tuple(batch['targets'].shape)
     # We need a 2d mask for WMT.
     mask_shape = targets_shape if len(targets_shape) < 3 else targets_shape[0]
-    # Will also be zero-padded.
+    # The weights will also be padded.
     batch['weights'] = np.ones(mask_shape)
 
   def _prepare(x):
@@ -42,7 +43,7 @@ def shard_and_maybe_pad_np(
 
     # Pad if remainder_size != 0 (should only be possible during evaluation).
     if remainder_size != 0:
-      x = pad(x, pad_size, 'jax')
+      x = pad(x, pad_size, 'jax', padding_value=padding_value)
 
     # Reshape (global_batch_size, ...) to
     # (local_device_count, per_device_batch_size, ...).
@@ -52,21 +53,26 @@ def shard_and_maybe_pad_np(
   return jax.tree_map(_prepare, batch)
 
 
-def pad(tensor: spec.Tensor, pad_size: int, framework: str) -> spec.Tensor:
+def pad(tensor: spec.Tensor,
+        pad_size: int,
+        framework: str,
+        padding_value: int = 0) -> spec.Tensor:
   if len(tensor) > 1:
     pad_size = (pad_size, *tensor.shape[1:])
   if framework == 'pytorch':
-    padding = torch.zeros(pad_size, dtype=tensor.dtype, device=tensor.device)
+    padding = torch.full(
+        pad_size, padding_value, dtype=tensor.dtype, device=tensor.device)
     padded_tensor = torch.cat((tensor, padding), dim=0)
   elif framework == 'jax':
-    padding = np.zeros(pad_size, dtype=tensor.dtype)
+    padding = np.full(pad_size, padding_value, dtype=tensor.dtype)
     padded_tensor = np.concatenate((tensor, padding), axis=0)
   else:
     raise ValueError(f'Framework has to be pytorch or jax, but is {framework}.')
   return padded_tensor
 
 
-def mixup_pytorch(batch, alpha=0.2):
+def mixup_pytorch(batch: Tuple[spec.Tensor, spec.Tensor],
+                  alpha: float = 0.2) -> Tuple[spec.Tensor, spec.Tensor]:
   inputs, targets = batch
   # Transform to one-hot targets.
   targets = F.one_hot(targets, num_classes=1000)
@@ -80,11 +86,11 @@ def mixup_pytorch(batch, alpha=0.2):
 
 
 # github.com/pytorch/pytorch/issues/23900#issuecomment-518858050
-def cycle(iterable,
-          keys=('inputs', 'targets'),
-          custom_sampler=False,
-          use_mixup=False,
-          mixup_alpha=0.2):
+def cycle(iterable: Iterable,
+          keys: Tuple[str, ...] = ('inputs', 'targets'),
+          custom_sampler: bool = False,
+          use_mixup: bool = False,
+          mixup_alpha: float = 0.2):
   iterator = iter(iterable)
   epoch = 0
   while True:

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -278,8 +278,8 @@ class Workload(metaclass=abc.ABCMeta):
       label_batch: Union[Tuple[Tensor, Tensor], Tensor],
       logits_batch: Union[Tuple[Tensor, Tensor], Tensor],
       mask_batch: Optional[Tensor] = None,
-      label_smoothing: float = 0.0) -> Tensor:  # differentiable
-    """Return 1-d array of per-example losses."""
+      label_smoothing: float = 0.0) -> Tuple[Tensor, Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
 
   @abc.abstractmethod
   def _eval_model_on_split(self,

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
@@ -10,7 +10,7 @@ from flax import jax_utils
 import jax
 import tensorflow as tf
 
-from algorithmic_efficiency.data_utils import shard_numpy_ds
+from algorithmic_efficiency.data_utils import shard_and_maybe_pad_np
 
 IMAGE_SIZE = 32
 MEAN_RGB = [0.49139968 * 255, 0.48215827 * 255, 0.44653124 * 255]
@@ -255,7 +255,7 @@ def create_input_iter(split,
       aspect_ratio_range=aspect_ratio_range,
       area_range=area_range)
   it = map(
-      functools.partial(shard_numpy_ds, global_batch_size=global_batch_size),
+      functools.partial(shard_and_maybe_pad_np, global_batch_size=global_batch_size),
       ds)
 
   # Note(Dan S): On a Nvidia 2080 Ti GPU, this increased GPU utilization by 10%.

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
@@ -255,7 +255,8 @@ def create_input_iter(split,
       aspect_ratio_range=aspect_ratio_range,
       area_range=area_range)
   it = map(
-      functools.partial(shard_and_maybe_pad_np, global_batch_size=global_batch_size),
+      functools.partial(
+          shard_and_maybe_pad_np, global_batch_size=global_batch_size),
       ds)
 
   # Note(Dan S): On a Nvidia 2080 Ti GPU, this increased GPU utilization by 10%.

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
@@ -150,24 +150,33 @@ class CifarWorkload(BaseCifarWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self,
-              label_batch: spec.Tensor,
-              logits_batch: spec.Tensor,
-              mask_batch: Optional[spec.Tensor] = None,
-              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor,
+      mask_batch: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
     one_hot_targets = jax.nn.one_hot(label_batch, 10)
     smoothed_targets = optax.smooth_labels(one_hot_targets, label_smoothing)
-    losses = -jnp.sum(smoothed_targets * nn.log_softmax(logits_batch), axis=-1)
+    per_example_losses = -jnp.sum(
+        smoothed_targets * nn.log_softmax(logits_batch), axis=-1)
     # mask_batch is assumed to be shape [batch]
     if mask_batch is not None:
-      losses *= mask_batch
-    return losses
+      per_example_losses *= mask_batch
+      n_valid_examples = mask_batch.sum()
+    else:
+      n_valid_examples = len(per_example_losses)
+    summed_loss = per_example_losses.sum()
+    return summed_loss / n_valid_examples, per_example_losses
 
   def _compute_metrics(self,
                        logits: spec.Tensor,
                        labels: spec.Tensor,
                        weights: spec.Tensor) -> Dict[str, spec.Tensor]:
-    loss = jnp.sum(self.loss_fn(labels, logits, weights))
+    _, per_example_losses = self.loss_fn(labels, logits, weights)
+    loss = jnp.sum(per_example_losses)
     # Number of correct predictions.
     accuracy = jnp.sum((jnp.argmax(logits, -1) == labels) * weights)
     metrics = {

--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -103,7 +103,7 @@ def get_criteo1tb_dataset(split: str,
 
   ds = map(
       functools.partial(
-          data_utils.shard_numpy_ds, global_batch_size=global_batch_size),
+          data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
       ds)
 
   return ds

--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -103,7 +103,8 @@ def get_criteo1tb_dataset(split: str,
 
   ds = map(
       functools.partial(
-          data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
+          data_utils.shard_and_maybe_pad_np,
+          global_batch_size=global_batch_size),
       ds)
 
   return ds

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -57,19 +57,26 @@ class FastMRIWorkload(BaseFastMRIWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self,
-              label_batch: spec.Tensor,
-              logits_batch: spec.Tensor,
-              mask_batch: Optional[spec.Tensor] = None,
-              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor,
+      mask_batch: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
     del label_smoothing
-    losses = jnp.mean(
+    per_example_losses = jnp.mean(
         jnp.abs(logits_batch - label_batch),
         axis=tuple(range(1, logits_batch.ndim)))
     # mask_batch is assumed to be shape [batch].
     if mask_batch is not None:
-      losses *= mask_batch
-    return losses
+      per_example_losses *= mask_batch
+      n_valid_examples = mask_batch.sum()
+    else:
+      n_valid_examples = len(per_example_losses)
+    summed_loss = per_example_losses.sum()
+    return summed_loss / n_valid_examples, per_example_losses
 
   @functools.partial(
       jax.pmap,
@@ -98,7 +105,8 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         std=batch['std'],
         volume_max=batch['volume_max'])
     ssim_sum = jnp.sum(ssim_vals * weights)
-    loss = jnp.sum(self.loss_fn(batch['targets'], logits, weights))
+    _, per_example_losses = self.loss_fn(batch['targets'], logits, weights)
+    loss = jnp.sum(per_example_losses)
     metrics = {
         'ssim': ssim_sum,
         'loss': loss,

--- a/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
@@ -231,5 +231,6 @@ def load_fastmri_split(global_batch_size,
     ds = ds.prefetch(10)
     return map(
         functools.partial(
-            data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
+            data_utils.shard_and_maybe_pad_np,
+            global_batch_size=global_batch_size),
         ds)

--- a/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
@@ -221,7 +221,7 @@ def load_fastmri_split(global_batch_size,
 
   if is_train:
     ds = ds.prefetch(10)
-    iterator = map(data_utils.shard_numpy_ds, ds)
+    iterator = map(data_utils.shard_and_maybe_pad_np, ds)
     return iterator
   else:
     if num_batches:
@@ -231,5 +231,5 @@ def load_fastmri_split(global_batch_size,
     ds = ds.prefetch(10)
     return map(
         functools.partial(
-            data_utils.shard_numpy_ds, global_batch_size=global_batch_size),
+            data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
         ds)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -380,7 +380,7 @@ def create_input_iter(split: str,
       use_randaug=use_randaug)
   it = map(
       functools.partial(
-          data_utils.shard_numpy_ds, global_batch_size=global_batch_size),
+          data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
       ds)
 
   # Note(Dan S): On a Nvidia 2080 Ti GPU, this increased GPU utilization by 10%.

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -380,7 +380,8 @@ def create_input_iter(split: str,
       use_randaug=use_randaug)
   it = map(
       functools.partial(
-          data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
+          data_utils.shard_and_maybe_pad_np,
+          global_batch_size=global_batch_size),
       ds)
 
   # Note(Dan S): On a Nvidia 2080 Ti GPU, this increased GPU utilization by 10%.

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -157,24 +157,30 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self,
-              label_batch: spec.Tensor,
-              logits_batch: spec.Tensor,
-              mask_batch: Optional[spec.Tensor] = None,
-              label_smoothing: float = 0.0) -> spec.Tensor:
-    """Cross Entropy Loss."""
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor,
+      mask_batch: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
     if label_batch.shape[-1] != self._num_classes:
       one_hot_labels = jax.nn.one_hot(
           label_batch, num_classes=self._num_classes)
     else:
       one_hot_labels = label_batch
     smoothed_labels = optax.smooth_labels(one_hot_labels, label_smoothing)
-    losses = -jnp.sum(
+    per_example_losses = -jnp.sum(
         smoothed_labels * jax.nn.log_softmax(logits_batch, axis=-1), axis=-1)
     # mask_batch is assumed to be shape [batch].
     if mask_batch is not None:
-      losses *= mask_batch
-    return losses
+      per_example_losses *= mask_batch
+      n_valid_examples = mask_batch.sum()
+    else:
+      n_valid_examples = len(per_example_losses)
+    summed_loss = per_example_losses.sum()
+    return summed_loss / n_valid_examples, per_example_losses
 
   def _compute_metrics(self,
                        logits: spec.Tensor,
@@ -182,7 +188,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
                        weights: spec.Tensor) -> Dict[str, spec.Tensor]:
     if weights is None:
       weights = jnp.ones(len(logits))
-    loss = jnp.sum(self.loss_fn(labels, logits, weights))
+    _, per_example_losses = self.loss_fn(labels, logits, weights)
+    loss = jnp.sum(per_example_losses)
     # not accuracy, but nr. of correct predictions
     accuracy = jnp.sum((jnp.argmax(logits, -1) == labels) * weights)
     metrics = {

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -211,21 +211,27 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self,
-              label_batch: spec.Tensor,
-              logits_batch: spec.Tensor,
-              mask_batch: Optional[spec.Tensor] = None,
-              label_smoothing: float = 0.0) -> spec.Tensor:
-    """Cross Entropy Loss."""
-    losses = F.cross_entropy(
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor,
+      mask_batch: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
+    per_example_losses = F.cross_entropy(
         logits_batch,
         label_batch,
         reduction='none',
         label_smoothing=label_smoothing)
     # mask_batch is assumed to be shape [batch].
     if mask_batch is not None:
-      losses *= mask_batch
-    return losses
+      per_example_losses *= mask_batch
+      n_valid_examples = mask_batch.sum()
+    else:
+      n_valid_examples = len(per_example_losses)
+    summed_loss = per_example_losses.sum()
+    return summed_loss / n_valid_examples, per_example_losses
 
   def _compute_metrics(self,
                        logits: spec.Tensor,
@@ -237,7 +243,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     predicted = torch.argmax(logits, 1)
     # not accuracy, but nr. of correct predictions
     accuracy = ((predicted == labels) * weights).sum()
-    loss = self.loss_fn(labels, logits, weights).sum()
+    _, per_example_losses = self.loss_fn(labels, logits, weights)
+    loss = per_example_losses.sum()
     return {'accuracy': accuracy, 'loss': loss}
 
   def _eval_model_on_split(self,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
@@ -40,6 +40,6 @@ def get_imagenet_v2_iter(data_dir: str,
   ds = ds.map(_decode_example, num_parallel_calls=16)
   ds = ds.batch(global_batch_size)
   shard_pad_fn = functools.partial(
-      data_utils.shard_numpy_ds, global_batch_size=global_batch_size)
+      data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size)
   it = map(shard_pad_fn, iter(ds))
   return it

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -70,7 +70,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     pass
 
-  def init_tokenizer(self, tokenizer_vocab_path):
+  def init_tokenizer(self, tokenizer_vocab_path: str) -> None:
     logging.info('Initializing tokenizer.')
     self.tokenizer = metrics.load_tokenizer(tokenizer_vocab_path)
 
@@ -114,6 +114,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
                          num_batches: Optional[int] = None,
                          repeat_final_dataset: bool = False):
     del data_rng
+    del num_batches
     del repeat_final_dataset
     train = False
 
@@ -185,7 +186,9 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     del label_smoothing
     return self._loss_fn(label_batch, logits_batch)['average_loss']
 
-  def greedy_decode(self, logits, logit_paddings):
+  def greedy_decode(
+      self, logits: spec.Tensor,
+      logit_paddings: spec.Tensor) -> Tuple[spec.Tensor, spec.Tensor]:
     framewise_tokens = logits.max(dim=-1)[1]
     framewise_tokens = framewise_tokens * (1 - logit_paddings)
 
@@ -214,7 +217,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     padding = (fin_result == 0)
     return fin_result, padding
 
-  def sync_sd(self, params):
+  def sync_sd(self, params: spec.ParameterContainer) -> None:
     sd = params.state_dict()
     dist.barrier()
     for k in sd:
@@ -231,7 +234,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
                            model_state: spec.ModelAuxiliaryState,
                            rng: spec.RandomState,
                            data_dir: str,
-                           global_step: int):
+                           global_step: int) -> Dict[str, float]:
     """Run a full evaluation of the model."""
     del global_step
     data_rng, model_rng = prng.split(rng, 2)

--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -1,11 +1,8 @@
 from typing import Optional
 
 from absl import flags
-from absl import logging
-import jax
-import numpy as np
-import torch
 
+from algorithmic_efficiency import data_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.librispeech_conformer import \
     input_pipeline
@@ -21,47 +18,47 @@ class BaseLibrispeechWorkload(spec.Workload):
     return eval_result['validation/wer'] < self.target_value
 
   @property
-  def target_value(self):
+  def target_value(self) -> float:
     return 0.0842
 
   @property
-  def loss_type(self):
+  def loss_type(self) -> spec.LossType:
     return spec.LossType.CTC_LOSS
 
   @property
-  def num_train_examples(self):
+  def num_train_examples(self) -> int:
     return 263840
 
   @property
-  def num_eval_train_examples(self):
+  def num_eval_train_examples(self) -> int:
     return 256
 
   @property
-  def num_validation_examples(self):
+  def num_validation_examples(self) -> int:
     return 5348
 
   @property
-  def num_test_examples(self):
+  def num_test_examples(self) -> int:
     return 2472
 
   @property
-  def eval_batch_size(self):
+  def eval_batch_size(self) -> int:
     return 256
 
   @property
-  def train_mean(self):
+  def train_mean(self) -> float:
     return 0.0
 
   @property
-  def train_stddev(self):
+  def train_stddev(self) -> float:
     return 1.0
 
   @property
-  def max_allowed_runtime_sec(self):
+  def max_allowed_runtime_sec(self) -> int:
     return 72000  # 20h
 
   @property
-  def eval_period_time_sec(self):
+  def eval_period_time_sec(self) -> int:
     return 40 * 60  # 40m
 
   def _build_input_queue(self,
@@ -72,69 +69,19 @@ class BaseLibrispeechWorkload(spec.Workload):
                          cache: Optional[bool] = False,
                          repeat_final_dataset: Optional[bool] = False,
                          num_batches: Optional[int] = None):
+    del cache
+    del repeat_final_dataset
     return self._build_dataset(data_rng,
                                split,
                                data_dir,
                                global_batch_size,
                                num_batches)
 
-  def shard(self, batch, n_devices=None):
-    if n_devices is None:
-      n_devices = max(torch.cuda.device_count(), jax.local_device_count())
-
-    # Otherwise, the entries are arrays, so just reshape them.
-    def _shard_array(array):
-      return array.reshape((n_devices, -1) + array.shape[1:])
-
-    return jax.tree_map(_shard_array, batch)
-
-  def maybe_pad_batch(self, batch, desired_batch_size, padding_value=0.0):
-    """Zero pad the batch on the right to desired_batch_size.
-
-    All keys in the batch dictionary will have their corresponding arrays
-    padded. Will return a dictionary with the same keys.
-
-    Args:
-      batch: A dictionary mapping keys to arrays. We assume that inputs is
-      one of the keys.
-      desired_batch_size: All arrays in the dict will be padded to have
-      first dimension equal to desired_batch_size.
-      padding_value: value to be used as padding.
-
-    Returns:
-      A dictionary mapping the same keys to the padded batches. Additionally
-      we add a key representing weights, to indicate how the batch was padded.
-    """
-    batch_axis = 0
-    inputs, input_paddings = batch['inputs']
-    targets, target_paddings = batch['targets']
-
-    batch_size = inputs.shape[batch_axis]
-    batch_pad = desired_batch_size - batch_size
-
-    # Most batches will not need padding so we quickly return to avoid slowdown.
-    if batch_pad == 0:
-      new_batch = jax.tree_map(lambda x: x, batch)
-      return new_batch
-
-    def zero_pad(ar, pad_axis):
-      pw = [(0, 0)] * ar.ndim
-      pw[pad_axis] = (0, batch_pad)
-      return np.pad(ar, pw, mode='constant', constant_values=padding_value)
-
-    padded_batch = {
-        'inputs': (zero_pad(inputs, batch_axis),
-                   zero_pad(input_paddings, batch_axis)),
-        'targets': (zero_pad(targets, batch_axis),
-                    zero_pad(target_paddings, batch_axis))
-    }
-    return padded_batch
-
   def _build_dataset(self,
                      data_rng: spec.RandomState,
                      split: str,
                      data_dir: str,
-                     batch_size: int,
+                     global_batch_size: int,
                      num_batches: Optional[int] = None):
     train = False
     if split == 'train':
@@ -151,16 +98,12 @@ class BaseLibrispeechWorkload(spec.Workload):
                                                 data_dir,
                                                 data_rng,
                                                 train,
-                                                batch_size,
+                                                global_batch_size,
                                                 num_batches)
 
-    logging.info('done loading split = %s', split)
-
     for batch in iter(ds):
-      batch = jax.tree_map(lambda x: x._numpy(), batch)  # pylint: disable=protected-access
-      batch = self.maybe_pad_batch(batch, batch_size, padding_value=1.0)
-      batch = self.shard(batch)
-
+      batch = data_utils.shard_and_maybe_pad_np(
+          batch, padding_value=1, global_batch_size=global_batch_size)
       yield batch
 
   @property

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -64,7 +64,7 @@ class MnistWorkload(BaseMnistWorkload):
     ds = ds.batch(global_batch_size, drop_remainder=is_train)
     ds = map(
         functools.partial(
-            data_utils.shard_numpy_ds, global_batch_size=global_batch_size),
+            data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
         ds)
     return iter(ds)
 

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -64,7 +64,8 @@ class MnistWorkload(BaseMnistWorkload):
     ds = ds.batch(global_batch_size, drop_remainder=is_train)
     ds = map(
         functools.partial(
-            data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
+            data_utils.shard_and_maybe_pad_np,
+            global_batch_size=global_batch_size),
         ds)
     return iter(ds)
 

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -119,18 +119,26 @@ class MnistWorkload(BaseMnistWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self,
-              label_batch: spec.Tensor,
-              logits_batch: spec.Tensor,
-              mask_batch: Optional[spec.Tensor] = None,
-              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor,
+      mask_batch: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
     one_hot_targets = jax.nn.one_hot(label_batch, 10)
     smoothed_targets = optax.smooth_labels(one_hot_targets, label_smoothing)
-    losses = -jnp.sum(smoothed_targets * nn.log_softmax(logits_batch), axis=-1)
+    per_example_losses = -jnp.sum(
+        smoothed_targets * nn.log_softmax(logits_batch), axis=-1)
     # mask_batch is assumed to be shape [batch].
     if mask_batch is not None:
-      losses *= mask_batch
-    return losses
+      per_example_losses *= mask_batch
+      n_valid_examples = mask_batch.sum()
+    else:
+      n_valid_examples = len(per_example_losses)
+    summed_loss = per_example_losses.sum()
+    return summed_loss / n_valid_examples, per_example_losses
 
   @functools.partial(
       jax.pmap,
@@ -155,7 +163,8 @@ class MnistWorkload(BaseMnistWorkload):
       weights = jnp.ones(len(logits))
     accuracy = jnp.sum(
         (jnp.argmax(logits, axis=-1) == batch['targets']) * weights)
-    loss = jnp.sum(self.loss_fn(batch['targets'], logits, weights))
+    _, per_example_losses = self.loss_fn(batch['targets'], logits, weights)
+    loss = jnp.sum(per_example_losses)
     metrics = {'accuracy': accuracy, 'loss': loss}
     metrics = lax.psum(metrics, axis_name='batch')
     return metrics

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -164,20 +164,27 @@ class MnistWorkload(BaseMnistWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self,
-              label_batch: spec.Tensor,
-              logits_batch: spec.Tensor,
-              mask_batch: Optional[spec.Tensor] = None,
-              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
-    losses = F.cross_entropy(
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor,
+      mask_batch: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
+    per_example_losses = F.cross_entropy(
         logits_batch,
         label_batch,
         reduction='none',
         label_smoothing=label_smoothing)
     # mask_batch is assumed to be shape [batch].
     if mask_batch is not None:
-      losses *= mask_batch
-    return losses
+      per_example_losses *= mask_batch
+      n_valid_examples = mask_batch.sum()
+    else:
+      n_valid_examples = len(per_example_losses)
+    summed_loss = per_example_losses.sum()
+    return summed_loss / n_valid_examples, per_example_losses
 
   def _eval_model(
       self,
@@ -196,5 +203,6 @@ class MnistWorkload(BaseMnistWorkload):
     _, predicted = torch.max(logits.data, 1)
     # Number of correct predictions.
     accuracy = (predicted == batch['targets']).sum()
-    loss = self.loss_fn(batch['targets'], logits).sum()
+    _, per_example_losses = self.loss_fn(batch['targets'], logits)
+    loss = per_example_losses.sum()
     return {'accuracy': accuracy, 'loss': loss}

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_jax/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_jax/workload.py
@@ -93,11 +93,10 @@ class OgbgWorkload(BaseOgbgWorkload):
     abs_logits = jnp.where(positive_logits, logits, -logits)
     losses = relu_logits - (logits * smoothed_labels) + (
         jnp.log(1 + jnp.exp(-abs_logits)))
-    return jnp.where(mask, losses, jnp.nan)
+    return jnp.where(mask, losses, 0.)
 
   def _eval_metric(self, labels, logits, masks):
-    per_example_losses = self.loss_fn(labels, logits, masks)
-    loss = jnp.sum(jnp.where(masks, per_example_losses, 0)) / jnp.sum(masks)
+    loss, _ = self.loss_fn(labels, logits, masks)
     return metrics.EvalMetrics.single_from_model_output(
         loss=loss, logits=logits, labels=labels, mask=masks)
 

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
@@ -197,11 +197,10 @@ class OgbgWorkload(BaseOgbgWorkload):
     abs_logits = torch.where(positive_logits, logits, -logits)
     losses = relu_logits - (logits * smoothed_labels) + (
         torch.log(1 + torch.exp(-abs_logits)))
-    return torch.where(mask, losses, torch.nan)
+    return torch.where(mask, losses, 0.)
 
   def _eval_metric(self, labels, logits, masks):
-    per_example_losses = self.loss_fn(labels, logits, masks)
-    loss = torch.where(masks, per_example_losses, 0).sum() / masks.sum()
+    loss, _ = self.loss_fn(labels, logits, masks)
     return metrics.EvalMetrics.single_from_model_output(
         loss=loss.cpu().numpy(),
         logits=logits.cpu().numpy(),

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -1,6 +1,6 @@
 import itertools
 import math
-from typing import Dict
+from typing import Dict, Optional, Tuple
 
 from absl import flags
 import jax
@@ -81,17 +81,25 @@ class BaseOgbgWorkload(spec.Workload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(self,
-              label_batch: spec.Tensor,
-              logits_batch: spec.Tensor,
-              mask_batch: spec.Tensor,
-              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor,
+      mask_batch: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
     per_example_losses = self._binary_cross_entropy_with_mask(
         labels=label_batch,
         logits=logits_batch,
         mask=mask_batch,
         label_smoothing=label_smoothing)
-    return per_example_losses
+    if mask_batch is not None:
+      n_valid_examples = mask_batch.sum()
+    else:
+      n_valid_examples = len(per_example_losses)
+    summed_loss = per_example_losses.sum()
+    return summed_loss / n_valid_examples, per_example_losses
 
   @property
   def step_hint(self) -> int:

--- a/algorithmic_efficiency/workloads/wmt/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/wmt/input_pipeline.py
@@ -298,7 +298,7 @@ def get_wmt_dataset(data_rng,
 
   ds = map(
       functools.partial(
-          data_utils.shard_numpy_ds, global_batch_size=global_batch_size),
+          data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
       ds)
 
   return ds, sp_tokenizer

--- a/algorithmic_efficiency/workloads/wmt/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/wmt/input_pipeline.py
@@ -298,7 +298,8 @@ def get_wmt_dataset(data_rng,
 
   ds = map(
       functools.partial(
-          data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size),
+          data_utils.shard_and_maybe_pad_np,
+          global_batch_size=global_batch_size),
       ds)
 
   return ds, sp_tokenizer

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -44,7 +44,7 @@ class WmtWorkload(BaseWmtWorkload):
        values.
 
     Returns:
-      Tuple of loss for every example and batch normalizing factor.
+      Per-example losses.
     """
     if logits.ndim != targets.ndim + 1:
       raise ValueError(f'Incorrect shapes. Got shape {logits.shape} logits and '

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -1,6 +1,6 @@
 """WMT workload implemented in Jax."""
 import functools
-from typing import Dict, Optional, Tuple
+from typing import Dict, Iterator, Optional, Tuple
 
 from absl import logging
 from flax import jax_utils
@@ -19,7 +19,7 @@ from algorithmic_efficiency.workloads.wmt.wmt_jax import models
 from algorithmic_efficiency.workloads.wmt.workload import BaseWmtWorkload
 
 
-def _to_host(x):
+def _to_host(x: spec.Tensor) -> spec.Tensor:
   """Collect batches from all devices to host and flatten batch dimensions."""
   n_device, n_batch, *remaining_dims = x.shape
   return np.array(x).reshape((n_device * n_batch,) + tuple(remaining_dims))
@@ -28,11 +28,12 @@ def _to_host(x):
 class WmtWorkload(BaseWmtWorkload):
   """WMT Jax workload."""
 
-  def compute_weighted_cross_entropy(self,
-                                     logits,
-                                     targets,
-                                     weights=None,
-                                     label_smoothing=0.1):
+  def compute_weighted_cross_entropy(
+      self,
+      logits: spec.Tensor,
+      targets: spec.Tensor,
+      weights: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.1) -> spec.Tensor:
     """Compute weighted cross entropy and entropy for log probs and targets.
 
     Args:
@@ -61,7 +62,9 @@ class WmtWorkload(BaseWmtWorkload):
 
   @functools.partial(
       jax.pmap, axis_name='batch', static_broadcasted_argnums=(0,))
-  def eval_step_pmapped(self, params, batch):
+  def eval_step_pmapped(
+      self, params: spec.ParameterContainer,
+      batch: Dict[str, spec.Tensor]) -> Dict[str, spec.Tensor]:
     """Calculate evaluation metrics on a batch."""
     inputs = batch['inputs']
     targets = batch['targets']
@@ -73,13 +76,17 @@ class WmtWorkload(BaseWmtWorkload):
     metrics = self.compute_summed_metrics(logits, targets, weights)
     return metrics
 
-  def eval_step(self, params, batch):
+  def eval_step(self,
+                params: spec.ParameterContainer,
+                batch: Dict[str, spec.Tensor]) -> Dict[str, spec.Tensor]:
     replicated_eval_metrics = self.eval_step_pmapped(params, batch)
     return jax.tree_map(lambda x: jnp.sum(x, axis=0), replicated_eval_metrics)
 
   @functools.partial(
       jax.pmap, axis_name='batch', static_broadcasted_argnums=(0,))
-  def initialize_cache(self, inputs, max_decode_len=256):
+  def initialize_cache(self,
+                       inputs: spec.Tensor,
+                       max_decode_len: int = 256) -> Dict[str, spec.Tensor]:
     """Initialize a cache for a given input shape and max decode length."""
     config = models.TransformerConfig(deterministic=True, decode=True)
     target_shape = (inputs.shape[0], max_decode_len) + inputs.shape[2:]
@@ -93,12 +100,12 @@ class WmtWorkload(BaseWmtWorkload):
   @functools.partial(
       jax.pmap, axis_name='batch', static_broadcasted_argnums=(0, 4, 5))
   def predict_step(self,
-                   inputs,
-                   params,
-                   cache,
-                   eos_id,
-                   max_decode_len,
-                   beam_size=4):
+                   inputs: spec.Tensor,
+                   params: spec.ParameterContainer,
+                   cache: Dict[str, spec.Tensor],
+                   eos_id: int,
+                   max_decode_len: int,
+                   beam_size: int = 4) -> spec.Tensor:
     """Predict translation with fast decoding beam search on a batch."""
     config = models.TransformerConfig(deterministic=True, decode=True)
     # Prepare transformer fast-decoder call for beam search: for beam search, we
@@ -114,7 +121,9 @@ class WmtWorkload(BaseWmtWorkload):
         beam_size)
     raw_inputs = decode.flat_batch_beam_expand(inputs, beam_size)
 
-    def tokens_ids_to_logits(flat_ids, flat_cache):
+    def tokens_ids_to_logits(
+        flat_ids: spec.Tensor, flat_cache: Dict[str, spec.Tensor]
+    ) -> Tuple[spec.Tensor, Dict[str, spec.Tensor]]:
       """Token slice to logits from decoder model."""
       # --> [batch * beam, 1, vocab]
       flat_logits, new_vars = models.Transformer(config).apply(
@@ -150,10 +159,10 @@ class WmtWorkload(BaseWmtWorkload):
     return beam_seqs[:, -1, 1:]
 
   def translate_and_calculate_bleu(self,
-                                   params,
-                                   ds_iter,
-                                   num_batches,
-                                   max_predict_length: int):
+                                   params: spec.ParameterContainer,
+                                   ds_iter: Iterator,
+                                   num_batches: int,
+                                   max_predict_length: int) -> spec.Tensor:
     """Translates the `predict_ds` and calculates the BLEU score."""
     logging.info('Translating evaluation dataset.')
     references, predictions = [], []

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -41,7 +41,7 @@ class WmtWorkload(BaseWmtWorkload):
        values.
 
     Returns:
-      Tuple of loss for every example and batch normalizing factor.
+      Per-example losses.
     """
     if logits.ndim != targets.ndim + 1:
       raise ValueError(f'Incorrect shapes. Got shape {logits.shape} logits and '

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -30,7 +30,8 @@ class WmtWorkload(BaseWmtWorkload):
       logits: spec.Tensor,
       targets: spec.Tensor,
       weights: Optional[spec.Tensor] = None,
-      label_smoothing: float = 0.1) -> spec.Tensor:
+      label_smoothing: float = 0.1
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
     """Compute weighted cross entropy and entropy for log probs and targets.
 
     Args:
@@ -41,7 +42,7 @@ class WmtWorkload(BaseWmtWorkload):
        values.
 
     Returns:
-      Per-example losses.
+      (correct scalar average loss, 1-d array of per-example losses)
     """
     if logits.ndim != targets.ndim + 1:
       raise ValueError(f'Incorrect shapes. Got shape {logits.shape} logits and '
@@ -53,11 +54,14 @@ class WmtWorkload(BaseWmtWorkload):
       loss_fn = DP(loss_fn)
 
     # PyTorch loss functions expect the class dim directly after the batch dim.
-    loss = loss_fn(logits.transpose(-2, -1), targets)
+    per_example_losses = loss_fn(logits.transpose(-2, -1), targets)
     mask = torch.where(targets > 0, 1, 0)
     if weights is not None:
       mask = torch.logical_and(weights, mask)
-    return torch.where(mask.to(torch.bool), loss, torch.nan)
+    per_example_losses = torch.where(mask, per_example_losses, 0.)
+    summed_loss = per_example_losses.sum()
+    n_valid_samples = mask.sum()
+    return summed_loss / n_valid_samples, per_example_losses
 
   # Primary eval / decode step functions.
   # ----------------------------------------------------------------------------
@@ -311,13 +315,14 @@ class WmtWorkload(BaseWmtWorkload):
         model_state=None,
         rng=None,
         update_batch_norm=False)
-    loss = self.compute_weighted_cross_entropy(logits, targets, weights, 0.0)
+    _, per_example_losses = self.compute_weighted_cross_entropy(
+        logits, targets, weights, 0.0)
     mask = torch.where(targets > 0, 1, 0)
     if weights is not None:
       mask = torch.logical_and(weights, mask)
     acc_sum, weight_sum = self.compute_weighted_accuracy(logits, targets, mask)
     return {
-        'loss': torch.nansum(loss),
+        'loss': torch.sum(per_example_losses),
         'accuracy': acc_sum,
         'denominator': weight_sum,
     }

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -162,20 +162,6 @@ class BaseWmtWorkload(spec.Workload):
 
     return eval_results
 
-  def compute_summed_metrics(self,
-                             logits: spec.Tensor,
-                             labels: spec.Tensor,
-                             weights: spec.Tensor) -> Dict[str, spec.Tensor]:
-    """Compute metrics summed across examples."""
-    loss = self.compute_weighted_cross_entropy(logits, labels, weights, 0.0)
-    acc_sum, weight_sum = self.compute_weighted_accuracy(
-        logits, labels, weights)
-    return {
-        'loss': loss.sum(),
-        'accuracy': acc_sum,
-        'denominator': weight_sum,
-    }
-
   def compute_weighted_accuracy(
       self, logits: spec.Tensor, targets: spec.Tensor,
       weights: spec.Tensor) -> Tuple[spec.Tensor, spec.Tensor]:
@@ -190,8 +176,8 @@ class BaseWmtWorkload(spec.Workload):
       Tuple of scalar summed accuracy and batch normalizing factor.
     """
     if logits.ndim != targets.ndim + 1:
-      raise ValueError('Incorrect shapes. Got shape %s logits and %s targets' %
-                       (str(logits.shape), str(targets.shape)))
+      raise ValueError(f'Incorrect shapes. Got shape {logits.shape} logits and '
+                       f'{targets.shape} targets.')
     accuracy = (logits.argmax(-1) == targets) * weights
     normalizing_factor = weights.sum()
     return accuracy.sum(), normalizing_factor

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -188,12 +188,16 @@ class BaseWmtWorkload(spec.Workload):
     valid_toks = toks[:np.argmax(toks == decode.EOS_ID) + 1].astype(np.int32)
     return self._tokenizer.detokenize(valid_toks).numpy().decode('utf-8')
 
+  # Does NOT apply regularization, which is left to the submitter to do in
+  # `update_params`.
   def loss_fn(
       self,
-      label_batch: spec.Tensor,  # Dense (not one-hot) labels.
+      label_batch: spec.Tensor,
       logits_batch: spec.Tensor,
       mask_batch: Optional[spec.Tensor] = None,
-      label_smoothing: float = 0.0) -> spec.Tensor:
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
     return self.compute_weighted_cross_entropy(
         logits_batch,
         label_batch,

--- a/reference_algorithms/development_algorithms/cifar/cifar_jax/submission.py
+++ b/reference_algorithms/development_algorithms/cifar/cifar_jax/submission.py
@@ -91,7 +91,7 @@ def pmapped_train_step(workload,
         spec.ForwardPassMode.TRAIN,
         rng,
         update_batch_norm=True)
-    loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
+    loss, _ = workload.loss_fn(batch['targets'], logits)
     weight_penalty_params = jax.tree_util.tree_leaves(params)
     weight_l2 = sum(jnp.sum(x**2) for x in weight_penalty_params if x.ndim > 1)
     weight_penalty = hyperparameters.l2 * 0.5 * weight_l2

--- a/reference_algorithms/development_algorithms/cifar/cifar_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/cifar/cifar_pytorch/submission.py
@@ -81,8 +81,8 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=True)
 
-  loss = workload.loss_fn(
-      label_batch=batch['targets'], logits_batch=logits_batch).mean()
+  loss, _ = workload.loss_fn(
+      label_batch=batch['targets'], logits_batch=logits_batch)
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/reference_algorithms/development_algorithms/criteo1tb/criteo1tb_jax/submission.py
+++ b/reference_algorithms/development_algorithms/criteo1tb/criteo1tb_jax/submission.py
@@ -74,7 +74,7 @@ def pmapped_train_step(workload,
         spec.ForwardPassMode.TRAIN,
         rng,
         update_batch_norm=False)
-    loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
+    loss, _ = workload.loss_fn(batch['targets'], logits)
     return loss, new_model_state
 
   grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)

--- a/reference_algorithms/development_algorithms/criteo1tb/criteo1tb_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/criteo1tb/criteo1tb_pytorch/submission.py
@@ -76,8 +76,8 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=False)
 
-  loss = workload.loss_fn(
-      label_batch=batch['targets'], logits_batch=logits_batch).mean()
+  loss, _ = workload.loss_fn(
+      label_batch=batch['targets'], logits_batch=logits_batch)
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/reference_algorithms/development_algorithms/fastmri/fastmri_jax/submission.py
+++ b/reference_algorithms/development_algorithms/fastmri/fastmri_jax/submission.py
@@ -79,7 +79,7 @@ def pmapped_train_step(workload,
         mode=spec.ForwardPassMode.TRAIN,
         rng=rng,
         update_batch_norm=True)
-    loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
+    loss, _ = workload.loss_fn(batch['targets'], logits)
     weight_penalty_params = jax.tree_util.tree_leaves(params)
     weight_l2 = sum(jnp.sum(x**2) for x in weight_penalty_params if x.ndim > 1)
     weight_penalty = hyperparameters.l2 * 0.5 * weight_l2

--- a/reference_algorithms/development_algorithms/fastmri/fastmri_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/fastmri/fastmri_pytorch/submission.py
@@ -68,8 +68,8 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=True)
 
-  loss = workload.loss_fn(
-      label_batch=batch['targets'], logits_batch=outputs_batch).mean()
+  loss, _ = workload.loss_fn(
+      label_batch=batch['targets'], logits_batch=outputs_batch)
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/reference_algorithms/development_algorithms/imagenet_resnet/imagenet_jax/submission.py
+++ b/reference_algorithms/development_algorithms/imagenet_resnet/imagenet_jax/submission.py
@@ -87,7 +87,7 @@ def pmapped_train_step(workload,
         spec.ForwardPassMode.TRAIN,
         rng,
         update_batch_norm=True)
-    loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
+    loss, _ = workload.loss_fn(batch['targets'], logits)
     weight_penalty_params = jax.tree_util.tree_leaves(variables['params'])
     weight_l2 = sum(jnp.sum(x**2) for x in weight_penalty_params if x.ndim > 1)
     weight_penalty = hyperparameters.l2 * 0.5 * weight_l2

--- a/reference_algorithms/development_algorithms/imagenet_resnet/imagenet_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/imagenet_resnet/imagenet_pytorch/submission.py
@@ -84,8 +84,8 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=True)
 
-  loss = workload.loss_fn(
-      label_batch=batch['targets'], logits_batch=logits_batch).mean()
+  loss, _ = workload.loss_fn(
+      label_batch=batch['targets'], logits_batch=logits_batch)
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/reference_algorithms/development_algorithms/imagenet_vit/imagenet_jax/submission.py
+++ b/reference_algorithms/development_algorithms/imagenet_vit/imagenet_jax/submission.py
@@ -87,7 +87,7 @@ def pmapped_train_step(workload,
         spec.ForwardPassMode.TRAIN,
         rng,
         update_batch_norm=True)
-    loss = jnp.mean(workload.loss_fn(batch['targets'], logits))
+    loss, _ = workload.loss_fn(batch['targets'], logits)
     weight_penalty_params = jax.tree_util.tree_leaves(params)
     weight_l2 = sum(jnp.sum(x**2) for x in weight_penalty_params if x.ndim > 1)
     weight_penalty = hyperparameters.l2 * 0.5 * weight_l2

--- a/reference_algorithms/development_algorithms/imagenet_vit/imagenet_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/imagenet_vit/imagenet_pytorch/submission.py
@@ -82,8 +82,8 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=True)
 
-  loss = workload.loss_fn(
-      label_batch=batch['targets'], logits_batch=logits_batch).mean()
+  loss, _ = workload.loss_fn(
+      label_batch=batch['targets'], logits_batch=logits_batch)
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/reference_algorithms/development_algorithms/mnist/mnist_jax/submission.py
+++ b/reference_algorithms/development_algorithms/mnist/mnist_jax/submission.py
@@ -62,8 +62,8 @@ def pmapped_update_params(workload: spec.Workload,
         spec.ForwardPassMode.TRAIN,
         rng,
         update_batch_norm=True)
-    loss = workload.loss_fn(batch['targets'], logits_batch)
-    return jnp.mean(loss), new_model_state
+    loss, _ = workload.loss_fn(batch['targets'], logits_batch)
+    return loss, new_model_state
 
   grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
   (_, new_model_state), grad = grad_fn(current_param_container)

--- a/reference_algorithms/development_algorithms/mnist/mnist_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/mnist/mnist_pytorch/submission.py
@@ -59,8 +59,7 @@ def update_params(workload: spec.Workload,
       rng=rng,
       update_batch_norm=True)
 
-  loss = workload.loss_fn(
-      label_batch=batch['targets'], logits_batch=output).mean()
+  loss, _ = workload.loss_fn(label_batch=batch['targets'], logits_batch=output)
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/reference_algorithms/development_algorithms/ogbg/ogbg_jax/submission.py
+++ b/reference_algorithms/development_algorithms/ogbg/ogbg_jax/submission.py
@@ -41,7 +41,7 @@ def train_step(workload,
                batch,
                rng):
 
-  def loss_fn(params):
+  def _loss_fn(params):
     logits_batch, new_model_state  = workload.model_fn(
         params,
         batch,
@@ -50,15 +50,10 @@ def train_step(workload,
         rng,
         update_batch_norm=True)
     mask_batch = batch['weights']
-    per_example_losses = workload.loss_fn(batch['targets'],
-                                          logits_batch,
-                                          mask_batch)
-    mean_loss = (
-        jnp.sum(jnp.where(mask_batch, per_example_losses, 0)) /
-        jnp.sum(mask_batch))
+    mean_loss, _ = workload.loss_fn(batch['targets'], logits_batch, mask_batch)
     return mean_loss, new_model_state
 
-  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
+  grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)
   (_, new_model_state), grad = grad_fn(current_param_container)
   grad = lax.pmean(grad, axis_name='batch')
   updates, new_optimizer_state = opt_update_fn(

--- a/reference_algorithms/development_algorithms/ogbg/ogbg_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/ogbg/ogbg_pytorch/submission.py
@@ -58,8 +58,7 @@ def update_params(workload: spec.Workload,
       update_batch_norm=True)
 
   mask = batch['weights']
-  per_example_losses = workload.loss_fn(batch['targets'], logits, mask)
-  loss = torch.where(mask, per_example_losses, 0).sum() / mask.sum()
+  loss, _ = workload.loss_fn(batch['targets'], logits, mask)
 
   loss.backward()
   optimizer_state['optimizer'].step()

--- a/reference_algorithms/development_algorithms/wmt/wmt_jax/submission.py
+++ b/reference_algorithms/development_algorithms/wmt/wmt_jax/submission.py
@@ -108,6 +108,7 @@ def pmapped_train_step(workload,
                        dropout_rng,
                        hyperparameters):
   """Perform a single training step."""
+  del hyperparameters
 
   def _loss_fn(params):
     """Loss function used for training."""
@@ -119,9 +120,7 @@ def pmapped_train_step(workload,
         rng=dropout_rng,
         update_batch_norm=False)
     targets = batch['targets']
-    weights = jnp.where(targets > 0, 1.0, 0.0)
-    loss = (workload.loss_fn(targets, logits, label_smoothing=0.1) *
-            weights).sum() / weights.sum()
+    loss = jnp.nanmean(workload.loss_fn(targets, logits, label_smoothing=0.1))
     return loss
 
   grad_fn = jax.value_and_grad(_loss_fn)

--- a/reference_algorithms/development_algorithms/wmt/wmt_jax/submission.py
+++ b/reference_algorithms/development_algorithms/wmt/wmt_jax/submission.py
@@ -120,7 +120,7 @@ def pmapped_train_step(workload,
         rng=dropout_rng,
         update_batch_norm=False)
     targets = batch['targets']
-    loss = jnp.nanmean(workload.loss_fn(targets, logits, label_smoothing=0.1))
+    loss, _ = workload.loss_fn(targets, logits, label_smoothing=0.1)
     return loss
 
   grad_fn = jax.value_and_grad(_loss_fn)

--- a/reference_algorithms/development_algorithms/wmt/wmt_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/wmt/wmt_pytorch/submission.py
@@ -101,8 +101,9 @@ def update_params(workload: spec.Workload,
                   rng: spec.RandomState) -> spec.UpdateReturn:
   """Return (updated_optimizer_state, updated_params)."""
   del current_params_types
-  del eval_results
+  del hyperparameters
   del loss_type
+  del eval_results
 
   current_model = current_param_container
   current_param_container.train()
@@ -118,9 +119,7 @@ def update_params(workload: spec.Workload,
       update_batch_norm=False)
 
   targets = batch['targets']
-  weights = torch.where(targets > 0, 1.0, 0.0)
-  loss = (workload.loss_fn(targets, logits, label_smoothing=0.1) *
-          weights).sum() / weights.sum()
+  loss = torch.nanmean(workload.loss_fn(targets, logits, label_smoothing=0.1))
   loss.backward()
 
   lr = optimizer_state['scheduler'](global_step).item()

--- a/reference_algorithms/development_algorithms/wmt/wmt_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/wmt/wmt_pytorch/submission.py
@@ -119,7 +119,7 @@ def update_params(workload: spec.Workload,
       update_batch_norm=False)
 
   targets = batch['targets']
-  loss = torch.nanmean(workload.loss_fn(targets, logits, label_smoothing=0.1))
+  loss, _ = workload.loss_fn(targets, logits, label_smoothing=0.1)
   loss.backward()
 
   lr = optimizer_state['scheduler'](global_step).item()

--- a/reference_algorithms/target_setting_algorithms/jax_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/jax_submission_base.py
@@ -37,12 +37,11 @@ def pmapped_train_step(workload,
         spec.ForwardPassMode.TRAIN,
         rng,
         update_batch_norm=True)
-    loss = jnp.nanmean(
-        workload.loss_fn(
-            label_batch=batch['targets'],
-            logits_batch=logits,
-            mask_batch=batch.get('weights'),
-            label_smoothing=label_smoothing))
+    loss, _ = workload.loss_fn(
+        label_batch=batch['targets'],
+        logits_batch=logits,
+        mask_batch=batch.get('weights'),
+        label_smoothing=label_smoothing)
     return loss, new_model_state
 
   grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)

--- a/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/pytorch_submission_base.py
@@ -42,12 +42,11 @@ def update_params(workload: spec.Workload,
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
-  loss = torch.nanmean(
-      workload.loss_fn(
-          label_batch=batch['targets'],
-          logits_batch=logits_batch,
-          mask_batch=batch.get('weights'),
-          label_smoothing=label_smoothing))
+  loss, _ = workload.loss_fn(
+      label_batch=batch['targets'],
+      logits_batch=logits_batch,
+      mask_batch=batch.get('weights'),
+      label_smoothing=label_smoothing)
 
   loss.backward()
   if grad_clip is not None:


### PR DESCRIPTION
This PR is a follow-up to #233. It 
- renames `shard_numpy_ds` to `shard_and_maybe_pad_np`,
- refactors padding in librispeech workloads to use `shard_and_maybe_pad_np`,
- adds more type hints to the WMT workloads,
- refactors the use of weights in the WMT workloads, which fixes #227 (at least it should, I did not train long enough to check),
- and changes the `loss_fn` API to return a tuple `(correct averaged loss, per-example losses)` instead of just a tensor `per_example_losses`.