### PR TITLE
NCCL Timeout Fix

### DIFF
--- a/algorithmic_efficiency/checkpoint_utils.py
+++ b/algorithmic_efficiency/checkpoint_utils.py
@@ -96,7 +96,7 @@ def maybe_restore_checkpoint(framework: str,
           checkpoint_state['optimizer_state'][key])
       checkpoint_state['optimizer_state'][key] = optimizer_state[key]
 
-    logging.info(f'Loaded checkpoint from {save_path}')
+    logging.info(f'Loaded checkpoint from {save_path}.')
   return (checkpoint_state['optimizer_state'],
           checkpoint_state['model_params'],
           checkpoint_state['model_state'],
@@ -161,7 +161,4 @@ def save_checkpoint(framework: str,
       save_path = os.path.join(checkpoint_dir, 'checkpoint')
       torch.save(checkpoint_state, save_path)
 
-  if USE_PYTORCH_DDP:
-    dist.barrier()
-  if RANK == 0:
-    logging.info(f'Saved checkpoint to {save_path}')
+    logging.info(f'Saved checkpoint to {save_path}.')

--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -85,7 +85,7 @@ def get_log_dir(experiment_dir,
 
   # Setup log dir
   logging_dir_path = os.path.join(experiment_path, run_dir)
-  logging.info(f'Creating experiment run directory at {logging_dir_path}')
+  logging.info(f'Creating experiment run directory at {logging_dir_path}.')
   makedir(logging_dir_path)
   return logging_dir_path
 
@@ -95,14 +95,14 @@ def write_hparams(hparams: spec.Hyperparameters,
   hparams_file_name = os.path.join(tuning_dir, 'hparams.json')
   if os.path.exists(hparams_file_name):
     # If hparams.json already exist, use the previously saved hyperparameters.
-    logging.info('Loading hparams from %s', hparams_file_name)
+    logging.info('Loading hparams from %s.', hparams_file_name)
     with open(hparams_file_name, 'r') as f:
       hparams_dict = json.load(f)
     hparams = collections.namedtuple('Hyperparameters',
                                      hparams_dict)(**hparams_dict)
     return hparams
   else:
-    logging.info('Saving hparams to %s', hparams_file_name)
+    logging.info('Saving hparams to %s.', hparams_file_name)
     if RANK == 0:
       with open(hparams_file_name, 'w') as f:
         f.write(json.dumps(hparams._asdict(), indent=2))

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -276,13 +276,17 @@ def train_once(
          checkpoint_dir=log_dir)
     meta_data = logger_utils.get_meta_data(workload)
     meta_file_name = os.path.join(log_dir, f'meta_data_{preemption_count}.json')
-    logging.info(f'Saving meta data to {meta_file_name}',)
+    logging.info(f'Saving meta data to {meta_file_name}.')
     logger_utils.write_json(meta_file_name, meta_data)
     flag_file_name = os.path.join(log_dir, f'flags_{preemption_count}.json')
-    logging.info(f'Saving flags to {flag_file_name}')
+    logging.info(f'Saving flags to {flag_file_name}.')
     logger_utils.write_json(flag_file_name, flags.FLAGS.flag_values_dict())
     metrics_logger = logger_utils.set_up_loggers(log_dir, flags.FLAGS)
     workload.attach_metrics_logger(metrics_logger)
+
+  if USE_PYTORCH_DDP:
+    # Make sure all processes start training at the same time.
+    dist.barrier()
 
   global_start_time = time.time()
   logging.info('Starting training loop.')
@@ -321,9 +325,6 @@ def train_once(
     global_step += 1
     if (max_global_steps is not None) and (global_step == max_global_steps):
       train_state['training_complete'] = True
-    if USE_PYTORCH_DDP:
-      # Make sure all processes run eval after the same step when using DDP.
-      dist.barrier()
     current_time = time.time()
     train_state['accumulated_submission_time'] += current_time - start_time
     train_state['is_time_remaining'] = (
@@ -368,8 +369,8 @@ def train_once(
         except RuntimeError as e:
           logging.exception(f'Eval step {global_step} error.\n')
           if 'out of memory' in str(e):
-            logging.warning('error: GPU out of memory during eval during step '
-                            f'{global_step}, error : {str(e)}')
+            logging.warning('Error: GPU out of memory during eval during step '
+                            f'{global_step}, error : {str(e)}.')
             if torch.cuda.is_available():
               torch.cuda.empty_cache()
 
@@ -475,7 +476,7 @@ def score_submission_on_workload(
       tuning_dir_name = None
       if log_dir is not None:
         tuning_dir_name = os.path.join(log_dir, f'trial_{hi + 1}')
-        logging.info(f'Creating tuning directory at {tuning_dir_name}')
+        logging.info(f'Creating tuning directory at {tuning_dir_name}.')
         logger_utils.makedir(tuning_dir_name)
 
         # If existing hyperparameter exists, use saved


### PR DESCRIPTION
This PR should fix #247 resulting from PR #237. As @chandramouli-sastry pointed out, `get_log_dir(..)` function returns `None` for non-rank 0 processes and this results in `dist.barrier()` call in the `checkpoint_utils.py` to hang. 

In light of the change in the way we get `log_dir`, I modified the code accordingly. Especially, I added `dist.barrier()` in front of `time.time()` calls and removed irrelevant `RANK == 0` checks. This should restore the previous behaviour and now imagenet workload does not face NCCL timeout issue. 