### PR TITLE
Small fix for WMT data download when using torch DDP

### DIFF
--- a/algorithmic_efficiency/workloads/wmt/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/wmt/input_pipeline.py
@@ -271,13 +271,6 @@ def get_wmt_dataset(data_rng,
     ds_name = 'wmt17_translate/de-en:1.0.0'
   dataset_builder = tfds.builder(ds_name, data_dir=data_dir)
 
-  if (USE_PYTORCH_DDP and (RANK == 0))or not USE_PYTORCH_DDP:
-      dataset_builder.download_and_prepare()
-
-  # Block other processes until data is downloaded and prepared
-  if USE_PYTORCH_DDP:
-    dist.barrier()
-
   ds = dataset_builder.as_dataset(
       split=TFDS_SPLIT_NAME[split], shuffle_files=False)
 

--- a/algorithmic_efficiency/workloads/wmt/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/wmt/input_pipeline.py
@@ -11,7 +11,7 @@ from algorithmic_efficiency import data_utils
 from algorithmic_efficiency.pytorch_utils import pytorch_setup
 from algorithmic_efficiency.workloads.wmt import tokenizer
 
-USE_PYTORCH_DDP, RANK, _, _ = pytorch_setup()
+RANK = pytorch_setup()[1]
 # Avoid multithreading in all processes but the first (rank 0).
 AUTOTUNE = tf.data.AUTOTUNE if RANK == 0 else None
 Features = Dict[str, tf.Tensor]

--- a/algorithmic_efficiency/workloads/wmt/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/wmt/input_pipeline.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Optional, Union
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
-import torch.distributed as dist
 
 from algorithmic_efficiency import data_utils
 from algorithmic_efficiency.pytorch_utils import pytorch_setup


### PR DESCRIPTION
In the current state, multiple processes will try to download and extract the data and the submission_runner will crash with a file_exists error. 
See https://github.com/mlcommons/algorithmic-efficiency/issues/297