### PR TITLE
[WIP] FFCV Implementation for ImageNet

### DIFF
--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -250,8 +250,8 @@ class PrefetchedWrapper:
     return len(self.dataloader)
 
   def __iter__(self):
-    if isinstance(self.dataloader.sampler,
-                  (DistributedSampler, DistributedEvalSampler)):
+    if hasattr(self.dataloader, 'sampler') and isinstance(
+        self.dataloader.sampler, (DistributedSampler, DistributedEvalSampler)):
       self.dataloader.sampler.set_epoch(self.epoch)
     self.epoch += 1
     return self.prefetched_loader()

--- a/algorithmic_efficiency/init_utils.py
+++ b/algorithmic_efficiency/init_utils.py
@@ -12,6 +12,6 @@ def pytorch_default_init(module: nn.Module) -> None:
   # Perform lecun_normal initialization.
   fan_in, _ = nn.init._calculate_fan_in_and_fan_out(module.weight)
   std = math.sqrt(1. / fan_in) / .87962566103423978
-  nn.init.trunc_normal_(module.weight.data, std=std)
+  nn.init.trunc_normal_(module.weight, std=std)
   if module.bias is not None:
-    nn.init.constant_(module.bias.data, 0.)
+    nn.init.constant_(module.bias, 0.)

--- a/algorithmic_efficiency/pytorch_utils.py
+++ b/algorithmic_efficiency/pytorch_utils.py
@@ -29,6 +29,8 @@ def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler) -> None:
   # From the docs: "(...) causes cuDNN to benchmark multiple convolution
   # algorithms and select the fastest."
   torch.backends.cudnn.benchmark = True
+  torch.autograd.profiler.emit_nvtx(False)
+  torch.autograd.profiler.profile(False)
 
   if use_pytorch_ddp:
     # Avoid tf input pipeline creating too many threads.

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, List, Optional, Type, Union
 import torch
 from torch import nn
 from torch import Tensor
-# import torch.nn.functional as F
+import torch.nn.functional as F
 
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.init_utils import pytorch_default_init
@@ -251,7 +251,7 @@ class ResNet(nn.Module):
     x = self.conv1(x)
     x = self.bn1(x)
     x = self.relu(x)
-    # x = F.pad(x, [0, 1, 0, 1], 'constant', float('-inf'))
+    x = F.pad(x, [0, 1, 0, 1], 'constant', float('-inf'))
     x = self.maxpool(x)
 
     x = self.layer1(x)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, List, Optional, Type, Union
 import torch
 from torch import nn
 from torch import Tensor
-import torch.nn.functional as F
+# import torch.nn.functional as F
 
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.init_utils import pytorch_default_init
@@ -187,10 +187,10 @@ class ResNet(nn.Module):
       if isinstance(m, nn.Conv2d):
         pytorch_default_init(m)
       elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
-        nn.init.constant_(m.weight.data, 1)
-        nn.init.constant_(m.bias.data, 0)
-    nn.init.normal_(self.fc.weight.data, std=1e-2)
-    nn.init.constant_(self.fc.bias.data, 0.)
+        nn.init.constant_(m.weight, 1)
+        nn.init.constant_(m.bias, 0)
+    nn.init.normal_(self.fc.weight, std=1e-2)
+    nn.init.constant_(self.fc.bias, 0.)
 
     # Zero-initialize the last BN in each residual branch,
     # so that the residual branch starts with zeros,
@@ -200,9 +200,9 @@ class ResNet(nn.Module):
     if zero_init_residual:
       for m in self.modules():
         if isinstance(m, Bottleneck):
-          nn.init.constant_(m.bn3.weight.data, 0)
+          nn.init.constant_(m.bn3.weight, 0)
         elif isinstance(m, BasicBlock):
