### PR TITLE
Add pre-commit checks and relevant documentation.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/google/yapf
+    rev: v0.32.0
+    hooks:
+      - id: yapf
+        args: ["--in-place", "--parallel", "--verbose", "--recursive"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/pylint
+    rev: v2.14.5
+    hooks:
+      - id: pylint

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 
    ```bash
    pip3 install -e '.[dev]'
+   pre-commit install
    ```
 
    To get an installation with the requirements for all workloads and development, use the argument `[full_dev]`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,7 @@ dev =
   pylint==2.14.5
   pytest==7.1.2
   yapf==0.32.0
+  pre-commit==2.20.0
 
 # Workloads #
 criteo1tb =


### PR DESCRIPTION
NOTE: Waiting on #264 to be merged.

By asking developers to run the updated `Development` instructions, we automatically run / fix all the linting issues prior to each commit. Configured using the same `yapf`, `isort`, and `pylint` versions with the same arguments.