### PR TITLE
Fix `num_eval_train_examples` for all workloads

### DIFF
--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
@@ -166,12 +166,7 @@ def create_split(split,
                  num_batches=None,
                  aspect_ratio_range=(0.75, 4.0 / 3.0),
                  area_range=(0.08, 1.0)):
-  """Creates a split from the ImageNet dataset using TensorFlow Datasets."""
-  if split == 'eval_train':
-    split = 'train'
-  elif split == 'validation':
-    split = 'test'
-
+  """Creates a split from the CIFAR-10 dataset using TensorFlow Datasets."""
   shuffle_rng, preprocess_rng = jax.random.split(rng, 2)
 
   def preprocess_example(example):

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
@@ -201,7 +201,7 @@ def create_split(split,
   if cache:
     ds = ds.cache()
 
-  if train:
+  if train or split == 'eval_train':
     ds = ds.repeat()
     ds = ds.shuffle(16 * global_batch_size, seed=shuffle_rng[0])
 

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
@@ -49,10 +49,8 @@ class CifarWorkload(BaseCifarWorkload):
     ds_builder.download_and_prepare()
     train = split == 'train'
     assert self.num_train_examples + self.num_validation_examples == 50000
-    if split == 'train':
+    if split in ['train', 'eval_train']:
       split = f'train[:{self.num_train_examples}]'
-    elif split == 'eval_train':
-      split = f'train[:{self.num_eval_train_examples}]'
     elif split == 'validation':
       split = f'train[{self.num_train_examples}:]'
     ds = input_pipeline.create_input_iter(

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
@@ -48,6 +48,13 @@ class CifarWorkload(BaseCifarWorkload):
     ds_builder = tfds.builder('cifar10:3.0.2', data_dir=data_dir)
     ds_builder.download_and_prepare()
     train = split == 'train'
+    assert self.num_train_examples + self.num_validation_examples == 50000
+    if split == 'train':
+      split = f'train[:{self.num_train_examples}]'
+    elif split == 'eval_train':
+      split = f'train[:{self.num_eval_train_examples}]'
+    elif split == 'validation':
+      split = f'train[{self.num_train_examples}:]'
     ds = input_pipeline.create_input_iter(
         split,
         ds_builder,

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import math
+import random
 from typing import Dict, Optional, Tuple
 
 import torch
@@ -67,6 +68,7 @@ class CifarWorkload(BaseCifarWorkload):
         transform=transform)
     assert self.num_train_examples + self.num_validation_examples == 50000
     indices = list(range(50000))
+    random.Random(data_rng[0]).shuffle(indices)
     indices_split = {
         'train': indices[:self.num_train_examples],
         'validation': indices[self.num_train_examples:],

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -68,12 +68,14 @@ class CifarWorkload(BaseCifarWorkload):
         transform=transform)
     assert self.num_train_examples + self.num_validation_examples == 50000
     indices = list(range(50000))
-    random.Random(data_rng[0]).shuffle(indices)
     indices_split = {
         'train': indices[:self.num_train_examples],
         'validation': indices[self.num_train_examples:],
-        'eval_train': indices[:self.num_eval_train_examples]
     }
+    if split == 'eval_train':
+      train_indices = indices_split['train']
+      random.Random(data_rng[0]).shuffle(train_indices)
+      indices_split['eval_train'] = train_indices[:self.num_eval_train_examples]
     if split in indices_split:
       dataset = torch.utils.data.Subset(dataset, indices_split[split])
 

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -68,7 +68,6 @@ class CifarWorkload(BaseCifarWorkload):
         transform=transform)
     assert self.num_train_examples + self.num_validation_examples == 50000
     indices = list(range(50000))
-    random.Random(data_rng[0]).shuffle(indices)
     indices_split = {
         'train': indices[:self.num_train_examples],
         'validation': indices[self.num_train_examples:],

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import math
-import random
 from typing import Dict, Optional, Tuple
 
 import torch

--- a/algorithmic_efficiency/workloads/cifar/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/workload.py
@@ -1,5 +1,7 @@
 """CIFAR workload parent class."""
 
+import math
+
 from algorithmic_efficiency import spec
 
 
@@ -22,7 +24,12 @@ class BaseCifarWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self):
-    return 5000
+    # Round up from num_validation_examples (which is the default for
+    # num_eval_train_examples) to the next multiple of eval_batch_size, so that
+    # we don't have to extract the correctly sized subset of the training data.
+    rounded_up_multiple = math.ceil(self.num_validation_examples /
+                                    self.eval_batch_size)
+    return rounded_up_multiple * self.eval_batch_size
 
   @property
   def num_validation_examples(self):

--- a/algorithmic_efficiency/workloads/cifar/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/workload.py
@@ -22,7 +22,7 @@ class BaseCifarWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self):
-    return 10000
+    return 5000
 
   @property
   def num_validation_examples(self):

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -37,7 +37,12 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self) -> int:
-    return 89_137_318 // 2
+    # Round up from num_validation_examples (which is the default for
+    # num_eval_train_examples) to the next multiple of eval_batch_size, so that
+    # we don't have to extract the correctly sized subset of the training data.
+    rounded_up_multiple = math.ceil(
+        self.num_validation_examples / self.eval_batch_size)
+    return rounded_up_multiple * self.eval_batch_size
 
   @property
   def num_validation_examples(self) -> int:

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -24,47 +24,47 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
     return eval_result['validation/loss'] < self.target_value
 
   @property
