### PR TITLE
Add baseline search spaces for LAMB, SAM, Adafactor, and Shampoo

### DIFF
--- a/baselines/adafactor/tuning_search_space.json
+++ b/baselines/adafactor/tuning_search_space.json
@@ -3,24 +3,21 @@
         "min": 1e-4, "max": 1e-2, "scaling": "log"
     },
     "one_minus_beta1": {
-        "min": 5e-2, "max": 0.43, "scaling": "log"
+        "min": 1e-2, "max": 0.45, "scaling": "log"
     },
     "beta2": {
-        "feasible_points": [0.999]
+        "feasible_points": [0.99]
     },
     "warmup_factor": {
         "feasible_points": [0.05]
     },
     "weight_decay": {
-        "min": 1e-2, "max": 0.2, "scaling": "log"
+        "min": 1e-3, "max": 1.0, "scaling": "log"
     },
     "label_smoothing": {
         "feasible_points": [0.1, 0.2]
     },
     "dropout_rate": {
         "feasible_points": [0.0, 0.1]
-    },
-    "rho": {
-        "feasible_points": [0.01, 0.02, 0.05]
     }
 }

--- a/baselines/adafactor/tuning_search_space_no_beta1.json
+++ b/baselines/adafactor/tuning_search_space_no_beta1.json
@@ -3,24 +3,21 @@
         "min": 1e-4, "max": 1e-2, "scaling": "log"
     },
     "one_minus_beta1": {
-        "min": 5e-2, "max": 0.43, "scaling": "log"
+        "feasible_points": [0.1]
     },
     "beta2": {
-        "feasible_points": [0.999]
+        "feasible_points": [0.99]
     },
     "warmup_factor": {
         "feasible_points": [0.05]
     },
     "weight_decay": {
-        "min": 1e-2, "max": 0.2, "scaling": "log"
+        "min": 1e-3, "max": 1.0, "scaling": "log"
     },
     "label_smoothing": {
         "feasible_points": [0.1, 0.2]
     },
     "dropout_rate": {
         "feasible_points": [0.0, 0.1]
-    },
-    "rho": {
-        "feasible_points": [0.01, 0.02, 0.05]
     }
 }

--- a/baselines/lamb/tuning_search_space.json
+++ b/baselines/lamb/tuning_search_space.json
@@ -1,37 +1,23 @@
 {
     "learning_rate": {
-        "feasible_points": [
-            0
-        ]
+        "min": 1e-4, "max": 1e-2, "scaling": "log"
     },
-    "beta1": {
-        "feasible_points": [
-            0
-        ]
+    "one_minus_beta1": {
+        "min": 5e-2, "max": 0.3, "scaling": "log"
     },
     "beta2": {
-        "feasible_points": [
-            0
-        ]
+        "feasible_points": [0.999]
     },
     "warmup_factor": {
-        "feasible_points": [
-            0
-        ]
+        "feasible_points": [0.05]
     },
     "weight_decay": {
-        "feasible_points": [
-            0
-        ]
+        "min": 1e-3, "max": 1.0, "scaling": "log"
     },
     "label_smoothing": {
-        "feasible_points": [
-            0
-        ]
+        "feasible_points": [0.1, 0.2]
     },
-    "grad_clip": {
-        "feasible_points": [
-            0
-        ]
+    "dropout_rate": {
+        "feasible_points": [0.0, 0.1]
     }
 }

--- a/baselines/lamb/tuning_search_space_no_beta1.json
+++ b/baselines/lamb/tuning_search_space_no_beta1.json
@@ -3,7 +3,7 @@
         "min": 1e-4, "max": 1e-2, "scaling": "log"
     },
     "one_minus_beta1": {
-        "min": 5e-2, "max": 0.43, "scaling": "log"
+        "feasible_points": [0.1]
     },
     "beta2": {
         "feasible_points": [0.999]
@@ -12,15 +12,12 @@
         "feasible_points": [0.05]
     },
     "weight_decay": {
-        "min": 1e-2, "max": 0.2, "scaling": "log"
+        "min": 1e-3, "max": 1.0, "scaling": "log"
     },
     "label_smoothing": {
         "feasible_points": [0.1, 0.2]
     },
     "dropout_rate": {
         "feasible_points": [0.0, 0.1]
-    },
-    "rho": {
-        "feasible_points": [0.01, 0.02, 0.05]
     }
 }

--- a/baselines/sam/tuning_search_space_no_beta1.json
+++ b/baselines/sam/tuning_search_space_no_beta1.json
@@ -3,7 +3,7 @@
         "min": 1e-4, "max": 1e-2, "scaling": "log"
     },
     "one_minus_beta1": {
-        "min": 5e-2, "max": 0.43, "scaling": "log"
+        "feasible_points": [0.1]
     },
     "beta2": {
         "feasible_points": [0.999]

--- a/baselines/shampoo/tuning_search_space.json
+++ b/baselines/shampoo/tuning_search_space.json
@@ -3,7 +3,7 @@
         "min": 1e-4, "max": 1e-2, "scaling": "log"
     },
     "one_minus_beta1": {
-        "min": 5e-2, "max": 0.43, "scaling": "log"
+        "min": 1e-2, "max": 0.15, "scaling": "log"
     },
     "beta2": {
         "feasible_points": [0.999]
@@ -12,15 +12,12 @@
         "feasible_points": [0.05]
     },
     "weight_decay": {
-        "min": 1e-2, "max": 0.2, "scaling": "log"
+        "min": 5e-3, "max": 1.0, "scaling": "log"
     },
     "label_smoothing": {
         "feasible_points": [0.1, 0.2]
     },
     "dropout_rate": {
         "feasible_points": [0.0, 0.1]
-    },
-    "rho": {
-        "feasible_points": [0.01, 0.02, 0.05]
     }
 }

--- a/baselines/shampoo/tuning_search_space_no_beta1.json
+++ b/baselines/shampoo/tuning_search_space_no_beta1.json
@@ -3,7 +3,7 @@
         "min": 1e-4, "max": 1e-2, "scaling": "log"
     },
     "one_minus_beta1": {
-        "min": 5e-2, "max": 0.43, "scaling": "log"
+        "feasible_points": [0.1]
     },
     "beta2": {
         "feasible_points": [0.999]
@@ -12,15 +12,12 @@
         "feasible_points": [0.05]
     },
     "weight_decay": {
-        "min": 1e-2, "max": 0.2, "scaling": "log"
+        "min": 5e-3, "max": 1.0, "scaling": "log"
     },
     "label_smoothing": {
         "feasible_points": [0.1, 0.2]
     },
     "dropout_rate": {
         "feasible_points": [0.0, 0.1]
-    },
-    "rho": {
-        "feasible_points": [0.01, 0.02, 0.05]
     }
 }


### PR DESCRIPTION
Adds baseline search spaces for LAMB, SAM, Adafactor, and Shampoo. Includes search spaces for tuning beta 1 and keeping beta 1 fixed.