### PR TITLE
Fix for nadamw baseline algo

### DIFF
--- a/baselines/nadamw/jax/submission.py
+++ b/baselines/nadamw/jax/submission.py
@@ -236,7 +236,7 @@ def pmapped_train_step(workload,
   (summed_loss, n_valid_examples, grad) = lax.psum(
       (summed_loss, n_valid_examples, grad), axis_name='batch')
   loss = summed_loss / n_valid_examples
-  grad /= n_valid_examples
+  grad = jax.tree_map(lambda x: x / n_valid_examples, grad)
 
   grad_norm = jnp.sqrt(
       sum(jnp.sum(g**2) for g in jax.tree_util.tree_leaves(grad)))


### PR DESCRIPTION
Fix for this error:
```
Traceback (most recent call last):  File "submission_runner.py", line 622, in <module>
    app.run(main)
  File "/usr/local/lib/python3.8/dist-packages/absl/app.py", line 312, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.8/dist-packages/absl/app.py", line 258, in _run_main
    sys.exit(main(argv))
  File "submission_runner.py", line 595, in main
    score = score_submission_on_workload(workload,
  File "submission_runner.py", line 530, in score_submission_on_workload    timing, metrics = train_once(workload, global_batch_size,  File "submission_runner.py", line 336, in train_once
    optimizer_state, model_params, model_state = update_params(
  File "/algorithmic-efficiency/baselines/nadamw/jax/submission.py", line 281, in update_params                                                                                   
    outputs = pmapped_train_step(workload,
  File "/algorithmic-efficiency/baselines/nadamw/jax/submission.py", line 239, in pmapped_train_step                                                                              
    grad /= n_valid_examples
TypeError: unsupported operand type(s) for /=: 'FrozenDict' and 'DynamicJaxprTracer'
```