-          nn.init.constant_(m.bn2.weight.data, 0)
+          nn.init.constant_(m.bn2.weight, 0)
 
   def _make_layer(self,
                   block: Type[Union[BasicBlock, Bottleneck]],
@@ -251,7 +251,7 @@ class ResNet(nn.Module):
     x = self.conv1(x)
     x = self.bn1(x)
     x = self.relu(x)
-    x = F.pad(x, [0, 1, 0, 1], 'constant', float('-inf'))
+    # x = F.pad(x, [0, 1, 0, 1], 'constant', float('-inf'))
     x = self.maxpool(x)
 
     x = self.layer1(x)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -257,6 +257,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       ds_iter_batch_size = global_batch_size
 
     ffcv_success = write_ffcv_imagenet(data_dir, split)
+    ffcv_success = False
     if ffcv_success:
       dataloader = self._build_ffcv_dataset(split,
                                             data_dir,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -221,7 +221,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
     dataloader = ffcv.loader.Loader(
         os.path.join(data_dir, f'{folder}.ffcv'),
-        batch_size=128,
+        batch_size=32,
         # We always use the same subset of the training data for evaluation.
         indices=range(self.num_eval_train_examples)
         if split == 'eval_train' else None,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -164,7 +164,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       data_dir: str,
       batch_size: int,
       use_randaug: bool = False) -> Iterator[Dict[str, spec.Tensor]]:
-    use_randaug = True
     is_train = split == 'train'
     folder = 'train' if 'train' in split else 'val'
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -107,7 +107,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       global_batch_size: int,
       cache: Optional[bool] = None,
       repeat_final_dataset: Optional[bool] = None,
-      use_mixup: bool = False,
       use_randaug: bool = False) -> Iterator[Dict[str, spec.Tensor]]:
     del data_rng
     del cache
@@ -178,7 +177,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       global_batch_size: int,
       cache: Optional[bool] = None,
       repeat_final_dataset: Optional[bool] = None,
-      use_mixup: bool = False,
       use_randaug: bool = False) -> Iterator[Dict[str, spec.Tensor]]:
     del data_rng
     del cache
@@ -206,7 +204,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       ]
     else:
       order = ffcv.loader.OrderOption.SEQUENTIAL
-      cropper = ffcv.transforms.CenterCropRGBImageDecoder(
+      cropper = ffcv.fields.rgb_image.CenterCropRGBImageDecoder(
           (self.center_crop_size, self.center_crop_size),
           ratio=self.center_crop_size / self.resize_size)
       image_pipeline = [
@@ -308,6 +306,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
+    model = model.to(memory_format=torch.channels_last)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -184,7 +184,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
               np.array(self.train_stddev),
               np.float32),
       ]
-      if randaugment:
+      if use_randaug:
         image_pipeline.insert(4, randaugment.RandAugment())
     else:
       order = ffcv.loader.OrderOption.SEQUENTIAL
@@ -215,13 +215,13 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         # We always use the same subset of the training data for evaluation.
         indices=range(self.num_eval_train_examples)
         if split == 'eval_train' else None,
-        num_workers=1,
+        num_workers=8,
         os_cache=True,
         order=order,
         drop_last=True if is_train else False,
         seed=0,
         pipelines={'image': image_pipeline, 'label': label_pipeline},
-        batches_ahead=1,
+        batches_ahead=2,
         distributed=USE_PYTORCH_DDP)
 
     return dataloader

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -221,7 +221,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
     dataloader = ffcv.loader.Loader(
         os.path.join(data_dir, f'{folder}.ffcv'),
-        batch_size=ds_iter_batch_size,
+        batch_size=128,
         # We always use the same subset of the training data for evaluation.
         indices=range(self.num_eval_train_examples)
         if split == 'eval_train' else None,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -215,13 +215,13 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         # We always use the same subset of the training data for evaluation.
         indices=range(self.num_eval_train_examples)
         if split == 'eval_train' else None,
-        num_workers=8,
+        num_workers=4,
         os_cache=True,
         order=order,
         drop_last=True if is_train else False,
         seed=0,
         pipelines={'image': image_pipeline, 'label': label_pipeline},
-        batches_ahead=2,
+        batches_ahead=1,
         distributed=USE_PYTORCH_DDP)
 
     return dataloader

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -226,6 +226,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         indices=range(self.num_eval_train_examples)
         if split == 'eval_train' else None,
         num_workers=2,
