### PR TITLE
Check if optimizer state entry has state_dict() method

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -158,6 +158,7 @@ def init_optimizer_state(
 
 - Allowed to create state for the optimizer
 - Does not involve the initialization for the model parameters, which in the Training Algorithm Track, is considered a fixed function, see [Model initialization](#model-initialization).
+- The optimizer state is a dictionary (`Dict[str, Any]`). For a PyTorch submission, any value in this dictionary which is a class instance with internal state has to have a `state_dict()` method implemented to be stored correctly at the training checkpoints.
 
 ###### Variable update function
 

--- a/algorithmic_efficiency/checkpoint_utils.py
+++ b/algorithmic_efficiency/checkpoint_utils.py
@@ -136,7 +136,8 @@ def save_checkpoint(framework: str,
     model_params = model_params.state_dict()
     optimizer_state_dict = {}
     for key in optimizer_state.keys():
-      optimizer_state_dict[key] = optimizer_state[key].state_dict()
+      if hasattr(optimizer_state[key], 'state_dict'):
+        optimizer_state_dict[key] = optimizer_state[key].state_dict()
     opt_state = optimizer_state_dict
 
   checkpoint_state = dict(

--- a/algorithmic_efficiency/checkpoint_utils.py
+++ b/algorithmic_efficiency/checkpoint_utils.py
@@ -138,6 +138,11 @@ def save_checkpoint(framework: str,
     for key in optimizer_state.keys():
       if hasattr(optimizer_state[key], 'state_dict'):
         optimizer_state_dict[key] = optimizer_state[key].state_dict()
+      else:
+        logging.warning(
+            f'The optimizer state for key {key} is not saved, because '
+            f'{type(optimizer_state[key])} has not implemented a state_dict() '
+            'method.')
     opt_state = optimizer_state_dict
 
   checkpoint_state = dict(

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -61,7 +61,7 @@ ParameterTypeTree = Dict[ParameterKey, Dict[ParameterKey, ParameterType]]
 
 RandomState = Any  # Union[jax.random.PRNGKey, int, bytes, ...]
 
-OptimizerState = Any
+OptimizerState = Dict[str, Any]
 Hyperparameters = Any
 Timing = int
 Steps = int


### PR DESCRIPTION
Currently, when creating a checkpoint of the optimizer state in PyTorch, we try to get the `state_dict()` for all keys in `optimizer_state`. However, there is at least one case where we just use a Python function and not a PyTorch lr schedule class for the learning rate schedule (see [here](https://github.com/runame/algorithmic-efficiency/blob/main/reference_algorithms/development_algorithms/wmt/wmt_pytorch/submission.py#L86-L87)). In this case there will be an `AttributeError` raised. I think this does not affect the target setting runs though.

Do you think the easy fix I implemented here is sufficient? Maybe we have to communicate to the user that all dict entries in the `optimizer_state` have to have `state_dict()` implemented to be correctly saved?