### PR TITLE
Fix `loss_fn` in librispeech workloads

### DIFF
--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -93,23 +93,33 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
           mutable=False)
       return (logits, logit_paddings), model_state
 
-  def loss_fn(self,
-              label_batch: Tuple[spec.Tensor, spec.Tensor],
-              logits_batch: Tuple[spec.Tensor, spec.Tensor],
-              mask_batch: Optional[spec.Tensor] = None,
-              label_smoothing: float = 0.0) -> spec.Tensor:  # differentiable
-    del mask_batch
+  # Does NOT apply regularization, which is left to the submitter to do in
+  # `update_params`.
+  def loss_fn(
+      self,
+      label_batch: spec.Tensor,
+      logits_batch: spec.Tensor,
+      mask_batch: Optional[spec.Tensor] = None,
+      label_smoothing: float = 0.0
+  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+    """Return (correct scalar average loss, 1-d array of per-example losses)."""
     del label_smoothing
     logits, logit_paddings = logits_batch
     targets, target_paddings = label_batch
     logprobs = nn.log_softmax(logits)
-    per_seq_loss = self.ctc_loss(logprobs,
-                                 logit_paddings,
-                                 targets,
-                                 target_paddings)
-    normalizer = jnp.sum(1 - target_paddings)
-    normalized_loss = jnp.sum(per_seq_loss) / jnp.maximum(normalizer, 1)
-    return normalized_loss
+    per_example_losses = self.ctc_loss(logprobs,
+                                       logit_paddings,
+                                       targets,
+                                       target_paddings)
+    # mask_batch is assumed to be shape [batch].
+    if mask_batch is not None:
+      per_example_losses *= mask_batch
+      mask_batch = jnp.logical_and(mask_batch, 1 - target_paddings)
+    else:
+      mask_batch = target_paddings
+    n_valid_examples = jnp.maximum(mask_batch.sum(), 1)
+    summed_loss = per_example_losses.sum()
+    return summed_loss / n_valid_examples, per_example_losses
 
   def ctc_loss(self,
                logits: spec.Tensor,
@@ -214,7 +224,8 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
         update_batch_norm=False)
 
     decoded, decoded_paddings = self.greedy_decode(logits, logit_paddings)
-    normalized_loss = self.loss_fn(batch['targets'], (logits, logit_paddings))
+    normalized_loss, _ = self.loss_fn(
+        batch['targets'], (logits, logit_paddings))
 
     targets, target_paddings = batch['targets']
     return self.metrics_bundle.gather_from_model_output(

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -116,7 +116,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       per_example_losses *= mask_batch
       mask_batch = jnp.logical_and(mask_batch, 1 - target_paddings)
     else:
-      mask_batch = target_paddings
+      mask_batch = 1 - target_paddings
     n_valid_examples = jnp.maximum(mask_batch.sum(), 1)
     summed_loss = per_example_losses.sum()
     return summed_loss / n_valid_examples, per_example_losses

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -274,7 +274,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       mean_loss, per_example_losses = self.loss_fn(
           (targets, target_paddings), (logits, logits_padding))
       summed_loss = per_example_losses.sum()
-      lengths = summed_loss / mean_loss
+      lengths = torch.round(summed_loss / mean_loss)
       batch_metrics = {
           'loss': summed_loss,
           'lengths': lengths,

--- a/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_jax/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_jax/submission.py
@@ -110,7 +110,7 @@ def pmapped_train_step(workload,
         rng={'params' : params_rng, 'dropout' : dropout_rng},
         update_batch_norm=True)
 
-    loss = workload.loss_fn(batch['targets'], (logits, logit_paddings))
+    loss, _ = workload.loss_fn(batch['targets'], (logits, logit_paddings))
     return loss, new_model_state
 
   grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)

--- a/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_pytorch/submission.py
@@ -62,6 +62,7 @@ def update_params(workload: spec.Workload,
   optimizer = optimizer_state['optimizer']
   optimizer.zero_grad()
   current_model = current_param_container
+
   (logits, logits_padding), _ = workload.model_fn(
       current_model,
       batch,
@@ -70,12 +71,14 @@ def update_params(workload: spec.Workload,
       rng,
       update_batch_norm=True)
 
-  train_ctc_loss = workload.loss_fn(batch['targets'], (logits, logits_padding))
-  train_ctc_loss.backward()
-  grad_clip = hyperparameters.grad_clip
+  loss, _ = workload.loss_fn(batch['targets'], (logits, logits_padding))
+  loss.backward()
+
   for g in optimizer.param_groups:
     g['lr'] = get_learning_rate(global_step, hyperparameters)
-  torch.nn.utils.clip_grad_norm_(current_model.parameters(), max_norm=grad_clip)
+  if hasattr(hyperparameters, 'grad_clib'):
+    torch.nn.utils.clip_grad_norm_(
+        current_model.parameters(), max_norm=hyperparameters.grad_clip)
   optimizer.step()
   return optimizer_state, current_param_container, None
 

--- a/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_conformer/librispeech_pytorch/submission.py
@@ -76,7 +76,7 @@ def update_params(workload: spec.Workload,
 
   for g in optimizer.param_groups:
     g['lr'] = get_learning_rate(global_step, hyperparameters)
-  if hasattr(hyperparameters, 'grad_clib'):
+  if hasattr(hyperparameters, 'grad_clip'):
     torch.nn.utils.clip_grad_norm_(
         current_model.parameters(), max_norm=hyperparameters.grad_clip)
   optimizer.step()

--- a/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_jax/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_jax/submission.py
@@ -110,7 +110,7 @@ def pmapped_train_step(workload,
         {'params' : params_rng, 'dropout' : dropout_rng},
         update_batch_norm=True)
 
-    loss = workload.loss_fn(batch['targets'], (logits, logit_paddings))
+    loss, _ = workload.loss_fn(batch['targets'], (logits, logit_paddings))
     return loss, new_model_state
 
   grad_fn = jax.value_and_grad(_loss_fn, has_aux=True)

--- a/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_pytorch/submission.py
+++ b/reference_algorithms/development_algorithms/librispeech_deepspeech/librispeech_pytorch/submission.py
@@ -59,6 +59,7 @@ def update_params(workload: spec.Workload,
   optimizer = optimizer_state['optimizer']
   optimizer.zero_grad()
   current_model = current_param_container
+
   (logits, logits_padding), _ = workload.model_fn(
       current_model,
       batch,
@@ -67,12 +68,14 @@ def update_params(workload: spec.Workload,
       rng,
       update_batch_norm=True)
 
-  train_ctc_loss = workload.loss_fn(batch['targets'], (logits, logits_padding))
-  train_ctc_loss.backward()
-  grad_clip = hyperparameters.grad_clip
+  loss, _ = workload.loss_fn(batch['targets'], (logits, logits_padding))
+  loss.backward()
+
   for g in optimizer.param_groups:
     g['lr'] = get_learning_rate(global_step, hyperparameters)
-  torch.nn.utils.clip_grad_norm_(current_model.parameters(), max_norm=grad_clip)
+  if hasattr(hyperparameters, 'grad_clip'):
+    torch.nn.utils.clip_grad_norm_(
+        current_model.parameters(), max_norm=hyperparameters.grad_clip)
   optimizer.step()
   return optimizer_state, current_param_container, None
 


### PR DESCRIPTION
This PR is a follow-up to #234 and fixes the `loss_fn` in the librispeech workloads to adhere to the new spec. Moreover, I noticed that in the PyTorch workloads the loss was synced via `all_reduce` in `loss_fn`. This is a bug, since it introduces unnecessary communication overhead when using PyTorch DDP (and can maybe even lead to wrong behavior, not sure about that).