### PR TITLE
Fix bleu score calculation for PyTorch WMT

### DIFF
--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -34,7 +34,7 @@ def shard_and_maybe_pad_np(
       pad_size = local_device_count - remainder_size
     targets = batch['targets']
     targets_shape = tuple(
-        targets[0].shape if isinstance(inputs, tuple) else targets.shape[0])
+        targets[0].shape if isinstance(targets, tuple) else targets.shape)
     # We need a 2d mask for WMT.
     mask_shape = targets_shape if len(targets_shape) < 3 else targets_shape[0]
     # The weights will also be padded.

--- a/algorithmic_efficiency/workloads/wmt/bleu.py
+++ b/algorithmic_efficiency/workloads/wmt/bleu.py
@@ -1,205 +1,60 @@
-r"""Parallel BLEU score calculation.
+from typing import Optional, Sequence
 
-Modified from https://github.com/google/flax/tree/main/examples/wmt.
+from sacrebleu import BLEU
+from sacrebleu.metrics import BLEUScore
+import torch
+import torch.distributed as dist
 
-This version of BLEU calculation is derived from the MLPerf transformer
-reference.
-Tries to match SacreBLEU metric reasonably well, but is not identical.
+from algorithmic_efficiency.pytorch_utils import pytorch_setup
 
-Refs:
-    tokenizer at:
-    https://github.com/tensorflow/models/blob/master/official/transformer/utils/tokenizer.py
-    original preprocessing tokenizer:
-    https://github.com/moses-smt/mosesdecoder/blob/master/scripts/generic/mteval-v14.pl#L954-L983
-    original t2t code:
-    https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/utils/bleu_hook.py
-
-Usage:
-    refs = '''food bar brown cow
-    blee bloo dog sat
-    or please take me out
-    '''
-    hyps = '''foo bar brown cow
-    blee bloo dog sit
-    please do take me out
-    '''
-    bleu_local(refs.split('\n'), hyps.split('\n'))  # 39.65
-"""
-
-import collections
-import math
-import re
-import sys
-import unicodedata
-
-import numpy as np
-import six
+USE_PYTORCH_DDP, _, DEVICE, _ = pytorch_setup()
 
 
-class UnicodeRegex(object):
-  """Ad-hoc hack to recognize all punctuation and symbols."""
+# Modified (added sync for PyTorch DDP) from
+# github.com/mjpost/sacrebleu/blob/master/sacrebleu/metrics/base.py.
+def corpus_bleu(hypotheses: Sequence[str],
+                references: Sequence[Sequence[str]],
+                smooth_method: str = 'exp',
+                smooth_value: Optional[float] = None,
+                force: bool = False,
+                lowercase: bool = False,
+                tokenize: Optional[str] = BLEU.TOKENIZER_DEFAULT,
+                use_effective_order: bool = False) -> BLEUScore:
+  """Computes BLEU for a corpus against a single (or multiple) reference(s).
+    This is the main CLI entry point for computing BLEU between a system output
+    and a reference sentence.
+    :param hypotheses: A sequence of hypothesis strings.
+    :param references: A sequence of reference documents with document being
+        defined as a sequence of reference strings.
+    :param smooth_method:
+        The smoothing method to use ('floor', 'add-k', 'exp' or 'none').
+    :param smooth_value: The smoothing value for `floor` and `add-k` methods.
+        `None` falls back to default value.
+    :param force: Ignore data that looks already tokenized
+    :param lowercase: Lowercase the data
+    :param tokenize: The tokenizer to use
+    :param use_effective_order:
+        Don't take into account n-gram orders without any match.
+    :return: a `BLEUScore` object
+    """
+  metric = BLEU(
+      lowercase=lowercase,
+      force=force,
+      tokenize=tokenize,
+      smooth_method=smooth_method,
+      smooth_value=smooth_value,
+      effective_order=use_effective_order)
+  metric._check_corpus_score_args(hypotheses, references)
 
-  def __init__(self):
-    punctuation = self.property_chars('P')
-    self.nondigit_punct_re = re.compile(r'([^\d])([' + punctuation + r'])')
-    self.punct_nondigit_re = re.compile(r'([' + punctuation + r'])([^\d])')
-    self.symbol_re = re.compile('([' + self.property_chars('S') + '])')
+  # Collect corpus stats
+  stats = metric._extract_corpus_statistics(hypotheses, references)
 
-  def property_chars(self, prefix):
-    return ''.join(
-        six.unichr(x)
-        for x in range(sys.maxunicode)
-        if unicodedata.category(six.unichr(x)).startswith(prefix))
+  if USE_PYTORCH_DDP:
+    stats = torch.as_tensor(stats, device=DEVICE)
+    dist.all_reduce(stats)
+    stats = stats.cpu().numpy().tolist()
 
