### PR TITLE
Fix eval_train split ValueError for tfds

### DIFF
--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -19,7 +19,7 @@ from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax import \
     randaugment
 
 TFDS_SPLIT_NAME = {'train': 'train', 
-                   'train_val': 'train',
+                   'eval_train': 'train',
                    'validation': 'validation'}
 
 def _distorted_bounding_box_crop(image_bytes: spec.Tensor,
@@ -214,7 +214,7 @@ def preprocess_for_eval(image_bytes: spec.Tensor,
   image = _decode_and_center_crop(image_bytes, image_size, resize_size)
   image = tf.reshape(image, [image_size, image_size, 3])
   image = normalize_image(image, mean_rgb, stddev_rgb)
-  image = tf.image.convert_image_dtype(image, dtype=dtype)t
+  image = tf.image.convert_image_dtype(image, dtype=dtype)
   return image
 
 

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -18,6 +18,9 @@ from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax import \
     randaugment
 
+TFDS_SPLIT_NAME = {'train': 'train', 
+                   'train_val': 'train',
+                   'validation': 'validation'}
 
 def _distorted_bounding_box_crop(image_bytes: spec.Tensor,
                                  rng: spec.RandomState,
@@ -211,7 +214,7 @@ def preprocess_for_eval(image_bytes: spec.Tensor,
   image = _decode_and_center_crop(image_bytes, image_size, resize_size)
   image = tf.reshape(image, [image_size, image_size, 3])
   image = normalize_image(image, mean_rgb, stddev_rgb)
-  image = tf.image.convert_image_dtype(image, dtype=dtype)
+  image = tf.image.convert_image_dtype(image, dtype=dtype)t
   return image
 
 
@@ -297,7 +300,7 @@ def create_split(split,
     return {'inputs': image, 'targets': example['label']}
 
   ds = dataset_builder.as_dataset(
-      split=split, decoders={
+      split=TFDS_SPLIT_NAME[split], decoders={
           'image': tfds.decode.SkipDecoding(),
       })
   options = tf.data.Options()

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -18,9 +18,10 @@ from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.imagenet_resnet.imagenet_jax import \
     randaugment
 
-TFDS_SPLIT_NAME = {'train': 'train', 
-                   'eval_train': 'train',
-                   'validation': 'validation'}
+TFDS_SPLIT_NAME = {
+    'train': 'train', 'eval_train': 'train', 'validation': 'validation'
+}
+
 
 def _distorted_bounding_box_crop(image_bytes: spec.Tensor,
                                  rng: spec.RandomState,
@@ -300,7 +301,8 @@ def create_split(split,
     return {'inputs': image, 'targets': example['label']}
 
   ds = dataset_builder.as_dataset(
-      split=TFDS_SPLIT_NAME[split], decoders={
+      split=TFDS_SPLIT_NAME[split],
+      decoders={
           'image': tfds.decode.SkipDecoding(),
       })
   options = tf.data.Options()


### PR DESCRIPTION
This was broken after trying to get the "eval_train" split from tfds:

```
File "/home/bae_cs_research/env/lib/python3.7/site-packages/tensorflow_datasets/core/tfrecords_reader.py", line 729, in to_absolute
    for rel_instr in self._relative_instructions
  File "/home/bae_cs_research/env/lib/python3.7/site-packages/tensorflow_datasets/core/tfrecords_reader.py", line 729, in <listcomp>
    for rel_instr in self._relative_instructions
  File "/home/bae_cs_research/env/lib/python3.7/site-packages/tensorflow_datasets/core/tfrecords_reader.py", line 556, in _rel_to_abs_instr
    split, list(name2len)))
ValueError: Unknown split "eval_train". Should be one of ['train', 'validation'].
```

Verified that this worked now w ViT workload:
```
submission_runner.py     --framework=jax     --data_dir=/home/bae_cs_research/tensorflow_datasets/imagenet/jax. 
--imagenet_v2_data_dir=/home/bae_cs_research/     --experiment_dir=~     --experiment_name=target_setting     
--workload=imagenet_vit     --submission_path=reference_algorithms/target_setting_algorithms/jax_nadamw.py 
--tuning_search_space=reference_algorithms/target_setting_algorithms/imagenet_vit/tuning_search_space.json
--max_global_steps=140000     --profile --resume_last_run=False   
```

Output:
```
...
I1107 20:12:26.220413 139875228841792 spec.py:305] Evaluating on the training split.                                                                                               
I1107 20:12:26.225612 139875228841792 dataset_info.py:358] Load dataset info from /home/bae_cs_research/tensorflow_datasets/imagenet/jax/imagenet2012/5.1.0                        
I1107 20:12:26.231232 139875228841792 dataset_builder.py:351] Reusing dataset imagenet2012 (/home/bae_cs_research/tensorflow_datasets/imagenet/jax/imagenet2012/5.1.0)             
I1107 20:12:26.231599 139875228841792 logging_logger.py:36] Constructing tf.data.Dataset imagenet2012 for split train, from /home/bae_cs_research/tensorflow_datasets/imagenet/jax/
imagenet2012/5.1.0                                                                                                                                                                 
I1107 20:12:45.383222 139875228841792 spec.py:317] Evaluating on the validation split.                                                                                             
I1107 20:12:45.391458 139875228841792 dataset_info.py:358] Load dataset info from /home/bae_cs_research/tensorflow_datasets/imagenet/jax/imagenet2012/5.1.0                        
I1107 20:12:45.401611 139875228841792 dataset_builder.py:351] Reusing dataset imagenet2012 (/home/bae_cs_research/tensorflow_datasets/imagenet/jax/imagenet2012/5.1.0)             
I1107 20:12:45.402349 139875228841792 logging_logger.py:36] Constructing tf.data.Dataset imagenet2012 for split validation, from /home/bae_cs_research/tensorflow_datasets/imagenet
/jax/imagenet2012/5.1.0              
...
```