### PR TITLE
Jax ResNet Maxpool Padding

### DIFF
--- a/algorithmic_efficiency/init_utils.py
+++ b/algorithmic_efficiency/init_utils.py
@@ -12,6 +12,6 @@ def pytorch_default_init(module: nn.Module) -> None:
   # Perform lecun_normal initialization.
   fan_in, _ = nn.init._calculate_fan_in_and_fan_out(module.weight)
   std = math.sqrt(1. / fan_in) / .87962566103423978
-  nn.init.trunc_normal_(module.weight.data, std=std)
+  nn.init.trunc_normal_(module.weight, std=std)
   if module.bias is not None:
-    nn.init.constant_(module.bias.data, 0.)
+    nn.init.constant_(module.bias, 0.)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/models.py
@@ -97,7 +97,7 @@ class ResNet(nn.Module):
             x)
     x = norm(name='BatchNorm_init')(x)
     x = nn.relu(x)
-    x = nn.max_pool(x, (3, 3), strides=(2, 2), padding='SAME')
+    x = nn.max_pool(x, (3, 3), strides=(2, 2), padding=((1, 1), (1, 1)))
     for i, block_size in enumerate(self.stage_sizes):
       for j in range(block_size):
         strides = (2, 2) if i > 0 and j == 0 else (1, 1)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
@@ -172,7 +172,7 @@ class ResNet(nn.Module):
         3, self.inplanes, kernel_size=7, stride=2, padding=3, bias=False)
     self.bn1 = norm_layer(self.inplanes)
     self.relu = nn.ReLU(inplace=True)
-    self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=0)
+    self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
     self.layer1 = self._make_layer(block, 64, layers[0])
     self.layer2 = self._make_layer(
         block, 128, layers[1], stride=2, dilate=replace_stride_with_dilation[0])
@@ -186,11 +186,11 @@ class ResNet(nn.Module):
     for m in self.modules():
       if isinstance(m, nn.Conv2d):
         pytorch_default_init(m)
-      elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
-        nn.init.constant_(m.weight.data, 1)
-        nn.init.constant_(m.bias.data, 0)
-    nn.init.normal_(self.fc.weight.data, std=1e-2)
-    nn.init.constant_(self.fc.bias.data, 0.)
+      elif isinstance(m, nn.BatchNorm2d):
+        nn.init.constant_(m.weight, 1)
+        nn.init.constant_(m.bias, 0)
+    nn.init.normal_(self.fc.weight, std=1e-2)
+    nn.init.constant_(self.fc.bias, 0.)
 
     # Zero-initialize the last BN in each residual branch,
     # so that the residual branch starts with zeros,
@@ -200,9 +200,9 @@ class ResNet(nn.Module):
     if zero_init_residual:
       for m in self.modules():
         if isinstance(m, Bottleneck):
-          nn.init.constant_(m.bn3.weight.data, 0)
+          nn.init.constant_(m.bn3.weight, 0)
         elif isinstance(m, BasicBlock):
-          nn.init.constant_(m.bn2.weight.data, 0)
+          nn.init.constant_(m.bn2.weight, 0)
 
   def _make_layer(self,
                   block: Type[Union[BasicBlock, Bottleneck]],
@@ -251,7 +251,6 @@ class ResNet(nn.Module):
     x = self.conv1(x)
     x = self.bn1(x)
     x = self.relu(x)
-    x = F.pad(x, [0, 1, 0, 1], 'constant', float('-inf'))
     x = self.maxpool(x)
 
     x = self.layer1(x)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/models.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, List, Optional, Type, Union
 import torch
 from torch import nn
 from torch import Tensor
-import torch.nn.functional as F
 
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.init_utils import pytorch_default_init


### PR DESCRIPTION
Following up on #243; This PR reverts back to our PyTorch ResNet model and changes the Jax ResNet model to ensure we have the equivalent model. 

One question @chandramouli-sastry, when I run the model diff test, it gives me:
```
Number of values with identical shapes: 161
2.682209e-07
0.0
```
Do we expect both of these terms to be 0?