-  def target_value(self):
+  def target_value(self) -> float:
     return 0.124225
 
   @property
-  def loss_type(self):
+  def loss_type(self) -> spec.LossType:
     return spec.LossType.SIGMOID_CROSS_ENTROPY
 
   @property
-  def num_train_examples(self):
+  def num_train_examples(self) -> int:
     return 4_195_197_692
 
   @property
-  def num_eval_train_examples(self):
-    return 524_288 * 2
-
-  @property
-  def num_validation_examples(self):
+  def num_eval_train_examples(self) -> int:
     return 89_137_318 // 2
 
   @property
-  def num_test_examples(self):
+  def num_validation_examples(self) -> int:
     return 89_137_318 // 2
 
   @property
-  def eval_batch_size(self):
+  def num_test_examples(self) -> int:
+    return 89_137_318 // 2
+
+  @property
+  def eval_batch_size(self) -> int:
     return 524_288
 
   @property
-  def train_mean(self):
+  def train_mean(self) -> float:
     return 0.0
 
   @property
-  def train_stddev(self):
+  def train_stddev(self) -> float:
     return 1.0
 
   @property
-  def max_allowed_runtime_sec(self):
+  def max_allowed_runtime_sec(self) -> int:
     return 6 * 60 * 60
 
   @property
