### PR TITLE
Fix fastMRI issues

### DIFF
--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -135,6 +135,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
     del model_state
     del global_step
     data_rng, model_rng = prng.split(rng, 2)
+    num_batches = int(math.ceil(num_examples / global_batch_size))
     if split not in self._eval_iters:
       # These iterators repeat indefinitely.
       self._eval_iters[split] = self._build_input_queue(
@@ -142,10 +143,10 @@ class FastMRIWorkload(BaseFastMRIWorkload):
           split,
           data_dir,
           global_batch_size=global_batch_size,
-          repeat_final_dataset=True)
+          repeat_final_dataset=True,
+          num_batches=num_batches)
 
     total_metrics = {'ssim': 0., 'loss': 0.}
-    num_batches = int(math.ceil(num_examples / global_batch_size))
     eval_rngs = prng.split(model_rng, jax.local_device_count())
     for _ in range(num_batches):
       batch = next(self._eval_iters[split])

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -84,7 +84,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         batch = {}
         if split != 'train':
           # During eval, the batch size of the remainder might be different.
-          per_device_batch_size = torch.empty((1,),
+          per_device_batch_size = torch.empty((),
                                               dtype=torch.int32,
                                               device=DEVICE)
           dist.broadcast(per_device_batch_size, src=0)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -229,6 +229,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
     del model_state
     del global_step
     data_rng, model_rng = prng.split(rng, 2)
+    num_batches = int(math.ceil(num_examples / global_batch_size))
     if split not in self._eval_iters:
       # These iterators repeat indefinitely.
       self._eval_iters[split] = self._build_input_queue(
@@ -236,13 +237,13 @@ class FastMRIWorkload(BaseFastMRIWorkload):
           split,
           data_dir,
           global_batch_size=global_batch_size,
-          repeat_final_dataset=True)
+          repeat_final_dataset=True,
+          num_batches=num_batches)
 
     total_metrics = {
         'ssim': torch.tensor(0., device=DEVICE),
         'loss': torch.tensor(0., device=DEVICE),
     }
-    num_batches = int(math.ceil(num_examples / global_batch_size))
     for _ in range(num_batches):
       batch = next(self._eval_iters[split])
       batch_metrics = self._eval_model(params, batch, model_rng)

--- a/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/fastmri/input_pipeline.py
@@ -194,7 +194,8 @@ def load_fastmri_split(global_batch_size,
       cycle_length=32,
       block_length=64,
       num_parallel_calls=16)
-  ds = ds.cache()
+  if is_train:
+    ds = ds.cache()
 
   def process_example(example_index, example):
     if shuffle:
@@ -218,9 +219,6 @@ def load_fastmri_split(global_batch_size,
 
   ds = ds.batch(global_batch_size, drop_remainder=is_train)
 
-  if not is_train:
-    ds = ds.cache()
-
   if is_train:
     ds = ds.prefetch(10)
     iterator = map(data_utils.shard_and_maybe_pad_np, ds)
@@ -228,6 +226,7 @@ def load_fastmri_split(global_batch_size,
   else:
     if num_batches:
       ds = ds.take(num_batches)
+    ds = ds.cache()
     if repeat_final_eval_dataset:
       ds = ds.repeat()
     ds = ds.prefetch(10)

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -583,7 +583,7 @@ def main(_):
                                        FLAGS.tuning_search_space,
                                        FLAGS.num_tuning_trials,
                                        logging_dir_path)
-  logging.info(f'Final {FLAGS.workload} score: {score}')
+  logging.info(f'Final {FLAGS.workload} score: {score}')
 
   if FLAGS.profile:
     logging.info(profiler.summary())


### PR DESCRIPTION
Fixes #344.

Changes:
- Using `num_batches` for the eval input pipeline fixed the issue. I don't think there was a reason why we didn't use it before?
- I ran into a very bizarre issue: for some reason I had to adjust the shape of the receiving `per_device_batch_size` tensor to ensure it will have shape 0 to make the broadcasting work. However, the identical code works for the other workloads like WMT. No idea what's going on here, but at least it works now.
- I changed some things in the input pipeline to avoid the classic "The calling iterator did not fully read the dataset being cached. (...)" warning. Hopefully, this doesn't have unwanted side-effects.