+  # Compute the actual system score
+  actual_score = metric._aggregate_and_compute(stats)
 
-uregex = UnicodeRegex()
-
-
-def bleu_tokenize(string):
-  r"""Tokenize a string following the official BLEU implementation.
-
-  See https://github.com/moses-smt/mosesdecoder/'
-           'blob/master/scripts/generic/mteval-v14.pl#L954-L983
-  In our case, the input string is expected to be just one line
-  and no HTML entities de-escaping is needed.
-  So we just tokenize on punctuation and symbols,
-  except when a punctuation is preceded and followed by a digit
-  (e.g. a comma/dot as a thousand/decimal separator).
-
-  Note that a number (e.g. a year) followed by a dot at the end of sentence
-  is NOT tokenized, i.e. the dot stays with the number because
-  `s/(\p{P})(\P{N})/ $1 $2/g` does not match this case (unless we add a
-  space after each sentence). However, this error is already in the
-  original mteval-v14.pl and we want to be consistent with it.
-
-  Args:
-    string: the input string
-
-  Returns:
-    a list of tokens
-  """
-  string = uregex.nondigit_punct_re.sub(r'\1 \2 ', string)
-  string = uregex.punct_nondigit_re.sub(r' \1 \2', string)
-  string = uregex.symbol_re.sub(r' \1 ', string)
-  return string.split()
-
-
-def _get_ngrams(segment, max_order):
-  """Extracts all n-grams up to a given maximum order from an input segment.
-
-  Args:
-    segment: text segment from which n-grams will be extracted.
-    max_order: maximum length in tokens of the n-grams returned by this methods.
-
-  Returns:
-    The Counter containing all n-grams up to max_order in segment
-    with a count of how many times each n-gram occurred.
-  """
-  ngram_counts = collections.Counter()
-  for order in range(1, max_order + 1):
-    for i in range(0, len(segment) - order + 1):
-      ngram = tuple(segment[i:i + order])
-      ngram_counts[ngram] += 1
-  return ngram_counts
-
-
-def compute_bleu_matches(reference_corpus, translation_corpus, max_order=4):
-  """Computes BLEU match stats of translations against one or more references.
-
-  Args:
-    reference_corpus: list of references for each translation. Each reference
-      should be tokenized into a list of tokens.
-    translation_corpus: list of translations to score. Each translation should
-      be tokenized into a list of tokens.
-    max_order: Maximum n-gram order to use when computing BLEU score.
-
-  Returns:
-    Aggregated n-gram stats for BLEU calculation.
-  """
-  reference_length = 0
-  translation_length = 0
-
-  matches_by_order = [0] * max_order
-  possible_matches_by_order = [0] * max_order
-
-  for (references, translations) in zip(reference_corpus, translation_corpus):
-    reference_length += len(references)
-    translation_length += len(translations)
-    ref_ngram_counts = _get_ngrams(references, max_order)
-    translation_ngram_counts = _get_ngrams(translations, max_order)
-
-    overlap = dict((ngram, min(count, translation_ngram_counts[ngram]))
-                   for ngram,
-                   count in ref_ngram_counts.items())
-
-    for ngram in overlap:
-      matches_by_order[len(ngram) - 1] += overlap[ngram]
-    for ngram in translation_ngram_counts:
-      possible_matches_by_order[len(ngram) -
-                                1] += translation_ngram_counts[ngram]
-
-  return [
-      np.array(matches_by_order),
-      np.array(possible_matches_by_order),
-      np.array(reference_length),
-      np.array(translation_length)
-  ]
-
-
-def bleu_partial(ref_lines, hyp_lines, case_sensitive=False):
-  """Compute n-gram statistics for two lists of references and translations."""
-  if len(ref_lines) != len(hyp_lines):
-    raise ValueError('Reference and translation lists have different '
-                     'numbers of lines.')
-  if not case_sensitive:
-    ref_lines = [x.lower() for x in ref_lines]
-    hyp_lines = [x.lower() for x in hyp_lines]
-  ref_tokens = [bleu_tokenize(x) for x in ref_lines]
-  hyp_tokens = [bleu_tokenize(x) for x in hyp_lines]
-  return compute_bleu_matches(ref_tokens, hyp_tokens)
-
-
-def complete_bleu(matches_by_order,
-                  possible_matches_by_order,
-                  reference_length,
-                  translation_length,
-                  max_order=4,
-                  use_bp=True):
-  """Compute BLEU score from aggregated n-gram statistics."""
-  precisions = [0] * max_order
-  smooth = 1.0
-  geo_mean = 0.0
-  for i in range(0, max_order):
-    if possible_matches_by_order[i] > 0:
-      precisions[i] = matches_by_order[i] / possible_matches_by_order[i]
-      if matches_by_order[i] > 0:
-        precisions[i] = matches_by_order[i] / possible_matches_by_order[i]
-      else:
-        smooth *= 2
-        precisions[i] = 1.0 / (smooth * possible_matches_by_order[i])
-    else:
-      precisions[i] = 0.0
-
-  if max(precisions) > 0:
-    p_log_sum = sum(math.log(p) for p in precisions if p)
-    geo_mean = math.exp(p_log_sum / max_order)
-
-  if use_bp:
-    if not reference_length:
-      bp = 1.0
-    else:
-      ratio = translation_length / reference_length
-      if ratio <= 0.0:
-        bp = 0.0
-      elif ratio >= 1.0:
-        bp = 1.0
-      else:
-        bp = math.exp(1 - 1. / ratio)
-  bleu = geo_mean * bp
-  return float(bleu) * 100.0
-
-
-def bleu_local(ref_lines, hyp_lines, case_sensitive=False):
-  """Compute BLEU for two lists of reference and hypothesis translations."""
-  stats = bleu_partial(ref_lines, hyp_lines, case_sensitive=case_sensitive)
-  return complete_bleu(*stats) * 100
+  return actual_score