-  def eval_period_time_sec(self):
+  def eval_period_time_sec(self) -> int:
     return 24 * 60
 
   def _build_input_queue(self,

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -40,8 +40,8 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
     # Round up from num_validation_examples (which is the default for
     # num_eval_train_examples) to the next multiple of eval_batch_size, so that
     # we don't have to extract the correctly sized subset of the training data.
-    rounded_up_multiple = math.ceil(
-        self.num_validation_examples / self.eval_batch_size)
+    rounded_up_multiple = math.ceil(self.num_validation_examples /
+                                    self.eval_batch_size)
     return rounded_up_multiple * self.eval_batch_size
 
   @property

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -12,31 +12,31 @@ class BaseFastMRIWorkload(spec.Workload):
     return eval_result['validation/ssim'] > self.target_value
 
   @property
-  def target_value(self):
+  def target_value(self) -> float:
     return 0.7351
 
   @property
-  def loss_type(self):
+  def loss_type(self) -> spec.LossType:
     return spec.LossType.MEAN_ABSOLUTE_ERROR
 
   @property
-  def num_train_examples(self):
+  def num_train_examples(self) -> int:
     return 34742
 
   @property
-  def num_eval_train_examples(self):
-    return 3474
-
-  @property
-  def num_validation_examples(self):
+  def num_eval_train_examples(self) -> int:
     return 3554
 
   @property
-  def num_test_examples(self):
+  def num_validation_examples(self) -> int:
+    return 3554
+
+  @property
+  def num_test_examples(self) -> int:
     return 3581
 
   @property
-  def eval_batch_size(self):
+  def eval_batch_size(self) -> int:
     return 256
 
   @property
@@ -56,11 +56,11 @@ class BaseFastMRIWorkload(spec.Workload):
     return (4,)
 
   @property
-  def max_allowed_runtime_sec(self):
+  def max_allowed_runtime_sec(self) -> int:
     return 10800  # 3 hours
 
   @property
-  def eval_period_time_sec(self):
+  def eval_period_time_sec(self) -> int:
     return 80
 
   @property

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -29,7 +29,9 @@ class BaseFastMRIWorkload(spec.Workload):
     # Round up from num_validation_examples (which is the default for
     # num_eval_train_examples) to the next multiple of eval_batch_size, so that
     # we don't have to extract the correctly sized subset of the training data.
-    return math.ceil(3554 / self.eval_batch_size) * self.eval_batch_size
+    rounded_up_multiple = math.ceil(
+        self.num_validation_examples / self.eval_batch_size)
+    return rounded_up_multiple * self.eval_batch_size
 
   @property
   def num_validation_examples(self) -> int:

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -1,5 +1,6 @@
 """FastMRI workload parent class."""
 
+import math
 from typing import Optional
 
 from algorithmic_efficiency import spec
@@ -25,7 +26,10 @@ class BaseFastMRIWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self) -> int:
-    return 3554
+    # Round up from num_validation_examples (which is the default for
+    # num_eval_train_examples) to the next multiple of eval_batch_size, so that
+    # we don't have to extract the correctly sized subset of the training data.
+    return math.ceil(3554 / self.eval_batch_size) * self.eval_batch_size
 
   @property
   def num_validation_examples(self) -> int:

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -29,8 +29,8 @@ class BaseFastMRIWorkload(spec.Workload):
     # Round up from num_validation_examples (which is the default for
     # num_eval_train_examples) to the next multiple of eval_batch_size, so that
     # we don't have to extract the correctly sized subset of the training data.
-    rounded_up_multiple = math.ceil(
-        self.num_validation_examples / self.eval_batch_size)
+    rounded_up_multiple = math.ceil(self.num_validation_examples /
+                                    self.eval_batch_size)
     return rounded_up_multiple * self.eval_batch_size
 
   @property

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -307,7 +307,7 @@ def create_split(split,
   if cache:
     ds = ds.cache()
 
-  if train:
+  if train or split == 'eval_train':
     ds = ds.repeat()
     ds = ds.shuffle(16 * global_batch_size, seed=shuffle_rng[0])
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -53,8 +53,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     ds_builder = tfds.builder('imagenet2012:5.1.0', data_dir=data_dir)
     ds_builder.download_and_prepare()
     train = split == 'train'
-    if split == 'eval_train':
-      split = f'train[:{self.num_eval_train_examples}]'
     ds = input_pipeline.create_input_iter(
         split,
         ds_builder,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -4,6 +4,7 @@ import contextlib
 import itertools
 import math
 import os
+import random
 from typing import Dict, Iterator, Optional, Tuple
 
 import numpy as np
@@ -60,7 +61,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       repeat_final_dataset: Optional[bool] = None,
       use_mixup: bool = False,
       use_randaug: bool = False) -> Iterator[Dict[str, spec.Tensor]]:
-    del data_rng
     del cache
     del repeat_final_dataset
     if split == 'test':
@@ -99,9 +99,10 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         os.path.join(data_dir, folder), transform=transform_config)
 
     if split == 'eval_train':
-      # We always use the same subset of the training data for evaluation.
-      dataset = torch.utils.data.Subset(dataset,
-                                        range(self.num_eval_train_examples))
+      indices = list(range(self.num_train_examples))
+      random.Random(data_rng[0]).shuffle(indices)
+      dataset = torch.utils.data.Subset(
+          dataset, indices[:self.num_eval_train_examples])
 
     sampler = None
     if USE_PYTORCH_DDP:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -101,8 +101,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     if split == 'eval_train':
       indices = list(range(self.num_train_examples))
       random.Random(data_rng[0]).shuffle(indices)
-      dataset = torch.utils.data.Subset(
-          dataset, indices[:self.num_eval_train_examples])
+      dataset = torch.utils.data.Subset(dataset,
+                                        indices[:self.num_eval_train_examples])
 
     sampler = None
     if USE_PYTORCH_DDP:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -1,5 +1,6 @@
 """ImageNet workload parent class."""
 
