### PR TITLE
Fix occasional hanging for PyTorch workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ python3 submission_runner.py \
     --framework=jax \
     --workload=mnist \
     --experiment_dir=/home/znado \
+    --experiment_name=baseline \
     --submission_path=reference_algorithms/development_algorithms/mnist/mnist_jax/submission.py \
     --tuning_search_space=reference_algorithms/development_algorithms/mnist/tuning_search_space.json
 ```
@@ -155,6 +156,7 @@ python3 submission_runner.py \
     --framework=pytorch \
     --workload=mnist \
     --experiment_dir=/home/znado \
+    --experiment_name=baseline \
     --submission_path=reference_algorithms/development_algorithms/mnist/mnist_pytorch/submission.py \
     --tuning_search_space=reference_algorithms/development_algorithms/mnist/tuning_search_space.json
 ```

--- a/algorithmic_efficiency/pytorch_utils.py
+++ b/algorithmic_efficiency/pytorch_utils.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 from typing import Tuple
 
@@ -46,4 +45,10 @@ def pytorch_init(use_pytorch_ddp: bool, rank: int, profiler: Profiler) -> None:
 
       logging.info = logging_pass
     # Initialize the process group.
-    dist.init_process_group('nccl', timeout=datetime.timedelta(seconds=3600))
+    dist.init_process_group('nccl')
+
+
+def sync_ddp_time(time: float, device: torch.device) -> float:
+  time_tensor = torch.tensor(time, dtype=torch.float64, device=device)
+  dist.all_reduce(time_tensor, op=dist.ReduceOp.MAX)
+  return time_tensor.item()

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -1,7 +1,8 @@
 """MNIST workload implemented in Jax."""
+
 import functools
 import itertools
-from typing import Any, Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from flax import jax_utils
 from flax import linen as nn
@@ -18,6 +19,46 @@ from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.mnist.workload import BaseMnistWorkload
 
 
+def normalize(image: spec.Tensor, mean: float, stddev: float) -> spec.Tensor:
+  return (tf.cast(image, tf.float32) - mean) / stddev
+
+
+def get_mnist_dataset(data_rng: jax.random.PRNGKey,
+                      num_train_examples: int,
+                      train_mean: float,
+                      train_stddev: float,
+                      split: str,
+                      data_dir: str,
+                      global_batch_size: int):
+  shuffle = split in ['train', 'eval_train']
+  if shuffle:
+    tfds_split = f'train[:{num_train_examples}]'
+  elif split == 'validation':
+    tfds_split = f'train[{num_train_examples}:]'
+  else:
+    tfds_split = 'test'
+  ds = tfds.load(
+      'mnist:3.0.1', split=tfds_split, shuffle_files=False, data_dir=data_dir)
+  ds = ds.map(
+      lambda x: {
+          'inputs': normalize(x['image'], train_mean, train_stddev),
+          'targets': x['label'],
+      })
+  ds = ds.cache()
+  is_train = split == 'train'
+  if shuffle:
+    ds = ds.shuffle(16 * global_batch_size, seed=data_rng[0])
+    if is_train:
+      ds = ds.repeat()
+  ds = ds.batch(global_batch_size, drop_remainder=is_train)
+  ds = map(
+      functools.partial(
+          data_utils.shard_and_maybe_pad_np,
+          global_batch_size=global_batch_size),
+      ds)
+  return iter(ds)
+
+
 class _Model(nn.Module):
 
   @nn.compact
@@ -26,7 +67,7 @@ class _Model(nn.Module):
     input_size = 28 * 28
     num_hidden = 128
     num_classes = 10
-    x = x.reshape((x.shape[0], input_size))  # Flatten.
+    x = x.reshape((x.shape[0], input_size))
     x = nn.Dense(features=num_hidden, use_bias=True)(x)
     x = nn.sigmoid(x)
     x = nn.Dense(features=num_classes, use_bias=True)(x)
