### PR TITLE
Reintroduce broadcasting of `per_device_batch_size`

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
@@ -164,6 +164,10 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
         # Send batch to other devices when using DDP.
         if USE_PYTORCH_DDP:
           if not_train:
+            # During eval, the batch size of the remainder might be different.
+            per_device_batch_size = torch.tensor(
+                len(targets[0]), dtype=torch.int32, device=DEVICE)
+            dist.broadcast(per_device_batch_size, src=0)
             dist.broadcast(weights, src=0)
             weights = weights[0]
           dist.broadcast(inputs, src=0)
@@ -177,6 +181,11 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
             weights = weights.view(-1, *weights.shape[2:])
       else:
         if not_train:
+          # During eval, the batch size of the remainder might be different.
+          per_device_batch_size = torch.empty((1,),
+                                              dtype=torch.int32,
+                                              device=DEVICE)
+          dist.broadcast(per_device_batch_size, src=0)
           weights = torch.empty((N_GPUS, per_device_batch_size, 1),
                                 dtype=torch.float32,
                                 device=DEVICE)

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -248,10 +248,21 @@ class WmtWorkload(BaseWmtWorkload):
                   -1, value.shape[-1]))
         # Send batch to other devices when using DDP.
         if USE_PYTORCH_DDP:
+          # During eval, the batch size of the remainder might be different.
+          if split != 'train':
+            per_device_batch_size = torch.tensor(
+                len(batch['inputs']), dtype=torch.int32, device=DEVICE)
+            dist.broadcast(per_device_batch_size, src=0)
           # We don't need to broadcast the batch for the device with RANK == 0.
           dist.broadcast(torch.stack(tensor_list)[:, 1:].contiguous(), src=0)
       else:
         batch = {}
+        # During eval, the batch size of the remainder might be different.
+        if split != 'train':
+          per_device_batch_size = torch.empty((1,),
+                                              dtype=torch.int32,
+                                              device=DEVICE)
+          dist.broadcast(per_device_batch_size, src=0)
         # N_GPUS - 1 since we don't broadcast the batch for RANK == 0.
         tensor = torch.empty((n_inputs, N_GPUS - 1, per_device_batch_size, 256),
                              dtype=torch.int64,


### PR DESCRIPTION
Fixes #348. I removed the broadcasting of `per_device_batch_size` in #325, because I thought it will always be the same since we're using padding. However, in the case when the remainder size is < `eval_batch_size` AND divisible by the number of devices, it will be different. I even tested the change with WMT, but stopped after the eval on the first eval dataset, which was apparently too early (see #348).

_Update: I have verified that the issue is indeed fixed._