+import math
 from typing import Dict, Iterator, Optional, Tuple
 
 from algorithmic_efficiency import spec
@@ -26,7 +27,12 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self) -> int:
-    return 50000
+    # Round up from num_validation_examples (which is the default for
+    # num_eval_train_examples) to the next multiple of eval_batch_size, so that
+    # we don't have to extract the correctly sized subset of the training data.
+    rounded_up_multiple = math.ceil(
+        self.num_validation_examples / self.eval_batch_size)
+    return rounded_up_multiple * self.eval_batch_size
 
   @property
   def num_validation_examples(self) -> int:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -30,8 +30,8 @@ class BaseImagenetResNetWorkload(spec.Workload):
     # Round up from num_validation_examples (which is the default for
     # num_eval_train_examples) to the next multiple of eval_batch_size, so that
     # we don't have to extract the correctly sized subset of the training data.
-    rounded_up_multiple = math.ceil(
-        self.num_validation_examples / self.eval_batch_size)
+    rounded_up_multiple = math.ceil(self.num_validation_examples /
+                                    self.eval_batch_size)
     return rounded_up_multiple * self.eval_batch_size
 
   @property

--- a/algorithmic_efficiency/workloads/librispeech_conformer/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/input_pipeline.py
@@ -73,6 +73,8 @@ def get_librispeech_dataset(split_name: str,
 
   if is_training:
     ds = ds.repeat()
+  
+  if split in ['train', 'eval_train']:
     ds = ds.shuffle(16 * global_batch_size, seed=shuffle_rng[0])
 
   ds = ds.batch(global_batch_size, drop_remainder=is_training)

--- a/algorithmic_efficiency/workloads/librispeech_conformer/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/input_pipeline.py
@@ -24,19 +24,19 @@ def get_librispeech_dataset(split_name: str,
   ids = []
 
   for split in splits:
-    logging.info('loading split = %s', split)
-    feat_csv = '{}/{}.csv'.format(data_dir, split)
+    logging.info(f'Loading split = {split}.')
+    feat_csv = f'{data_dir}/{split}.csv'
 
     with open(feat_csv, newline='') as csvfile:
       data = list(csv.reader(csvfile))
 
     for example in data[1:]:
-      ids.append('{}/{}'.format(split, example[1]))
+      ids.append(f'{split}/{example[1]}')
 
   def load_data(example_id):
     example_id = example_id.decode('utf-8')
-    audio = np.load('{}/{}_audio.npy'.format(data_dir, example_id))
-    targets = np.load('{}/{}_targets.npy'.format(data_dir, example_id))
+    audio = np.load(f'{data_dir}/{example_id}_audio.npy')
+    targets = np.load(f'{data_dir}/{example_id}_targets.npy')
 
     audio_paddings = np.zeros_like(audio, dtype=np.float32)
     audio_paddings = np.pad(

--- a/algorithmic_efficiency/workloads/librispeech_conformer/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/input_pipeline.py
@@ -73,7 +73,7 @@ def get_librispeech_dataset(split_name: str,
 
   if is_training:
     ds = ds.repeat()
-  
+
   if split in ['train', 'eval_train']:
     ds = ds.shuffle(16 * global_batch_size, seed=shuffle_rng[0])
 

--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -35,7 +35,9 @@ class BaseLibrispeechWorkload(spec.Workload):
     # Round up from num_validation_examples (which is the default for
     # num_eval_train_examples) to the next multiple of eval_batch_size, so that
     # we don't have to extract the correctly sized subset of the training data.
-    return math.ceil(5348 / self.eval_batch_size) * self.eval_batch_size
+    rounded_up_multiple = math.ceil(
+        self.num_validation_examples / self.eval_batch_size)
+    return rounded_up_multiple * self.eval_batch_size
 
   @property
   def num_validation_examples(self) -> int:
@@ -92,7 +94,7 @@ class BaseLibrispeechWorkload(spec.Workload):
       split = 'train-clean-100+train-clean-360+train-other-500'
       train = True
     elif split == 'eval_train':
-      split = 'train-clean-100'
+      split = 'train-clean-100+train-clean-360+train-other-500'
     elif split == 'validation':
       split = 'dev-clean+dev-other'
     elif split == 'test':

--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -31,7 +31,7 @@ class BaseLibrispeechWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self) -> int:
-    return 256
+    return 5348
 
   @property
   def num_validation_examples(self) -> int:

--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -35,8 +35,8 @@ class BaseLibrispeechWorkload(spec.Workload):
     # Round up from num_validation_examples (which is the default for
     # num_eval_train_examples) to the next multiple of eval_batch_size, so that
     # we don't have to extract the correctly sized subset of the training data.
-    rounded_up_multiple = math.ceil(
-        self.num_validation_examples / self.eval_batch_size)
+    rounded_up_multiple = math.ceil(self.num_validation_examples /
+                                    self.eval_batch_size)
     return rounded_up_multiple * self.eval_batch_size
 
   @property

--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -1,3 +1,4 @@
+import math
 from typing import Optional
 
 from absl import flags
@@ -31,7 +32,10 @@ class BaseLibrispeechWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self) -> int:
-    return 5348
+    # Round up from num_validation_examples (which is the default for
+    # num_eval_train_examples) to the next multiple of eval_batch_size, so that
+    # we don't have to extract the correctly sized subset of the training data.
+    return math.ceil(5348 / self.eval_batch_size) * self.eval_batch_size
 
   @property
   def num_validation_examples(self) -> int:

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -8,7 +8,6 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 from torch.nn.parallel import DistributedDataParallel as DDP
-import torch.utils.data as pytorch_data_utils
 from torchvision import transforms
 from torchvision.datasets import MNIST
 

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -1,6 +1,7 @@
 """MNIST workload implemented in PyTorch."""
 from collections import OrderedDict
 import contextlib
+import random
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -52,34 +53,28 @@ class MnistWorkload(BaseMnistWorkload):
                      split: str,
                      data_dir: str,
                      batch_size: int):
-
-    dataloader_split = 'train' if split == 'eval_train' else split
+    train_split = False if split == 'test' else True
     transform = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((self.train_mean,), (self.train_stddev,))
     ])
     dataset = MNIST(
-        data_dir, train=dataloader_split, download=True, transform=transform)
+        data_dir, train=train_split, download=True, transform=transform)
     if split != 'test':
