### PR TITLE
Remove `reverse_translation` option

### DIFF
--- a/algorithmic_efficiency/workloads/wmt/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/wmt/input_pipeline.py
@@ -23,13 +23,9 @@ TFDS_SPLIT_NAME = {
 }
 
 
-def normalize_feature_names(ds_info, reverse_translation,
-                            features: Features) -> Features:
+def normalize_feature_names(ds_info, features: Features) -> Features:
   """Normalizes feature names to 'inputs' and 'targets'."""
-  in_lang, tar_lang = ds_info.supervised_keys
-  input_lang = tar_lang if reverse_translation else in_lang
-  target_lang = in_lang if reverse_translation else tar_lang
-
+  input_lang, target_lang = ds_info.supervised_keys
   features['inputs'] = features.pop(input_lang)
   features['targets'] = features.pop(target_lang)
   return features
@@ -262,7 +258,6 @@ def get_wmt_dataset(data_rng,
                     vocab_size: int,
                     global_batch_size: int,
                     num_batches: Optional[int] = None,
-                    reverse_translation: bool = True,
                     repeat_final_dataset: bool = False,
                     vocab_path: Optional[str] = None):
   """Load and return dataset of batched examples for use during training."""
@@ -285,9 +280,7 @@ def get_wmt_dataset(data_rng,
     ds = ds.with_options(options)
 
   ds = ds.map(
-      functools.partial(normalize_feature_names,
-                        dataset_builder.info,
-                        reverse_translation),
+      functools.partial(normalize_feature_names, dataset_builder.info),
       num_parallel_calls=AUTOTUNE)
 
   # Tokenize data.

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -103,7 +103,6 @@ class BaseWmtWorkload(spec.Workload):
         vocab_size=self._vocab_size,
         global_batch_size=global_batch_size,
         num_batches=num_batches,
-        reverse_translation=True,
         repeat_final_dataset=repeat_final_dataset)
 
     # Separate function is necessary because the code above has to be executed


### PR DESCRIPTION
Removes the option for changing the direction of translation (we don't use reverse translation for the target setting runs). Fixes #236.

The target setting run of the Jax WMT workload now reaches a validation bleu score of 30.62 after about 100k steps (the target is 30.879). This run used sacrebleu 1.3.1 (should be equivalent to 1.3.0). I will add the result of the PyTorch run here when it has finished.

I might change the version of sacrebleu in a follow-up PR, but it does not seem like the latest version yields a different result from 1.3.0 (used for the target setting runs).