### PR TITLE
Implement discrete (pre-selected) hyperparameters

### DIFF
--- a/algorithmic_efficiency/halton.py
+++ b/algorithmic_efficiency/halton.py
@@ -322,11 +322,11 @@ def zipit(generator_fns_or_sweeps: Sequence[Union[_GeneratorFn,
   return hyperparameter_sweep
 
 
-DICT_SEARCH_SPACE = Dict[str, Dict[str, Union[str, float, Sequence]]]
-LIST_SEARCH_SPACE = List[Dict[str, Union[str, float, Sequence]]]
+_DictSearchSpace = Dict[str, Dict[str, Union[str, float, Sequence]]]
+_ListSearchSpace = List[Dict[str, Union[str, float, Sequence]]]
 
 
-def generate_search(search_space: Union[DICT_SEARCH_SPACE, LIST_SEARCH_SPACE],
+def generate_search(search_space: Union[_DictSearchSpace, _ListSearchSpace],
                     num_trials: int) -> List[collections.namedtuple]:
   """Generate a random search with the given bounds and scaling.
 
@@ -380,10 +380,9 @@ def generate_search(search_space: Union[DICT_SEARCH_SPACE, LIST_SEARCH_SPACE],
     hyperparameters = []
     updated_num_trials = min(num_trials, len(search_space))
     if num_trials != len(search_space):
-      logging.info(
-          f'--num_tuning_trials was set to {num_trials}, but {len(search_space)} trial(s) '
-          f'found in the JSON file. Updating --num_tuning_trials to {updated_num_trials}.'
-      )
+      logging.info(f'--num_tuning_trials was set to {num_trials}, but '
+                   f'{len(search_space)} trial(s) found in the JSON file. '
+                   f'Updating --num_tuning_trials to {updated_num_trials}.')
     for trial in search_space:
       hyperparameters.append(named_tuple_class(**trial))
     return hyperparameters[:updated_num_trials]

--- a/algorithmic_efficiency/halton.py
+++ b/algorithmic_efficiency/halton.py
@@ -12,6 +12,7 @@ import itertools
 import math
 from typing import Any, Callable, Dict, List, Sequence, Text, Tuple, Union
 
+from absl import logging
 from numpy import random
 
 _SweepSequence = List[Dict[Text, Any]]
@@ -198,7 +199,7 @@ def _generate_double_point(name: Text,
                            min_val: float,
                            max_val: float,
                            scaling: Text,
-                           halton_point: float) -> float:
+                           halton_point: float) -> Tuple[str, float]:
   """Generate a float hyperparameter value from a Halton sequence point."""
   if scaling not in ['linear', 'log']:
     raise ValueError(
@@ -349,7 +350,7 @@ def generate_search(search_space: Union[DICT_SEARCH_SPACE, LIST_SEARCH_SPACE],
     assert len(search_space) > 0
     all_hyperparameter_names = list(search_space[0].keys())
   else:
-    raise AttributeError("tuning_search_space should either be a dict or list.")
+    raise AttributeError('tuning_search_space should either be a dict or list.')
 
   named_tuple_class = collections.namedtuple('Hyperparameters',
                                              all_hyperparameter_names)
@@ -378,6 +379,11 @@ def generate_search(search_space: Union[DICT_SEARCH_SPACE, LIST_SEARCH_SPACE],
   else:
     hyperparameters = []
     updated_num_trials = min(num_trials, len(search_space))
+    if num_trials != len(search_space):
+      logging.info(
+          f'--num_tuning_trials was set to {num_trials}, but {len(search_space)} trial(s) '
+          f'found in the JSON file. Updating --num_tuning_trials to {updated_num_trials}.'
+      )
     for trial in search_space:
       hyperparameters.append(named_tuple_class(**trial))
     return hyperparameters[:updated_num_trials]

--- a/reference_algorithms/development_algorithms/mnist/discrete_space.json
+++ b/reference_algorithms/development_algorithms/mnist/discrete_space.json
@@ -1,0 +1,17 @@
+[
+    {
+      "learning_rate": 1e-3,
+      "one_minus_beta_1": 0.999,
+      "epsilon": 0.9
+    },
+    {
+      "learning_rate": 1e-2,
+      "one_minus_beta_1": 0.99,
+      "epsilon": 0.99
+    },
+      {
+      "learning_rate": 1e-1,
+      "one_minus_beta_1": 0.9,
+      "epsilon": 0.999
+    }
+]

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -106,7 +106,7 @@ flags.DEFINE_string(
     None,
     'The path to the JSON file describing the external tuning search space.')
 flags.DEFINE_integer('num_tuning_trials',
-                     1,
+                     3,
                      'The number of external hyperparameter trials to run.')
 flags.DEFINE_string('data_dir', '~/tensorflow_datasets/', 'Dataset location.')
 flags.DEFINE_string('imagenet_v2_data_dir',

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -106,7 +106,7 @@ flags.DEFINE_string(
     None,
     'The path to the JSON file describing the external tuning search space.')
 flags.DEFINE_integer('num_tuning_trials',
-                     3,
+                     1,
                      'The number of external hyperparameter trials to run.')
 flags.DEFINE_string('data_dir', '~/tensorflow_datasets/', 'Dataset location.')
 flags.DEFINE_string('imagenet_v2_data_dir',


### PR DESCRIPTION
This PR implements another way of configuring the hyperparameters. The `tuning_search_space` can receive a JSON file consisting of a list of hyperparameters (instead of a dict of hyperparameters) so that the users can directly specify the hyperparameters they would like to use.

I added one example here: [reference_algorithms/development_algorithms/mnist/discrete_space.json](https://github.com/mlcommons/algorithmic-efficiency/compare/main...pomonam:discrete?expand=1#diff-a85a4f230fb03b7ab63e8fc3cfd0c8eb9c3110c0bf0f584a683cbf376021a428).