-      if split in ['train', 'validation']:
-        train_dataset, validation_dataset = pytorch_data_utils.random_split(
-            dataset,
-            [self.num_train_examples, self.num_validation_examples],
-            generator=torch.Generator().manual_seed(int(data_rng[0])))
-        if split == 'train':
-          dataset = train_dataset
-        elif split == 'validation':
-          dataset = validation_dataset
+      assert (self.num_eval_train_examples +
+              self.num_validation_examples == 60000)
+      indices = list(range(60000))
+      if split in ['train', 'eval_train']:
+        dataset_indices = indices[:self.num_train_examples]
+      elif split == 'validation':
+        dataset_indices = indices[self.num_train_examples:]
       if split == 'eval_train':
-        dataset, _ = pytorch_data_utils.random_split(
-            dataset,
-            [self.num_eval_train_examples,
-             60000 - self.num_eval_train_examples],
-            generator=torch.Generator().manual_seed(int(data_rng[0])))
-    # TODO: set seeds properly
-    is_train = split == 'train'
+        random.Random(data_rng[0]).shuffle(dataset_indices)
+        dataset_indices = dataset_indices[:self.num_eval_train_examples]
+      dataset = torch.utils.data.Subset(dataset, dataset_indices)
 
     sampler = None
+    is_train = split == 'train'
     if USE_PYTORCH_DDP:
       if is_train:
         sampler = torch.utils.data.distributed.DistributedSampler(

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -22,31 +22,31 @@ class BaseMnistWorkload(spec.Workload):
     return eval_result['validation/accuracy'] > self.target_value
 
   @property
-  def target_value(self):
+  def target_value(self) -> float:
     return 0.9
 
   @property
-  def loss_type(self):
+  def loss_type(self) -> spec.LossType:
     return spec.LossType.SOFTMAX_CROSS_ENTROPY
 
   @property
-  def num_train_examples(self):
+  def num_train_examples(self) -> int:
     return 50000
 
   @property
-  def num_eval_train_examples(self):
+  def num_eval_train_examples(self) -> int:
     return 10000
 
   @property
-  def num_validation_examples(self):
+  def num_validation_examples(self) -> int:
     return 10000
 
   @property
-  def num_test_examples(self):
+  def num_test_examples(self) -> int:
     return 10000
 
   @property
-  def eval_batch_size(self):
+  def eval_batch_size(self) -> int:
     return 10000
 
   @property
@@ -58,11 +58,11 @@ class BaseMnistWorkload(spec.Workload):
     return 0.3081
 
   @property
-  def max_allowed_runtime_sec(self):
+  def max_allowed_runtime_sec(self) -> int:
     return 60
 
   @property
-  def eval_period_time_sec(self):
+  def eval_period_time_sec(self) -> int:
     return 10
 
   @property

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -35,7 +35,12 @@ class BaseMnistWorkload(spec.Workload):
 
   @property
   def num_eval_train_examples(self) -> int:
-    return 10000
+    # Round up from num_validation_examples (which is the default for
+    # num_eval_train_examples) to the next multiple of eval_batch_size, so that
+    # we don't have to extract the correctly sized subset of the training data.
+    rounded_up_multiple = math.ceil(self.num_validation_examples /
+                                    self.eval_batch_size)
+    return rounded_up_multiple * self.eval_batch_size
 
   @property
   def num_validation_examples(self) -> int:

--- a/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
@@ -163,8 +163,5 @@ def _get_batch_iterator(dataset_iter, global_batch_size, num_shards=None):
 def get_dataset_iter(split, data_rng, data_dir, global_batch_size):
   shuffle = split in ['train', 'eval_train']
   ds = _load_dataset(
-      split,
-      should_shuffle=shuffle,
-      data_rng=data_rng,
-      data_dir=data_dir)
+      split, should_shuffle=shuffle, data_rng=data_rng, data_dir=data_dir)
   return _get_batch_iterator(iter(ds), global_batch_size)

