### PR TITLE
Conformer eval fix

### DIFF
--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -288,7 +288,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
     targets, target_paddings = batch['targets']
     return self.metrics_bundle.gather_from_model_output(
-        normalized_loss=normalized_loss,
+        loss_dict=loss,
         decoded=decoded,
         decoded_paddings=decoded_paddings,
         targets=targets,

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -284,7 +284,6 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
     decoded, decoded_paddings = self.greedy_decode(logits, logit_paddings)
     loss = self.loss_fn(batch['targets'], (logits, logit_paddings))
-    normalized_loss = loss['summed'] / loss['n_valid_examples']
 
     targets, target_paddings = batch['targets']
     return self.metrics_bundle.gather_from_model_output(

--- a/algorithmic_efficiency/workloads/librispeech_conformer/metrics.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/metrics.py
@@ -20,7 +20,8 @@ def average_ctc_loss():
 
     @classmethod
     def from_model_output(cls, loss_dict, **_):
-      return cls(total=loss_dict['summed'], weight=loss_dict['n_valid_examples'])
+      return cls(
+          total=loss_dict['summed'], weight=loss_dict['n_valid_examples'])
 
     def merge(self, other):
       return type(self)(

--- a/algorithmic_efficiency/workloads/librispeech_conformer/metrics.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/metrics.py
@@ -19,8 +19,8 @@ def average_ctc_loss():
     weight: np.float32
 
     @classmethod
-    def from_model_output(cls, normalized_loss, **_):
-      return cls(total=normalized_loss, weight=1.0)
+    def from_model_output(cls, loss_dict, **_):
+      return cls(total=loss_dict['summed'], weight=loss_dict['n_valid_examples'])
 
     def merge(self, other):
       return type(self)(


### PR DESCRIPTION
Addresses https://github.com/mlcommons/algorithmic-efficiency/issues/318 
I ran the tests to confirm that the diff between eval results of jax and pytorch is now resolved. 