--- a/algorithmic_efficiency/workloads/wmt/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/wmt/input_pipeline.py
@@ -15,6 +15,13 @@ RANK = pytorch_setup()[1]
 AUTOTUNE = tf.data.AUTOTUNE if RANK == 0 else None
 Features = Dict[str, tf.Tensor]
 
+TFDS_SPLIT_NAME = {
+    'train': 'train',
+    'eval_train': 'train',
+    'validation': 'validation',
+    'test': 'test'
+}
+
 
 def normalize_feature_names(ds_info, reverse_translation,
                             features: Features) -> Features:
@@ -268,7 +275,8 @@ def get_wmt_dataset(data_rng,
     ds_name = 'wmt17_translate/de-en:1.0.0'
   dataset_builder = tfds.builder(ds_name, data_dir=data_dir)
   dataset_builder.download_and_prepare()
-  ds = dataset_builder.as_dataset(split=split, shuffle_files=False)
+  ds = dataset_builder.as_dataset(
+      split=TFDS_SPLIT_NAME[split], shuffle_files=False)
 
   # Avoid creating too many threads when using PyTorch DDP.
   if RANK != 0:

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -14,6 +14,7 @@ import sacrebleu
 
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
+from algorithmic_efficiency.workloads.wmt import bleu
 from algorithmic_efficiency.workloads.wmt import decode
 from algorithmic_efficiency.workloads.wmt.wmt_jax import models
 from algorithmic_efficiency.workloads.wmt.workload import BaseWmtWorkload
@@ -198,7 +199,7 @@ class WmtWorkload(BaseWmtWorkload):
         predictions.append(self._decode_tokens(predicted[idx]))
 
     # Calculate BLEU score for translated eval corpus against reference.
-    bleu_score = sacrebleu.corpus_bleu(predictions, [references]).score
+    bleu_score = bleu.corpus_bleu(predictions, [references]).score
     return bleu_score
 
   def init_model_fn(

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -10,7 +10,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-import sacrebleu
 
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -58,7 +58,8 @@ class WmtWorkload(BaseWmtWorkload):
     mask = torch.where(targets > 0, 1, 0)
     if weights is not None:
       mask = torch.logical_and(weights, mask)
-    per_example_losses = torch.where(mask, per_example_losses, 0.)
+    per_example_losses = torch.where(
+        mask.to(torch.bool), per_example_losses, 0.)
     summed_loss = per_example_losses.sum()
     n_valid_samples = mask.sum()
     return summed_loss / n_valid_samples, per_example_losses

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -150,14 +150,7 @@ class WmtWorkload(BaseWmtWorkload):
         predictions.append(self._decode_tokens(predicted[idx]))
 
     # Calculate BLEU score for translated eval corpus against reference.
-    bleu_matches = bleu.bleu_partial(references, predictions)
-    if USE_PYTORCH_DDP:
-      # Sync matches across devices.
-      for idx, array in enumerate(bleu_matches):
-        tensor = torch.as_tensor(array, device=DEVICE)
-        dist.all_reduce(tensor)
-        bleu_matches[idx] = tensor.cpu().numpy()
-    bleu_score = bleu.complete_bleu(*bleu_matches)
+    bleu_score = bleu.corpus_bleu(predictions, [references]).score
     return bleu_score
 
   def init_model_fn(


### PR DESCRIPTION
This PR switches the bleu score calculation to sacrebleu for PyTorch WMT, to match the one used in Jax WMT. The only difference is that for PyTorch DDP the statistics have to be synced via an `all_gather` operation at the right position. I'm currently running a test run which checks that his sync happens correctly.

_Update: The sync works fine now._