--- a/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
@@ -161,9 +161,10 @@ def _get_batch_iterator(dataset_iter, global_batch_size, num_shards=None):
 
 
 def get_dataset_iter(split, data_rng, data_dir, global_batch_size):
+  shuffle = split in ['train', 'eval_train']
   ds = _load_dataset(
       split,
-      should_shuffle=(split == 'train'),
+      should_shuffle=shuffle,
       data_rng=data_rng,
       data_dir=data_dir)
   return _get_batch_iterator(iter(ds), global_batch_size)

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -8,6 +8,7 @@ import jax
 from algorithmic_efficiency import random_utils as prng
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.ogbg import input_pipeline
+from algorithmic_efficiency.workloads.ogbg import metrics
 
 FLAGS = flags.FLAGS
 
@@ -20,31 +21,31 @@ class BaseOgbgWorkload(spec.Workload):
     return eval_result['validation/mean_average_precision'] > self.target_value
 
   @property
-  def target_value(self):
+  def target_value(self) -> float:
     return 0.28380056
 
   @property
-  def loss_type(self):
+  def loss_type(self) -> spec.LossType:
     return spec.LossType.SOFTMAX_CROSS_ENTROPY
 
   @property
-  def num_train_examples(self):
+  def num_train_examples(self) -> int:
     return 350343
 
   @property
-  def num_eval_train_examples(self):
+  def num_eval_train_examples(self) -> int:
     return 43793
 
   @property
-  def num_validation_examples(self):
+  def num_validation_examples(self) -> int:
     return 43793
 
   @property
-  def num_test_examples(self):
+  def num_test_examples(self) -> int:
     return 43793
 
   @property
-  def eval_batch_size(self):
+  def eval_batch_size(self) -> int:
     return 32768
 
   @property
@@ -56,11 +57,11 @@ class BaseOgbgWorkload(spec.Workload):
     raise NotImplementedError
 
   @property
-  def max_allowed_runtime_sec(self):
+  def max_allowed_runtime_sec(self) -> int:
     return 12000  # 3h20m
 
   @property