@@ -34,55 +75,6 @@ class _Model(nn.Module):
 
 
 class MnistWorkload(BaseMnistWorkload):
-
-  def _normalize(self, image):
-    return (tf.cast(image, tf.float32) - self.train_mean) / self.train_stddev
-
-  def _build_dataset(self,
-                     data_rng: jax.random.PRNGKey,
-                     split: str,
-                     data_dir: str,
-                     global_batch_size: int):
-    shuffle = split in ['train', 'eval_train']
-    if shuffle:
-      tfds_split = f'train[:{self.num_train_examples}]'
-    elif split == 'validation':
-      tfds_split = f'train[{self.num_train_examples}:]'
-    else:
-      tfds_split = 'test'
-    ds = tfds.load(
-        'mnist:3.0.1', split=tfds_split, shuffle_files=False, data_dir=data_dir)
-    ds = ds.map(lambda x: {
-        'inputs': self._normalize(x['image']),
-        'targets': x['label'],
-    })
-    ds = ds.cache()
-    is_train = split == 'train'
-    if shuffle:
-      ds = ds.shuffle(16 * global_batch_size, seed=data_rng[0])
-      if is_train:
-        ds = ds.repeat()
-    ds = ds.batch(global_batch_size, drop_remainder=is_train)
-    ds = map(
-        functools.partial(
-            data_utils.shard_and_maybe_pad_np,
-            global_batch_size=global_batch_size),
-        ds)
-    return iter(ds)
-
-  def is_output_params(self, param_key: spec.ParameterKey) -> bool:
-    return param_key == 'Dense_1'
-
-  def _build_input_queue(self,
-                         data_rng,
-                         split: str,
-                         data_dir: str,
-                         global_batch_size: int) -> Dict[str, Any]:
-    ds = self._build_dataset(data_rng, split, data_dir, global_batch_size)
-    if split != 'train':
-      # Note that this stores the entire eval dataset in memory.
-      ds = itertools.cycle(ds)
-    return ds
 
   def init_model_fn(
       self,
@@ -99,6 +91,9 @@ class MnistWorkload(BaseMnistWorkload):
     self._param_shapes = param_utils.jax_param_shapes(initial_params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
     return jax_utils.replicate(initial_params), None
+
+  def is_output_params(self, param_key: spec.ParameterKey) -> bool:
+    return param_key == 'Dense_1'
 
   def model_fn(
       self,
@@ -120,19 +115,17 @@ class MnistWorkload(BaseMnistWorkload):
 
   # Does NOT apply regularization, which is left to the submitter to do in
   # `update_params`.
-  def loss_fn(
-      self,
-      label_batch: spec.Tensor,
-      logits_batch: spec.Tensor,
-      mask_batch: Optional[spec.Tensor] = None,
-      label_smoothing: float = 0.0
-  ) -> Tuple[spec.Tensor, spec.Tensor]:  # differentiable
+  def loss_fn(self,
+              label_batch: spec.Tensor,
+              logits_batch: spec.Tensor,
+              mask_batch: Optional[spec.Tensor] = None,
+              label_smoothing: float = 0.0) -> Tuple[spec.Tensor, spec.Tensor]:
     """Return (correct scalar average loss, 1-d array of per-example losses)."""
     one_hot_targets = jax.nn.one_hot(label_batch, 10)
     smoothed_targets = optax.smooth_labels(one_hot_targets, label_smoothing)
     per_example_losses = -jnp.sum(
         smoothed_targets * nn.log_softmax(logits_batch), axis=-1)
-    # mask_batch is assumed to be shape [batch].
+    # `mask_batch` is assumed to be shape [batch].
     if mask_batch is not None:
       per_example_losses *= mask_batch
       n_valid_examples = mask_batch.sum()

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -2,7 +2,6 @@
 
 from collections import OrderedDict
 import contextlib
-import itertools
 from typing import Dict, Iterator, Optional, Tuple
 
 import numpy as np

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -78,7 +78,7 @@ class MnistWorkload(BaseMnistWorkload):
                                          global_batch_size,
                                          num_batches,
                                          repeat_final_dataset)
-    return map(mnist_to_torch, itertools.cycle(np_iter))
+    return map(mnist_to_torch, np_iter)
 
   def init_model_fn(
       self,

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -1,21 +1,22 @@
 """MNIST workload parent class."""
 
+import functools
+import itertools
 import math
 import os
-from typing import Dict, Iterator, Optional, Tuple
-# from algorithmic_efficiency.workloads.mnist.mnist_jax.workload import get_mnist_dataset
+from typing import Dict, Iterator, Optional
+
 from absl import flags
 from flax import jax_utils
 import jax
-import torch
 import tensorflow as tf
 import tensorflow_datasets as tfds
+import torch
 import torch.distributed as dist
-import itertools
+
+from algorithmic_efficiency import data_utils
 from algorithmic_efficiency import spec
 import algorithmic_efficiency.random_utils as prng
-import functools
-from algorithmic_efficiency import data_utils
 
 FLAGS = flags.FLAGS
 USE_PYTORCH_DDP = 'LOCAL_RANK' in os.environ

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -47,7 +47,6 @@ def get_mnist_dataset(data_rng: jax.random.PRNGKey,
           'inputs': normalize(x['image'], train_mean, train_stddev),
           'targets': x['label'],
       })
-  ds = ds.cache()
   is_train = split == 'train'
   if shuffle:
     ds = ds.shuffle(16 * global_batch_size, seed=data_rng[0])
@@ -134,9 +133,7 @@ class BaseMnistWorkload(spec.Workload):
         data_dir=data_dir,
         global_batch_size=global_batch_size)
 
-    if split != 'train':
-      # Note that this stores the entire eval dataset in memory.
-      ds = itertools.cycle(ds)
+    ds = itertools.cycle(ds)
     return ds
 
   @property

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -1,24 +1,69 @@
 """MNIST workload parent class."""
+
 import math
 import os
-from typing import Dict
-
+from typing import Dict, Iterator, Optional, Tuple
+# from algorithmic_efficiency.workloads.mnist.mnist_jax.workload import get_mnist_dataset
 from absl import flags
 from flax import jax_utils
 import jax
 import torch
+import tensorflow as tf
+import tensorflow_datasets as tfds
 import torch.distributed as dist
-
+import itertools
 from algorithmic_efficiency import spec
 import algorithmic_efficiency.random_utils as prng
+import functools
+from algorithmic_efficiency import data_utils
 
 FLAGS = flags.FLAGS
 USE_PYTORCH_DDP = 'LOCAL_RANK' in os.environ
 
 
+def normalize(image, mean, stddev):
+  return (tf.cast(image, tf.float32) - mean) / stddev
+
+
+def get_mnist_dataset(data_rng: jax.random.PRNGKey,
+                      num_train_examples: int,
+                      train_mean,
+                      train_stddev,
+                      split: str,
+                      data_dir: str,
+                      global_batch_size: int):
+  shuffle = split in ['train', 'eval_train']
+  if shuffle:
+    tfds_split = f'train[:{num_train_examples}]'
+  elif split == 'validation':
+    tfds_split = f'train[{num_train_examples}:]'
+  else:
+    tfds_split = 'test'
+  ds = tfds.load(
+      'mnist:3.0.1', split=tfds_split, shuffle_files=False, data_dir=data_dir)
+  ds = ds.map(
+      lambda x: {
+          'inputs': normalize(x['image'], train_mean, train_stddev),
+          'targets': x['label'],
+      })
+  ds = ds.cache()
+  is_train = split == 'train'
+  if shuffle:
+    ds = ds.shuffle(16 * global_batch_size, seed=data_rng[0])
+    if is_train:
+      ds = ds.repeat()
+  ds = ds.batch(global_batch_size, drop_remainder=is_train)
+  ds = map(
+      functools.partial(
+          data_utils.shard_and_maybe_pad_np,
+          global_batch_size=global_batch_size),
+      ds)
+  return iter(ds)
+
+
 class BaseMnistWorkload(spec.Workload):
 
-  def has_reached_goal(self, eval_result: float) -> bool:
+  def has_reached_goal(self, eval_result: Dict[str, float]) -> bool:
     return eval_result['validation/accuracy'] > self.target_value
 
   @property
@@ -55,11 +100,11 @@ class BaseMnistWorkload(spec.Workload):
     return 10000
 
   @property
-  def train_mean(self):
+  def train_mean(self) -> float:
     return 0.1307
 
   @property
-  def train_stddev(self):
+  def train_stddev(self) -> float:
     return 0.3081
 
   @property
@@ -70,12 +115,43 @@ class BaseMnistWorkload(spec.Workload):
   def eval_period_time_sec(self) -> int:
     return 10
 
+  def _build_input_queue(
+      self,
+      data_rng: spec.RandomState,
+      split: str,
+      data_dir: str,
+      global_batch_size: int,
+      cache: Optional[bool] = None,
+      repeat_final_dataset: Optional[bool] = None,
+      num_batches: Optional[int] = None) -> Iterator[Dict[str, spec.Tensor]]:
+    ds = get_mnist_dataset(
+        data_rng=data_rng,
+        num_train_examples=self.num_train_examples,
+        train_mean=self.train_mean,
+        train_stddev=self.train_stddev,
+        split=split,
+        data_dir=data_dir,
+        global_batch_size=global_batch_size)
+
+    if split != 'train':
+      # Note that this stores the entire eval dataset in memory.
+      ds = itertools.cycle(ds)
+    return ds
+
   @property
   def step_hint(self) -> int:
     # Note that the target setting algorithms were not actually run on this
     # workload, but for completeness we provide the number of steps for 10
     # epochs at batch size 64.
     return 7813
+
+  def _eval_model(
+      self,
+      params: spec.ParameterContainer,
+      batch: Dict[str, spec.Tensor],
+      model_state: spec.ModelAuxiliaryState,
+      rng: spec.RandomState) -> Dict[spec.Tensor, spec.ModelAuxiliaryState]:
+    raise NotImplementedError
 
   def _eval_model_on_split(self,
                            split: str,
@@ -111,6 +187,7 @@ class BaseMnistWorkload(spec.Workload):
       }
     if FLAGS.framework == 'jax':
       total_metrics = jax_utils.unreplicate(total_metrics)
+      return {k: float(v / num_examples) for k, v in total_metrics.items()}
     elif USE_PYTORCH_DDP:
       for metric in total_metrics.values():
         dist.all_reduce(metric)

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -398,12 +398,12 @@ def train_once(workload: spec.Workload,
               torch.cuda.empty_cache()
 
   metrics = {'eval_results': eval_results, 'global_step': global_step}
-  if USE_PYTORCH_DDP:
-    # Sync final score (accumulated training time); choose highest, i.e. worst.
-    score_tensor = torch.tensor(
-        train_state['accumulated_submission_time'], device=DEVICE)
-    dist.all_reduce(score_tensor, op=dist.ReduceOp.MAX)
-    train_state['accumulated_submission_time'] = score_tensor.item()
+  # if USE_PYTORCH_DDP:
+  #   # Sync final score (accumulated training time); choose highest, i.e. worst.
+  #   score_tensor = torch.tensor(
+  #       train_state['accumulated_submission_time'], device=DEVICE)
+  #   dist.all_reduce(score_tensor, op=dist.ReduceOp.MAX)
+  #   train_state['accumulated_submission_time'] = score_tensor.item()
 
   if log_dir is not None:
     metrics_logger.append_scalar_metrics(

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -297,7 +297,7 @@ def train_once(workload: spec.Workload,
     data_select_rng, update_rng, eval_rng = prng.split(step_rng, 3)
     start_time = time.time()
     if USE_PYTORCH_DDP:
-      start_time_tensor = torch.tensor(start_time, device=DEVICE)
+      start_time_tensor = torch.tensor(start_time, dtype=torch.float64, device=DEVICE)
       dist.all_reduce(start_time_tensor, op=dist.ReduceOp.MAX)
       start_time = start_time_tensor.item()
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -10,7 +10,8 @@ python3 submission_runner.py \
     --tuning_ruleset=external \
     --tuning_search_space=reference_algorithms/development_algorithms/mnist/tuning_search_space.json \
     --num_tuning_trials=3 \
-    --experiment_dir=/home/znado/experiment_dir
+    --experiment_dir=/home/znado/experiment_dir \
+    --experiment_name=baseline
 """
 import datetime
 import importlib
@@ -285,7 +286,8 @@ def train_once(workload: spec.Workload,
   global_start_time = time.time()
   if USE_PYTORCH_DDP:
     # Make sure all processes start training at the same time.
-    global_start_time_tensor = torch.tensor(global_start_time, dtype=torch.float64, device=DEVICE)
+    global_start_time_tensor = torch.tensor(
+        global_start_time, dtype=torch.float64, device=DEVICE)
     dist.all_reduce(global_start_time_tensor, op=dist.ReduceOp.MAX)
     global_start_time = global_start_time_tensor.item()
 
@@ -297,7 +299,8 @@ def train_once(workload: spec.Workload,
     data_select_rng, update_rng, eval_rng = prng.split(step_rng, 3)
     start_time = time.time()
     if USE_PYTORCH_DDP:
-      start_time_tensor = torch.tensor(start_time, dtype=torch.float64, device=DEVICE)
+      start_time_tensor = torch.tensor(
+          start_time, dtype=torch.float64, device=DEVICE)
       dist.all_reduce(start_time_tensor, op=dist.ReduceOp.MAX)
       start_time = start_time_tensor.item()
 
@@ -332,7 +335,8 @@ def train_once(workload: spec.Workload,
 
     current_time = time.time()
     if USE_PYTORCH_DDP:
-      current_time_tensor = torch.tensor(current_time, dtype=torch.float64, device=DEVICE)
+      current_time_tensor = torch.tensor(
+          current_time, dtype=torch.float64, device=DEVICE)
       dist.all_reduce(current_time_tensor, op=dist.ReduceOp.MAX)
       current_time = current_time_tensor.item()
 
@@ -381,7 +385,10 @@ def train_once(workload: spec.Workload,
           train_state['last_eval_time'] = time.time()
           if USE_PYTORCH_DDP:
             # Make sure all processes finish evaluation at the same time.
-            last_eval_time_tensor = torch.tensor(train_state['last_eval_time'], dtype=torch.float64, device=DEVICE)
+            last_eval_time_tensor = torch.tensor(
+                train_state['last_eval_time'],
+                dtype=torch.float64,
+                device=DEVICE)
             dist.all_reduce(last_eval_time_tensor, op=dist.ReduceOp.MAX)
             train_state['last_eval_time'] = last_eval_time_tensor.item()
 


### PR DESCRIPTION
Previously, PyTorch workloads had occasional hanging issues as `time.time()` was not synchronized across multiple devices; the hanging happened as there is an if-statement w.r.t. the evaluation time elapse.  This PR fixes this behaviour in `submission_runner.py` by synchronizing the time. E.g.,

```
start_time = time.time()
if USE_PYTORCH_DDP:
  start_time_tensor = torch.tensor(
      start_time, dtype=torch.float64, device=DEVICE)
  dist.all_reduce(start_time_tensor, op=dist.ReduceOp.MAX)
  start_time = start_time_tensor.item()
```

Furthermore, I did minor cleaning for MNIST workloads and unified the data loading pipeline.