### PR TITLE
fix tfds split name for ogbg

### DIFF
--- a/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
@@ -14,8 +14,12 @@ AVG_NODES_PER_GRAPH = 26
 AVG_EDGES_PER_GRAPH = 56
 
 TFDS_SPLIT_NAME = {
-    'train': 'train', 'eval_train': 'train', 'validation': 'validation', 'test':'test'
+    'train': 'train',
+    'eval_train': 'train',
+    'validation': 'validation',
+    'test': 'test'
 }
+
 
 def _load_dataset(split, should_shuffle, data_rng, data_dir):
   """Loads a dataset split from TFDS."""

--- a/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/ogbg/input_pipeline.py
@@ -13,6 +13,9 @@ import torch
 AVG_NODES_PER_GRAPH = 26
 AVG_EDGES_PER_GRAPH = 56
 
+TFDS_SPLIT_NAME = {
+    'train': 'train', 'eval_train': 'train', 'validation': 'validation', 'test':'test'
+}
 
 def _load_dataset(split, should_shuffle, data_rng, data_dir):
   """Loads a dataset split from TFDS."""
@@ -27,7 +30,7 @@ def _load_dataset(split, should_shuffle, data_rng, data_dir):
   read_config = tfds.ReadConfig(add_tfds_id=True, shuffle_seed=file_data_rng)
   dataset = tfds.load(
       'ogbg_molpcba:0.1.2',
-      split=split,
+      split=TFDS_SPLIT_NAME[split],
       shuffle_files=should_shuffle,
       read_config=read_config,
       data_dir=data_dir)


### PR DESCRIPTION
Verified that this worked w:
```
python3 submission_runner.py     --framework=jax     --data_dir=/home/kasimbeg/tensorflow_datasets     --experiment_dir=/home/kasimbeg     --experiment_name=target_setting     --workload=ogbg     --submission_path=reference_algorithms/target_setting_algorithms/jax_nesterov.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/ogbg/tuning_search_space.json     --max_global_steps=70000     --profile 
```

Output:
```
I1107 21:38:05.677005 139645644851008 spec.py:305] Evaluating on the training split.
I1107 21:39:26.299205 139645644851008 spec.py:317] Evaluating on the validation split.
I1107 21:39:28.702938 139645644851008 spec.py:333] Evaluating on the test split.
I1107 21:39:31.057778 139645644851008 submission_runner.py:345] Time since start: 500.73s,      Step: 1166,     {'train/accuracy': 0.9867238998413086, 'train/loss': 0.05542554706335068, 'train/mean_average_precision': 0.02926342938373612, 'validation/accuracy': 0.9841179251670837, 'validation/loss': 0.06531117856502533, 'validation/mean_average_precision': 0.029944910965671544, 'validation/num_examples': 43793, 'test/accuracy': 0.983142077922821, 'test/loss': 0.06871972233057022, 'test/mean_average_precision': 0.03162979707581475, 'test/num_examples': 43793}
```