### PR TITLE
ImageNet Timing Fixes

### DIFF
--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -247,8 +247,8 @@ class PrefetchedWrapper:
     self.dataloader = dataloader
     self.epoch = start_epoch
     self.device = device
-    self.data_mean = torch.tensor(mean, device=device).view(1, 3, 1, 1)
-    self.data_std = torch.tensor(std, device=device).view(1, 3, 1, 1)
+    # self.data_mean = torch.tensor(mean, device=device).view(1, 3, 1, 1)
+    # self.data_std = torch.tensor(std, device=device).view(1, 3, 1, 1)
 
   def __len__(self):
     return len(self.dataloader)
@@ -268,7 +268,7 @@ class PrefetchedWrapper:
       with torch.cuda.stream(stream):
         next_inputs = next_inputs.to(
             self.device, dtype=torch.float,
-            non_blocking=True).sub(self.data_mean).div(self.data_std)
+            non_blocking=True)
         next_targets = next_targets.to(self.device, non_blocking=True)
 
       if not first:

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -111,133 +111,6 @@ def cycle(iterable: Iterable,
         iterable.sampler.set_epoch(epoch)
       iterator = iter(iterable)
 
-
-# github.com/SeungjunNah/DeepDeblur-PyTorch/blob/master/src/data/sampler.py
-class DistributedEvalSampler(Sampler):
-  r"""
-  DistributedEvalSampler is different from DistributedSampler.
-  It does NOT add extra samples to make it evenly divisible.
-  DistributedEvalSampler should NOT be used for training. The distributed
-  processes could hang forever.
-  See this issue for details: https://github.com/pytorch/pytorch/issues/22584
-  shuffle is disabled by default
-  DistributedEvalSampler is for evaluation purpose where synchronization does
-  not happen every epoch.
-  Synchronization should be done outside the dataloader loop.
-  Sampler that restricts data loading to a subset of the dataset.
-  It is especially useful in conjunction with
-  :class:`torch.nn.parallel.DistributedDataParallel`. In such a case, each
-  process can pass a :class`~DistributedEvalSampler` instance as
-  a :class:`~torch.utils.data.DataLoader` sampler, and load a subset of the
-  original dataset that is exclusive to it.
-  .. note::
-    Dataset is assumed to be of constant size.
-  Arguments:
-    dataset: Dataset used for sampling.
-    num_replicas (int, optional): Number of processes participating in
-        distributed training. By default, :attr:`rank` is retrieved from the
-        current distributed group.
-    rank (int, optional): Rank of the current process within
-        :attr:`num_replicas`. By default, :attr:`rank` is retrieved from the
-        current distributed group.
-    shuffle (bool, optional): If ``True``, sampler will shuffle the
-        indices. Default: ``False``
-    seed (int, optional): random seed used to shuffle the sampler if
-        :attr:`shuffle=True`. This number should be identical across all
-        processes in the distributed group. Default: ``0``.
-  .. warning::
-    In distributed mode, calling the :meth`set_epoch(epoch) <set_epoch>`
-    method at the beginning of each epoch **before** creating the
-    :class:`DataLoader` iterator is necessary to make shuffling work
-    properly across multiple epochs. Otherwise, the same ordering will be
-    always used.
-  Example::
-    >>> sampler = DistributedSampler(dataset) if is_distributed else None
-    >>> loader = DataLoader(dataset, shuffle=(sampler is None),
-    ...                     sampler=sampler)
-    >>> for epoch in range(start_epoch, n_epochs):
-    ...     if is_distributed:
-    ...         sampler.set_epoch(epoch)
-    ...     train(loader)
-  """
-
-  def __init__(self,
-               dataset,
-               num_replicas=None,
-               rank=None,
-               shuffle=False,
-               seed=0):
-    if num_replicas is None:
-      if not dist.is_available():
-        raise RuntimeError('Requires distributed package to be available.')
-      num_replicas = dist.get_world_size()
-    if rank is None:
-      if not dist.is_available():
-        raise RuntimeError('Requires distributed package to be available.')
-      rank = dist.get_rank()
-    self.dataset = dataset
-    self.num_replicas = num_replicas
-    self.rank = rank
-    self.epoch = 0
-    # true value without extra samples
-    self.total_size = len(self.dataset)
-    indices = list(range(self.total_size))
-    indices = indices[self.rank:self.total_size:self.num_replicas]
-    # true value without extra samples
-    self.num_samples = len(indices)
-
-    self.shuffle = shuffle
-    self.seed = seed
-
-  def __iter__(self):
-    if self.shuffle:
-      # deterministically shuffle based on epoch and seed
-      g = torch.Generator()
-      g.manual_seed(self.seed + self.epoch)
-      indices = torch.randperm(len(self.dataset), generator=g).tolist()
-    else:
-      indices = list(range(len(self.dataset)))
-
-    # subsample
-    indices = indices[self.rank:self.total_size:self.num_replicas]
-    assert len(indices) == self.num_samples
-
-    return iter(indices)
-
-  def __len__(self):
-    return self.num_samples
-
-  def set_epoch(self, epoch):
-    r"""
-    Sets the epoch for this sampler. When :attr:`shuffle=True`, this
-    ensures all replicas use a different random ordering for each epoch.
-    Otherwise, the next iteration of this sampler will yield the same
-    ordering.
-    Arguments:
-        epoch (int): _epoch number.
-    """
-    self.epoch = epoch
-
-
-# github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/Classification/
-# ConvNets/image_classification/dataloaders.py
-def fast_collate(batch, memory_format=torch.contiguous_format):
-  imgs = [img[0] for img in batch]
-  targets = torch.tensor([target[1] for target in batch], dtype=torch.int64)
-  w = imgs[0].size[0]
-  h = imgs[0].size[1]
-  tensor = torch.zeros(
-      (len(imgs), 3, h, w),
-      dtype=torch.uint8).contiguous(memory_format=memory_format)
-  for i, img in enumerate(imgs):
-    nump_array = np.asarray(img, dtype=np.uint8)
-    if nump_array.ndim < 3:
-      nump_array = np.expand_dims(nump_array, axis=-1)
-    nump_array = np.rollaxis(nump_array, 2)
-    tensor[i] += torch.from_numpy(nump_array.copy())
-  return tensor, targets
-
-
 # Inspired by
 # github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/Classification/
 # ConvNets/image_classification/dataloaders.py
@@ -252,8 +125,7 @@ class PrefetchedWrapper:
     return len(self.dataloader)
 
   def __iter__(self):
-    if isinstance(self.dataloader.sampler,
-                  (DistributedSampler, DistributedEvalSampler)):
+    if isinstance(self.dataloader.sampler, DistributedSampler):
       self.dataloader.sampler.set_epoch(self.epoch)
     self.epoch += 1
     return self.prefetched_loader()

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -243,12 +243,10 @@ def fast_collate(batch, memory_format=torch.contiguous_format):
 # ConvNets/image_classification/dataloaders.py
 class PrefetchedWrapper:
 
-  def __init__(self, dataloader, device, mean, std, start_epoch=0):
+  def __init__(self, dataloader, device, start_epoch=0):
     self.dataloader = dataloader
     self.epoch = start_epoch
     self.device = device
-    # self.data_mean = torch.tensor(mean, device=device).view(1, 3, 1, 1)
-    # self.data_std = torch.tensor(std, device=device).view(1, 3, 1, 1)
 
   def __len__(self):
     return len(self.dataloader)

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -83,10 +83,7 @@ class CifarWorkload(BaseCifarWorkload):
     if USE_PYTORCH_DDP:
       if is_train:
         sampler = torch.utils.data.distributed.DistributedSampler(
-            dataset, num_replicas=N_GPUS, rank=RANK, shuffle=True)
-      else:
-        sampler = data_utils.DistributedEvalSampler(
-            dataset, num_replicas=N_GPUS, rank=RANK, shuffle=False)
+          dataset, drop_last=is_train, num_replicas=N_GPUS, rank=RANK, shuffle=is_train)
       batch_size //= N_GPUS
     dataloader = torch.utils.data.DataLoader(
         dataset,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -125,10 +125,11 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=8,
+        num_workers=4,
         pin_memory=True,
         drop_last=is_train,
-        persistent_workers=True)
+        # persistent_workers=True
+    )
     dataloader = data_utils.PrefetchedWrapper(dataloader, DEVICE)
     dataloader = data_utils.cycle(
         dataloader,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -122,7 +122,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=4,
+        num_workers=2,
         pin_memory=True,
         drop_last=is_train,
         # persistent_workers=True

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -135,9 +135,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         drop_last=is_train,
         persistent_workers=True)
     dataloader = data_utils.PrefetchedWrapper(dataloader,
-                                              DEVICE,
-                                              self.train_mean,
-                                              self.train_stddev)
+                                              DEVICE)
     dataloader = data_utils.cycle(
         dataloader,
         custom_sampler=USE_PYTORCH_DDP,
@@ -161,7 +159,6 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
-        # model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
         model = DDP(model, device_ids=[RANK], output_device=RANK)
       else:
         model = torch.nn.DataParallel(model)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -87,7 +87,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       ]
       if use_randaug:
         transform_config.append(randaugment.RandAugment())
