### PR TITLE
Conformer JAX specaug fix

### DIFF
--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
@@ -8,7 +8,7 @@ github.com/tensorflow/lingvo/blob/master/lingvo/jax/layers/spectrum_augmenter.py
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
-
+import numpy as np
 
 class SpecAug(nn.Module):
   """Layer performs masking prodecure along time and frequency axis.
@@ -17,13 +17,13 @@ class SpecAug(nn.Module):
   This is an essential component in speech recognition models that helps achieve
   better word error rates.
   """
-  freq_mask_count: int = 1
-  freq_mask_max_bins: int = 15
-  time_mask_count: int = 1
-  time_mask_max_frames: int = 50
-  time_mask_max_ratio: float = 1.0
+  freq_mask_count: int = 2
+  freq_mask_max_bins: int = 27
+  time_mask_count: int = 10
+  time_mask_max_frames: int = 40
+  time_mask_max_ratio: float = 0.05
   time_masks_per_frame: float = 0.0
-  use_dynamic_time_mask_max_frames: bool = False
+  use_dynamic_time_mask_max_frames: bool = True
 
   def next_prng_key(self, name='dropout'):
     return self.make_rng(name)
@@ -32,7 +32,6 @@ class SpecAug(nn.Module):
                 batch_size,
                 choose_range,
                 mask_size,
-                global_seed,
                 max_length=None,
                 masks_per_frame=0.0,
                 multiplicity=1,
@@ -43,7 +42,7 @@ class SpecAug(nn.Module):
     else:
       max_length = choose_range * max_ratio
     masked_portion = jax.random.uniform(
-        key=global_seed,
+        key=self.next_prng_key(),
         shape=(batch_size, multiplicity),
         minval=0.0,
         maxval=1.0)
@@ -58,7 +57,8 @@ class SpecAug(nn.Module):
 
     # Choose starting point.
     random_start = jax.random.uniform(
-        key=global_seed, shape=(batch_size, multiplicity), maxval=1.0)
+        key=self.next_prng_key(), shape=(batch_size, multiplicity), maxval=1.0)
+
     start_with_in_valid_range = random_start * (choose_range - length + 1)
     start = start_with_in_valid_range.astype(jnp.int32)
     end = start + length - 1
@@ -90,7 +90,7 @@ class SpecAug(nn.Module):
 
     return mask
 
-  def _time_mask(self, inputs, length, global_seed):
+  def _time_mask(self, inputs, length):
     # Get time masking parameters.
     time_mask_max_frames = self.time_mask_max_frames
     use_dynamic_time_mask_max_frames = self.use_dynamic_time_mask_max_frames
@@ -114,16 +114,27 @@ class SpecAug(nn.Module):
         batch_size,
         choose_range=length,
         mask_size=time_length,
-        global_seed=global_seed,
         max_length=time_mask_max_frames,
         masks_per_frame=self.time_masks_per_frame,
         multiplicity=multiplicity,
         max_ratio=max_ratio)
 
+    # print('block arrays shape = ', block_arrays.shape)
+    # print('block arrays = ', block_arrays)
+
+    # np_block_arrays = {'block_arrays' : np.array(block_arrays)}
+    # np.savez("jnp_block_arrays", **np_block_arrays)
+
+    # npz_file = np.load("jnp_block_arrays.npz")
+
+    # print(npz_file['block_arrays'])
+    # block_arrays = jnp.array(npz_file['block_arrays'])
+    # npz_file.close()
+
     outputs = jnp.einsum('bxy,bx->bxy', inputs, block_arrays)
     return outputs
 
-  def _frequency_mask(self, inputs, global_seed):
+  def _frequency_mask(self, inputs):
     # Mask parameters.
     freq_mask_max_bins = self.freq_mask_max_bins
     multiplicity = self.freq_mask_count
@@ -140,7 +151,6 @@ class SpecAug(nn.Module):
         batch_size,
         choose_range=choose_range,
         mask_size=num_freq,
-        global_seed=global_seed,
         max_length=freq_mask_max_bins,
         masks_per_frame=0.0,
         multiplicity=multiplicity,
@@ -153,9 +163,7 @@ class SpecAug(nn.Module):
   def __call__(self, inputs, paddings):
     lengths = jnp.einsum('bh->b', 1 - paddings).astype(jnp.int32)
 
-    prng_key = self.next_prng_key()
-    inputs = self._time_mask(inputs, lengths, global_seed=prng_key)
-    prng_key = self.next_prng_key()
-    inputs = self._frequency_mask(inputs, global_seed=prng_key)
+    inputs = self._time_mask(inputs, lengths)
+    inputs = self._frequency_mask(inputs)
 
     return inputs, paddings

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
@@ -8,6 +8,7 @@ github.com/tensorflow/lingvo/blob/master/lingvo/jax/layers/spectrum_augmenter.py
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
+
 import numpy as np
 
 class SpecAug(nn.Module):
@@ -118,18 +119,6 @@ class SpecAug(nn.Module):
         masks_per_frame=self.time_masks_per_frame,
         multiplicity=multiplicity,
         max_ratio=max_ratio)
-
-    # print('block arrays shape = ', block_arrays.shape)
-    # print('block arrays = ', block_arrays)
-
-    # np_block_arrays = {'block_arrays' : np.array(block_arrays)}
-    # np.savez("jnp_block_arrays", **np_block_arrays)
-
-    # npz_file = np.load("jnp_block_arrays.npz")
-
-    # print(npz_file['block_arrays'])
-    # block_arrays = jnp.array(npz_file['block_arrays'])
-    # npz_file.close()
 
     outputs = jnp.einsum('bxy,bx->bxy', inputs, block_arrays)
     return outputs

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
@@ -8,7 +8,6 @@ github.com/tensorflow/lingvo/blob/master/lingvo/jax/layers/spectrum_augmenter.py
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 
 class SpecAug(nn.Module):

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
@@ -8,8 +8,8 @@ github.com/tensorflow/lingvo/blob/master/lingvo/jax/layers/spectrum_augmenter.py
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
-
 import numpy as np
+
 
 class SpecAug(nn.Module):
   """Layer performs masking prodecure along time and frequency axis.


### PR DESCRIPTION
with this fix conformer jax run hits target in 88.8k steps compared to pytorch run that hits target in 87k steps 
without this fix conformer jax run takes 100k steps consistently to hit target 

run link with fix : https://tensorboard.dev/experiment/oxLx9xcRSB2t5L1Kt2CaKQ/

