### PR TITLE
Switch to `sacrebleu==1.3.1`

### DIFF
--- a/algorithmic_efficiency/scoring.py
+++ b/algorithmic_efficiency/scoring.py
@@ -29,8 +29,9 @@ import itertools
 import operator
 import os
 
-import pandas as pd
+import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 
 MIN_EVAL_METRICS = [
     'ce_loss',

--- a/algorithmic_efficiency/workloads/wmt/bleu.py
+++ b/algorithmic_efficiency/workloads/wmt/bleu.py
@@ -1,7 +1,8 @@
-from typing import Optional, Sequence
+from itertools import zip_longest
+from typing import Sequence
 
-from sacrebleu import BLEU
-from sacrebleu.metrics import BLEUScore
+from absl import logging
+import sacrebleu
 import torch
 import torch.distributed as dist
 
@@ -11,65 +12,99 @@ USE_PYTORCH_DDP, _, DEVICE, N_GPUS = pytorch_setup()
 
 
 # Modified (added sync for PyTorch DDP) from
-# github.com/mjpost/sacrebleu/blob/master/sacrebleu/metrics/base.py.
-def corpus_bleu(hypotheses: Sequence[str],
-                references: Sequence[Sequence[str]],
+# https://github.com/mjpost/sacrebleu/blob/v1.3.1/sacrebleu.py.
+# Assumes that sacrebleu==1.3.1 is installed.
+def corpus_bleu(sys_stream: Sequence[str],
+                ref_streams: Sequence[str],
                 smooth_method: str = 'exp',
-                smooth_value: Optional[float] = None,
+                smooth_value: float = 0.0,
                 force: bool = False,
                 lowercase: bool = False,
-                tokenize: Optional[str] = BLEU.TOKENIZER_DEFAULT,
-                use_effective_order: bool = False) -> BLEUScore:
-  """Computes BLEU for a corpus against a single (or multiple) reference(s).
-    This is the main CLI entry point for computing BLEU between a system output
-    and a reference sentence.
-    :param hypotheses: A sequence of hypothesis strings.
-    :param references: A sequence of reference documents with document being
-        defined as a sequence of reference strings.
-    :param smooth_method:
-        The smoothing method to use ('floor', 'add-k', 'exp' or 'none').
-    :param smooth_value: The smoothing value for `floor` and `add-k` methods.
-        `None` falls back to default value.
-    :param force: Ignore data that looks already tokenized
-    :param lowercase: Lowercase the data
-    :param tokenize: The tokenizer to use
-    :param use_effective_order:
-        Don't take into account n-gram orders without any match.
-    :return: a `BLEUScore` object
-    """
-  metric = BLEU(
-      lowercase=lowercase,
-      force=force,
-      tokenize=tokenize,
+                tokenize: str = '13a',
+                use_effective_order: bool = False) -> sacrebleu.BLEU:
+  """Produces BLEU scores along with its sufficient statistics from a source
+  against one or more references.
+      :param sys_stream: The system stream (a sequence of segments).
+      :param ref_streams: A list of one or more reference streams
+                          (each a sequence of segments).
+      :param smooth: The smoothing method to use.
+      :param smooth_value: For 'floor' smoothing, the floor to use.
+      :param force: Ignore data that looks already tokenized.
+      :param lowercase: Lowercase the data.
+      :param tokenize: The tokenizer to use.
+      :return: A BLEU object containing everything you'd want.
+  """
+
+  # Add some robustness to the input arguments
+  if isinstance(sys_stream, str):
+    sys_stream = [sys_stream]
+  if isinstance(ref_streams, str):
+    ref_streams = [[ref_streams]]
+
+  sys_len = 0
+  ref_len = 0
+
+  correct = [0 for _ in range(sacrebleu.NGRAM_ORDER)]
+  total = [0 for _ in range(sacrebleu.NGRAM_ORDER)]
+
+  # look for already-tokenized sentences
+  tokenized_count = 0
+
+  fhs = [sys_stream] + ref_streams
+  for lines in zip_longest(*fhs):
+    if None in lines:
+      raise EOFError('Source and reference streams have different lengths!')
+
+    if lowercase:
+      lines = [x.lower() for x in lines]
+
+    if not (force or tokenize is 'none') and lines[0].rstrip().endswith(' .'):
+      tokenized_count += 1
+
+      if tokenized_count == 100:
+        logging.warning(
+            'That\'s 100 lines that end in a tokenized period (\'.\')')
+        logging.warning('It looks like you forgot to detokenize your test '
+                        'data, which may hurt your score.')
+        logging.warning('If you insist your data is detokenized, '
+                        'or don\'t care, you can suppress this message with '
+                        '\'--force\'.')
+
+    output, *refs = [sacrebleu.TOKENIZERS[tokenize](x.rstrip()) for x in lines]
+
+    ref_ngrams, _, closest_len = sacrebleu.ref_stats(output, refs)
+
+    sys_len += len(output.split())
+    ref_len += closest_len
+
+    sys_ngrams = sacrebleu.extract_ngrams(output)
+    for ngram in sys_ngrams.keys():
+      n = len(ngram.split())
+      correct[n - 1] += min(sys_ngrams[ngram], ref_ngrams.get(ngram, 0))
+      total[n - 1] += sys_ngrams[ngram]
+
+  # When using PyTorch DDP, get stats from all processes and sum them.
+  if USE_PYTORCH_DDP:
+    # Sum `sys_len` and `ref_len` integers from all processes.
+    sys_len = torch.tensor(sys_len, dtype=torch.int64, device=DEVICE)
+    dist.all_reduce(sys_len)
+    sys_len = sys_len.item()
+    ref_len = torch.tensor(ref_len, dtype=torch.int64, device=DEVICE)
+    dist.all_reduce(ref_len)
+    ref_len = ref_len.item()
+    # Sum `correct` and `total` sequences from all processes.
+    correct = torch.tensor(correct, dtype=torch.int64, device=DEVICE)
+    dist.all_reduce(correct)
+    correct = correct.cpu().numpy().tolist()
+    total = torch.tensor(total, dtype=torch.int64, device=DEVICE)
+    dist.all_reduce(total)
+    total = total.cpu().numpy().tolist()
+
+  return sacrebleu.compute_bleu(
+      correct,
+      total,
+      sys_len,
+      ref_len,
       smooth_method=smooth_method,
       smooth_value=smooth_value,
-      effective_order=use_effective_order)
-  metric._check_corpus_score_args(hypotheses, references)
-
-  # Collect corpus stats
-  stats = metric._extract_corpus_statistics(hypotheses, references)
-
-  # When using PyTorch DDP, get stats from all processes and concatenate them.
-  if USE_PYTORCH_DDP:
-    length = torch.tensor(len(stats), dtype=torch.int64, device=DEVICE)
-    all_lengths = [torch.empty_like(length) for _ in range(N_GPUS)]
-    dist.all_gather(all_lengths, length)
-    max_length = max(all_lengths)
-    stats = torch.as_tensor(stats, dtype=torch.int64, device=DEVICE)
-    # If the evaluation dataset cannot be split into N_GPUS equally sized
-    # subsets, we have to pad (with zeros) to be able to use all_gather.
-    if length < max_length:
-      padding_size = max_length - length
-      padding = stats.new_zeros((padding_size, *stats.shape[1:]))
-      stats = torch.cat((stats, padding))
-    all_stats = [torch.empty_like(stats) for _ in range(N_GPUS)]
-    dist.all_gather(all_stats, stats)
-    # Remove padding before concatenating the stats from all processes.
-    stats = torch.cat(
-        [all_stats[i][:length] for i, length in enumerate(all_lengths)])
-    stats = stats.cpu().numpy().tolist()
-
-  # Compute the actual system score
-  actual_score = metric._aggregate_and_compute(stats)
-
-  return actual_score
+      use_effective_order=use_effective_order)

--- a/algorithmic_efficiency/workloads/wmt/bleu.py
+++ b/algorithmic_efficiency/workloads/wmt/bleu.py
@@ -58,7 +58,7 @@ def corpus_bleu(sys_stream: Sequence[str],
     if lowercase:
       lines = [x.lower() for x in lines]
 
-    if not (force or tokenize is 'none') and lines[0].rstrip().endswith(' .'):
+    if not (force or tokenize == 'none') and lines[0].rstrip().endswith(' .'):
       tokenized_count += 1
 
       if tokenized_count == 100:

--- a/algorithmic_efficiency/workloads/wmt/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/workload.py
@@ -32,7 +32,7 @@ class BaseWmtWorkload(spec.Workload):
 
   @property
   def target_value(self) -> float:
-    return 30.879  # TODO(namanagarwal): This will edited again soon.
+    return 30.6446
 
   @property
   def loss_type(self) -> spec.LossType:

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,7 @@ librispeech_conformer_jax =
 wmt =
   sentencepiece==0.1.97
   tensorflow-text==2.9.0
-  sacrebleu==2.3.1
+  sacrebleu==1.3.1
 
 # Frameworks #
 


### PR DESCRIPTION
This PR switches to `sacrebleu==1.3.1`, since this is what is used for the target setting runs (actually 1.3.0 is used, but this version is not available on pip and seems to be identical code-wise to 1.3.1), and updates the WMT target validation bleu score to 30.6446. The Jax and the PyTorch versions of the workload both reach this target in the expected number of steps.