-      # transform_config.append(normalize)
+      transform_config.append(normalize)
       transform_config = transforms.Compose(transform_config)
     else:
       transform_config = transforms.Compose([

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -87,14 +87,14 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       ]
       if use_randaug:
         transform_config.append(randaugment.RandAugment())
-      # transform_config.append(normalize)
+      transform_config.append(normalize)
       transform_config = transforms.Compose(transform_config)
     else:
       transform_config = transforms.Compose([
           transforms.Resize(self.resize_size),
           transforms.CenterCrop(self.center_crop_size),
           transforms.ToTensor(),
-          # normalize
+          normalize
       ])
 
     folder = 'train' if 'train' in split else 'val'
@@ -125,7 +125,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         num_workers=4 if is_train else 0,
         pin_memory=True,
         drop_last=is_train,
-        # persistent_workers=True
+        persistent_workers=True
     )
     dataloader = data_utils.PrefetchedWrapper(dataloader, DEVICE)
     dataloader = data_utils.cycle(

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -214,7 +214,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       logits_batch: spec.Tensor,
       mask_batch: Optional[spec.Tensor] = None,
       label_smoothing: float = 0.0
-  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+  ) -> Tuple[spec.Tensor, spec.Tensor]:
     """Return (correct scalar average loss, 1-d array of per-example losses)."""
     per_example_losses = F.cross_entropy(
         logits_batch,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -87,14 +87,14 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       ]
       if use_randaug:
         transform_config.append(randaugment.RandAugment())
