### PR TITLE
Update startup.sh

### DIFF
--- a/docker/scripts/startup.sh
+++ b/docker/scripts/startup.sh
@@ -88,8 +88,8 @@ if [[ ! -z ${SUBMISSION_PATH+x} ]]
         ${SPECIAL_FLAGS} \
         2>&1 | tee ${LOG_FILE}
 
-    /google-cloud-sdk/bin/gsutil -m cp -r ${EXPERIMENT_DIR}/${EXPERIMENT_NAME}/${WORKLOAD}_${FRAMEWORK} ${EXPERIMENT_BUCKET}/${EXPERIMENT_NAME}
-    /google-cloud-sdk/bin/gsutil -m cp ${LOG_FILE} ${EXPERIMENT_BUCKET}/${EXPERIMENT_NAME}/${WORKLOAD}_${FRAMEWORK}
+    /google-cloud-sdk/bin/gsutil -m cp -r ${EXPERIMENT_DIR}/${EXPERIMENT_NAME}/${WORKLOAD}_${FRAMEWORK} ${EXPERIMENT_BUCKET}/${EXPERIMENT_NAME}/
+    /google-cloud-sdk/bin/gsutil -m cp ${LOG_FILE} ${EXPERIMENT_BUCKET}/${EXPERIMENT_NAME}/${WORKLOAD}_${FRAMEWORK}/
 
 fi
 


### PR DESCRIPTION
Weird GCP Bucket rules. Append / to folder names in cp operations so that files don't get unintentionally renamed to folder names and directory copies don't depend on whether the  destination folder exists or not.