+        os_cache=True,
         order=order,
         drop_last=True if is_train else False,
         seed=0,
@@ -291,7 +292,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
-    # model = model.to(memory_format=torch.channels_last)
+    model = model.to(memory_format=torch.channels_last)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -78,7 +78,7 @@ def write_ffcv_imagenet(data_dir: str,
             {
                 'image':
                     ffcv.fields.RGBImageField(
-                        write_mode='raw',
+                        write_mode='proportion',
                         max_resolution=500,
                         compress_probability=0.50,
                         jpeg_quality=90),
@@ -221,12 +221,11 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
     dataloader = ffcv.loader.Loader(
         os.path.join(data_dir, f'{folder}.ffcv'),
-        batch_size=32,
+        batch_size=ds_iter_batch_size,
         # We always use the same subset of the training data for evaluation.
         indices=range(self.num_eval_train_examples)
         if split == 'eval_train' else None,
         num_workers=2,
-        os_cache=True,
         order=order,
         drop_last=True if is_train else False,
         seed=0,
@@ -291,8 +290,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     model = resnet50()
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
-    model.to(DEVICE)
     model = model.to(memory_format=torch.channels_last)
+    model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -222,11 +222,13 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     dataloader = ffcv.loader.Loader(
         os.path.join(data_dir, f'{folder}.ffcv'),
         batch_size=ds_iter_batch_size,
+        # We always use the same subset of the training data for evaluation.
         indices=range(self.num_eval_train_examples)
         if split == 'eval_train' else None,
-        num_workers=4,
+        num_workers=2,
         order=order,
         drop_last=True if is_train else False,
+        seed=0,
         pipelines={'image': image_pipeline, 'label': label_pipeline},
         batches_ahead=1,
         distributed=USE_PYTORCH_DDP)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -101,16 +101,10 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
   def _build_pytorch_dataset(
       self,
-      data_rng: spec.RandomState,
       split: str,
       data_dir: str,
       global_batch_size: int,
-      cache: Optional[bool] = None,
-      repeat_final_dataset: Optional[bool] = None,
       use_randaug: bool = False) -> Iterator[Dict[str, spec.Tensor]]:
-    del data_rng
-    del cache
-    del repeat_final_dataset
 
     is_train = split == 'train'
 
@@ -171,16 +165,10 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
   def _build_ffcv_dataset(
       self,
-      data_rng: spec.RandomState,
       split: str,
       data_dir: str,
       global_batch_size: int,
-      cache: Optional[bool] = None,
-      repeat_final_dataset: Optional[bool] = None,
       use_randaug: bool = False) -> Iterator[Dict[str, spec.Tensor]]:
-    del data_rng
-    del cache
-    del repeat_final_dataset
 
     is_train = split == 'train'
     folder = 'train' if 'train' in split else 'val'
@@ -255,6 +243,9 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       repeat_final_dataset: Optional[bool] = None,
       use_mixup: bool = False,
       use_randaug: bool = False) -> Iterator[Dict[str, spec.Tensor]]:
+    del data_rng
+    del cache
+    del repeat_final_dataset
 
     if split == 'test':
       np_iter = imagenet_v2.get_imagenet_v2_iter(
@@ -268,22 +259,14 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
     success = write_ffcv_imagenet(data_dir, split)
     if success:
-      dataloader = self._build_ffcv_dataset(data_rng,
-                                            split,
+      dataloader = self._build_ffcv_dataset(split,
                                             data_dir,
                                             global_batch_size,
-                                            cache,
-                                            repeat_final_dataset,
-                                            use_mixup,
                                             use_randaug)
     else:
-      dataloader = self._build_pytorch_dataset(data_rng,
-                                               split,
+      dataloader = self._build_pytorch_dataset(split,
                                                data_dir,
                                                global_batch_size,
-                                               cache,
-                                               repeat_final_dataset,
-                                               use_mixup,
                                                use_randaug)
 
     dataloader = data_utils.cycle(

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -291,7 +291,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     self._param_shapes = param_utils.pytorch_param_shapes(model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)
     model.to(DEVICE)
-    model = model.to(memory_format=torch.channels_last)
+    # model = model.to(memory_format=torch.channels_last)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
@@ -37,7 +37,7 @@ def get_imagenet_v2_iter(data_dir: str,
                                                resize_size)
     return {'inputs': image, 'targets': example['label']}
 
-  ds = ds.map(_decode_example, num_parallel_calls=16)
+  ds = ds.map(_decode_example, num_parallel_calls=4)
   ds = ds.batch(global_batch_size)
   shard_pad_fn = functools.partial(
       data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
@@ -7,11 +7,15 @@ import functools
 from typing import Dict, Iterator, Tuple
 
 import tensorflow_datasets as tfds
+import torch.distributed as dist
 
 from algorithmic_efficiency import data_utils
 from algorithmic_efficiency import spec
+from algorithmic_efficiency.pytorch_utils import pytorch_setup
 from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax import \
     input_pipeline
+
+USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 
 
 def get_imagenet_v2_iter(data_dir: str,
@@ -21,13 +25,26 @@ def get_imagenet_v2_iter(data_dir: str,
                          image_size: int,
                          resize_size: int) -> Iterator[Dict[str, spec.Tensor]]:
   """Always caches and repeats indefinitely."""
-  ds = tfds.load(
-      'imagenet_v2/matched-frequency:3.0.0',
-      split='test',
-      data_dir=data_dir,
-      decoders={
-          'image': tfds.decode.SkipDecoding(),
-      })
+  if RANK == 0:
+    ds = tfds.load(
+        'imagenet_v2/matched-frequency:3.0.0',
+        split='test',
+        data_dir=data_dir,
+        decoders={
+            'image': tfds.decode.SkipDecoding(),
+        })
+  if USE_PYTORCH_DDP:
+    # If the dataset does not exist, wait for the download.
+    dist.barrier()
+
+  if RANK != 0:
+    ds = tfds.load(
+        'imagenet_v2/matched-frequency:3.0.0',
+        split='test',
+        data_dir=data_dir,
+        decoders={
+            'image': tfds.decode.SkipDecoding(),
+        })
 
   def _decode_example(example: Dict[str, float]) -> Dict[str, float]:
     image = input_pipeline.preprocess_for_eval(example['image'],

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -68,7 +68,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def max_allowed_runtime_sec(self) -> int:
-    return 1000  # 31 hours.
+    return 111600  # 31 hours.
 
   @property
   def eval_period_time_sec(self) -> int:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -68,7 +68,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def max_allowed_runtime_sec(self) -> int:
-    return 111600  # 31 hours.
+    return 1000  # 31 hours.
 
   @property
   def eval_period_time_sec(self) -> int:

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,18 +129,26 @@ pytorch_core_deps =
 # PyTorch CPU
 pytorch_cpu =
   %(pytorch_core_deps)s
-  torch==1.12.1
-  torchvision==0.13.1
+  torch==1.13.0
+  torchvision==0.14.0
 
 # PyTorch GPU
 pytorch_gpu =
   %(pytorch_core_deps)s
-  torch==1.12.1+cu113
-  torchvision==0.13.1+cu113
+  torch==1.13.0+cu117
+  torchvision==0.14.0+cu117
 
-# wandb
+# Weights & Biases Logging
 wandb =
   wandb==0.13.4
+
+# FFCV Data Loading
+ffcv =
+  opencv_python==4.6.0.66
+  numba==0.56.3
+  cupy==11.2.0
+  ffcv @ git+https://github.com/pomonam/ffcv.git
+
 
 ###############################################################################
 #                           Linting Configurations                            #

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -105,7 +105,7 @@ flags.DEFINE_string(
 flags.DEFINE_integer('num_tuning_trials',
                      1,
                      'The number of external hyperparameter trials to run.')
-flags.DEFINE_string('data_dir', '~/tensorflow_datasets/', 'Dataset location.')
+flags.DEFINE_string('data_dir', '~/datasets/', 'Dataset location.')
 flags.DEFINE_string('imagenet_v2_data_dir',
                     '~/tensorflow_datasets/',
                     'Dataset location for ImageNet-v2.')
@@ -276,6 +276,9 @@ def train_once(
     metrics_logger = logger_utils.set_up_loggers(log_dir, flags.FLAGS)
     workload.attach_metrics_logger(metrics_logger)
 
+  if USE_PYTORCH_DDP:
+    dist.barrier()
+
   global_start_time = time.time()
   logging.info('Starting training loop.')
   while train_state['is_time_remaining'] and \
@@ -313,9 +316,6 @@ def train_once(
     global_step += 1
     if (max_global_steps is not None) and (global_step == max_global_steps):
       train_state['training_complete'] = True
-    if USE_PYTORCH_DDP:
-      # Make sure all processes run eval after the same step when using DDP.
-      dist.barrier()
     current_time = time.time()
     train_state['accumulated_submission_time'] += current_time - start_time
     train_state['is_time_remaining'] = (
@@ -324,6 +324,9 @@ def train_once(
     # Check if submission is eligible for an untimed eval.
     if ((current_time - train_state['last_eval_time']) >=
         workload.eval_period_time_sec or train_state['training_complete']):
+      if USE_PYTORCH_DDP:
+        # Make sure all processes run eval after the same step when using DDP.
+        dist.barrier()
       with profiler.profile('Evaluation'):
         try:
           latest_eval_result = workload.eval_model(global_eval_batch_size,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -105,7 +105,7 @@ flags.DEFINE_string(
 flags.DEFINE_integer('num_tuning_trials',
                      1,
                      'The number of external hyperparameter trials to run.')
-flags.DEFINE_string('data_dir', '~/datasets/', 'Dataset location.')
+flags.DEFINE_string('data_dir', '~/tensorflow_datasets/', 'Dataset location.')
 flags.DEFINE_string('imagenet_v2_data_dir',
                     '~/tensorflow_datasets/',
                     'Dataset location for ImageNet-v2.')
@@ -316,6 +316,9 @@ def train_once(
     global_step += 1
     if (max_global_steps is not None) and (global_step == max_global_steps):
       train_state['training_complete'] = True
+    if USE_PYTORCH_DDP:
+      # Make sure all processes run eval after the same step when using DDP.
+      dist.barrier()
     current_time = time.time()
     train_state['accumulated_submission_time'] += current_time - start_time
     train_state['is_time_remaining'] = (
@@ -324,9 +327,6 @@ def train_once(
     # Check if submission is eligible for an untimed eval.
     if ((current_time - train_state['last_eval_time']) >=
         workload.eval_period_time_sec or train_state['training_complete']):
-      if USE_PYTORCH_DDP:
-        # Make sure all processes run eval after the same step when using DDP.
-        dist.barrier()
       with profiler.profile('Evaluation'):
         try:
           latest_eval_result = workload.eval_model(global_eval_batch_size,


### PR DESCRIPTION
This PR implements FFCV loaders on ImageNet workloads. There are some caveats:
- To use the FFCV loader, we require to use the Python version higher or equal to 3.8.
- The main branch for FFCV (v0.0.3) has several known issues such as memory usage. At the moment, I forked the FFCV loader to my repo (https://github.com/pomonam/ffcv) and installing from this repo.
- FFCV loader requires an additional 300G space. I made FFCV optional as the user might not have enough storage for conversion.

I am currently working on:
- [ ] Port existing data augmentation code (e.g., RandAugment) to be compatible with FFCV. 
- [x] There is an ongoing OOM issue with our batch size. I am debugging where the large GPU consumption stems from. 