-      transform_config.append(normalize)
+      # transform_config.append(normalize)
       transform_config = transforms.Compose(transform_config)
     else:
       transform_config = transforms.Compose([
           transforms.Resize(self.resize_size),
           transforms.CenterCrop(self.center_crop_size),
           transforms.ToTensor(),
-          normalize
+          # normalize
       ])
 
     folder = 'train' if 'train' in split else 'val'
@@ -122,7 +122,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=4,
+        num_workers=4 if is_train else 0,
         pin_memory=True,
         drop_last=is_train,
         # persistent_workers=True

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -125,7 +125,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         num_workers=4 if is_train else 0,
         pin_memory=True,
         drop_last=is_train,
-        persistent_workers=True
+        persistent_workers=is_train
     )
     dataloader = data_utils.PrefetchedWrapper(dataloader, DEVICE)
     dataloader = data_utils.cycle(

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -122,7 +122,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=2,
+        num_workers=4,
         pin_memory=True,
         drop_last=is_train,
         # persistent_workers=True

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -114,12 +114,9 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     else:
       ds_iter_batch_size = global_batch_size
     if USE_PYTORCH_DDP:
-      if is_train:
-        sampler = torch.utils.data.distributed.DistributedSampler(
-            dataset, num_replicas=N_GPUS, rank=RANK, shuffle=True)
-      else:
-        sampler = data_utils.DistributedEvalSampler(
-            dataset, num_replicas=N_GPUS, rank=RANK, shuffle=False)
+      sampler = torch.utils.data.distributed.DistributedSampler(
+          dataset, drop_last=is_train, num_replicas=N_GPUS, rank=RANK, shuffle=is_train)
+
     dataloader = torch.utils.data.DataLoader(
         dataset,
         batch_size=ds_iter_batch_size,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
@@ -37,7 +37,7 @@ def get_imagenet_v2_iter(data_dir: str,
                                                resize_size)
     return {'inputs': image, 'targets': example['label']}
 
-  ds = ds.map(_decode_example, num_parallel_calls=4)
+  ds = ds.map(_decode_example)
   ds = ds.batch(global_batch_size)
   shard_pad_fn = functools.partial(
       data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_v2.py
@@ -37,7 +37,7 @@ def get_imagenet_v2_iter(data_dir: str,
                                                resize_size)
     return {'inputs': image, 'targets': example['label']}
 
-  ds = ds.map(_decode_example, num_parallel_calls=16)
+  ds = ds.map(_decode_example, num_parallel_calls=4)
   ds = ds.batch(global_batch_size)
   shard_pad_fn = functools.partial(
       data_utils.shard_and_maybe_pad_np, global_batch_size=global_batch_size)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -74,7 +74,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def max_allowed_runtime_sec(self) -> int:
-    return 111600  # 31 hours.
+    return 520  # 31 hours.
 
   @property
   def eval_period_time_sec(self) -> int:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -74,7 +74,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def max_allowed_runtime_sec(self) -> int:
-    return 520  # 31 hours.
+    return 1800  # 31 hours.
 
   @property
   def eval_period_time_sec(self) -> int:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -44,7 +44,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def eval_batch_size(self) -> int:
-    return 1024
+    return 2
 
   @property
   def train_mean(self) -> Tuple[float, float, float]:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -74,7 +74,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def max_allowed_runtime_sec(self) -> int:
-    return 1800  # 31 hours.
+    return 111600  # 31 hours.
 
   @property
   def eval_period_time_sec(self) -> int:

--- a/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/workload.py
@@ -44,7 +44,7 @@ class BaseImagenetResNetWorkload(spec.Workload):
 
   @property
   def eval_batch_size(self) -> int:
-    return 2
+    return 1024
 
   @property
   def train_mean(self) -> Tuple[float, float, float]:

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -117,11 +117,11 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     del data_rng
     del num_batches
     del repeat_final_dataset
-    train = False
+    is_train = False
 
     if split == 'train':
       split = 'train-clean-100+train-clean-360+train-other-500'
-      train = True
+      is_train = True
     elif split == 'eval_train':
       split = 'train-clean-100+train-clean-360+train-other-500'
     elif split == 'validation':
@@ -142,20 +142,16 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     else:
       ds_iter_batch_size = global_batch_size
     if USE_PYTORCH_DDP:
-      if train:
-        sampler = torch.utils.data.distributed.DistributedSampler(
-            ds, num_replicas=N_GPUS, rank=RANK, shuffle=True, seed=0)
-      else:
-        sampler = data_utils.DistributedEvalSampler(
-            ds, num_replicas=N_GPUS, rank=RANK, shuffle=False)
+      sampler = torch.utils.data.distributed.DistributedSampler(
+          ds, drop_last=is_train, num_replicas=N_GPUS, rank=RANK, shuffle=is_train, seed=0)
     dataloader = torch.utils.data.DataLoader(
         ds,
         batch_size=ds_iter_batch_size,
-        shuffle=not USE_PYTORCH_DDP and train,
+        shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
         num_workers=4,
         pin_memory=True,
-        drop_last=train)
+        drop_last=is_train)
 
     dataloader = data_utils.cycle(
         dataloader, custom_sampler=USE_PYTORCH_DDP, use_mixup=False)

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -75,12 +75,8 @@ class MnistWorkload(BaseMnistWorkload):
     sampler = None
     is_train = split == 'train'
     if USE_PYTORCH_DDP:
-      if is_train:
-        sampler = torch.utils.data.distributed.DistributedSampler(
-            dataset, num_replicas=N_GPUS, rank=RANK, shuffle=True)
-      else:
-        sampler = data_utils.DistributedEvalSampler(
-            dataset, num_replicas=N_GPUS, rank=RANK, shuffle=False)
+      sampler = torch.utils.data.distributed.DistributedSampler(
+          dataset, drop_last=is_train, num_replicas=N_GPUS, rank=RANK, shuffle=is_train)
       batch_size //= N_GPUS
     dataloader = torch.utils.data.DataLoader(
         dataset,

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,14 +130,14 @@ pytorch_core_deps =
 # PyTorch CPU
 pytorch_cpu =
   %(pytorch_core_deps)s
-  torch==1.12.1
-  torchvision==0.13.1
+  torch==1.13.0
+  torchvision==0.14.0
 
 # PyTorch GPU
 pytorch_gpu =
   %(pytorch_core_deps)s
-  torch==1.12.1+cu113
-  torchvision==0.13.1+cu113
+  torch==1.13.0+cu117
+  torchvision==0.14.0+cu117
 
 # wandb
 wandb =


### PR DESCRIPTION
This PR aims to make the general PyTorch imagenet resnet workload more efficient. Specifically, this PR:
- Removes `fast_collate` and performs normalization with `torch.transform`.
- Removes sync batch norm. 
- Removes irrelevant functions.
- Updates PyTorch version (`1.12.1` --> `1.13.0`).

I confirmed that this reduces the timing for `load data` and `update_params`. Moreover, I ran full-scale experiments and confirmed that the changes still reach the target accuracy using target-setting hyperparameters. 

One minor thing is that increasing `num_workers` in the data loader seems to have a negative effect during the evaluation. I set `num_workers=0` for evaluation data loaders and this slightly slows down the evaluation. We may need to investigate this further in the future.