-  def eval_period_time_sec(self):
+  def eval_period_time_sec(self) -> int:
     return 4 * 60
 
   def _build_input_queue(self,
@@ -106,7 +107,11 @@ class BaseOgbgWorkload(spec.Workload):
     """Max num steps the target setting algo was given to reach the target."""
     return 60_000
 
-  def _eval_batch(self, params, batch, model_state, rng):
+  def _eval_batch(self,
+                  params: spec.ParameterContainer,
+                  batch: Dict[str, spec.Tensor],
+                  model_state: spec.ModelAuxiliaryState,
+                  rng: spec.RandomState) -> metrics.EvalMetrics:
     logits, _ = self.model_fn(
         params,
         batch,

--- a/algorithmic_efficiency/workloads/ogbg/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/workload.py
@@ -69,8 +69,6 @@ class BaseOgbgWorkload(spec.Workload):
                          split: str,
                          data_dir: str,
                          global_batch_size: int):
-    if split == 'eval_train':
-      split = f'train[:{self.num_eval_train_examples}]'
     dataset_iter = input_pipeline.get_dataset_iter(split,
                                                    data_rng,
                                                    data_dir,

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -48,8 +48,8 @@ class BaseWmtWorkload(spec.Workload):
     # Round up from num_validation_examples (which is the default for
     # num_eval_train_examples) to the next multiple of eval_batch_size, so that
     # we don't have to extract the correctly sized subset of the training data.
-    rounded_up_multiple = math.ceil(
-        self.num_validation_examples / self.eval_batch_size)
+    rounded_up_multiple = math.ceil(self.num_validation_examples /
+                                    self.eval_batch_size)
     return rounded_up_multiple * self.eval_batch_size
 
   @property

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -56,7 +56,7 @@ class BaseWmtWorkload(spec.Workload):
   @property
   def num_test_examples(self) -> int:
     # wmt14_translate/de-en 'test' split size.
-    return 3000
+    return 3003
 
   @property
   def eval_batch_size(self) -> int:
@@ -95,8 +95,6 @@ class BaseWmtWorkload(spec.Workload):
       # Without the '+1' only `num_eval_train_examples-1` examples are used
       # since one example is filtered out in the input pipeline.
       split = f'train[:{self.num_eval_train_examples+1}]'
-    if split == 'test':
-      split = f'test[:{self.num_test_examples}]'
     ds, self._tokenizer = input_pipeline.get_wmt_dataset(
         data_rng,
         split,


### PR DESCRIPTION
This PR fixes #223 (+ cosmetics, i.e. change string style in some places + add more type hints).

Moreover, I undid a change introduced by #244, see [my comment](https://github.com/mlcommons/algorithmic-efficiency/pull/244#discussion_r1013771250) there.

**Issues/Questions:**
- We could just set the `num_eval_train_examples` property in `spec.py` to return `self.num_validation_examples`?
- CIFAR10 Jax was using wrong splits, I fixed this. CIFAR10 PyTorch used random subsets instead of fixed ones, even though we might want this in general, it's done differently everywhere else right now, so I changed it to be more consistent (MNIST PyTorch also shuffles right now, whereas MNIST Jax does not -- haven't changed that).
- This also raises the general question: do we want to use random subsets when we only take a subset from a split? Currently, we just use [slices](https://www.tensorflow.org/datasets/splits?hl=en). This has a few problems: 1) if the data is ordered, we might only consider a subset of classes, 2) the order might not be consistent between TF and PyTorch datasets. However, when using random subsets, it might make sense to choose a fixed random subset for both Jax and PyTorch (independent of the run's random seed) so we can better compare results across runs.
- Librispeech: according to [TF datasets](https://www.tensorflow.org/datasets/catalog/librispeech) the total number of training examples we use is larger than what we state as the `num_train_examples` property: 263.840 != 281.241 = 104.014+148.688+28.539. The same holds for the number of test examples: 'test_clean' has 2.620 samples according to TF, we say we use 2.472. And also for the validation samples: 'dev_clean' (2.703) + 'dev_other' (2.864) = 5.567 != 5348. Is this expected, maybe due to the pre-processing?
- Librispeech + FastMRI: what is the best way to restrict the eval train split to the specific number of examples when we don't use TF datasets which we can slice? If I'm not missing something we currently just restrict the number of batches we take, but this might lead to using additional training samples for evaluation.