### PR TITLE
Fix chex dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,12 @@ wmt =
 jax_core_deps =
   flax==0.6.0
   optax==0.1.3
+  # Fix chex (optax dependency) version.
+  # Not fixing it can raise dependency issues with our 
+  # jax version.
+  # Todo(kasimbeg): verify if this is necessary after we 
+  # upgrade jax.
+  chex==0.1.6 
 
 # JAX CPU
 jax_cpu =


### PR DESCRIPTION
Optax does not fix the chex dependency, see [here](https://github.com/deepmind/optax/blob/master/requirements/requirements.txt#L2).  Currently it will install the newest version 0.1.7 which I believe is incompatible with our jax version, because I get the following error message:
```
"/algorithmic-efficiency/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py", line 16, in <module>
    import optax
  File "/usr/local/lib/python3.8/dist-packages/optax/__init__.py", line 17, in <module>
    from optax import experimental
  File "/usr/local/lib/python3.8/dist-packages/optax/experimental/__init__.py", line 20, in <module>
    from optax._src.experimental.complex_valued import split_real_and_imaginary
  File "/usr/local/lib/python3.8/dist-packages/optax/_src/experimental/complex_valued.py", line 32, in <module>
    import chex
  File "/usr/local/lib/python3.8/dist-packages/chex/__init__.py", line 17, in <module>
    from chex._src.asserts import assert_axis_dimension
  File "/usr/local/lib/python3.8/dist-packages/chex/_src/asserts.py", line 26, in <module>
    from chex._src import asserts_internal as _ai
  File "/usr/local/lib/python3.8/dist-packages/chex/_src/asserts_internal.py", line 34, in <module>
    from chex._src import pytypes
  File "/usr/local/lib/python3.8/dist-packages/chex/_src/pytypes.py", line 27, in <module>
    ArrayDevice = jax.Array
AttributeError: module 'jax' has no attribute 'Array'
```