### PR TITLE
Update timing in submission_runner.py

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install yapf
       run: |
         python -m pip install --upgrade pip
-        pip install yapf
+        pip install yapf==0.32
     - name: Run yapf
       run: |
         yapf . --diff --recursive

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -378,7 +378,7 @@ def train_once(
             eval_end_time = sync_ddp_time(eval_end_time, DEVICE)
           
           # Add times to eval results for logging
-          latest_eval_result['score'] = (train_state['acccumulated_submission_time'])
+          latest_eval_result['score'] = (train_state['accumulated_submission_time'])
           latest_eval_result['total_duration'] = eval_end_time - global_start_time
           latest_eval_result['accumulated_submission_time'] = train_state['accumulated_submission_time']
           

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -224,7 +224,8 @@ def train_once(
     profiler: Profiler,
     max_global_steps: int = None,
     log_dir: Optional[str] = None,
-    save_checkpoints: Optional[bool] = True) -> Tuple[spec.Timing, Dict[str, Any]]:
+    save_checkpoints: Optional[bool] = True
+) -> Tuple[spec.Timing, Dict[str, Any]]:
   data_rng, opt_init_rng, model_init_rng, rng = prng.split(rng, 4)
 
   # Workload setup.
@@ -259,6 +260,7 @@ def train_once(
       'test_goal_reached': False,
       'is_time_remaining': True,
       'last_eval_time': 0,
+      'training_complete': False,
       'accumulated_submission_time': 0,
       'training_complete': False,
       'accumulated_eval_time': 0,
@@ -312,6 +314,7 @@ def train_once(
   while train_state['is_time_remaining'] and \
       not goals_reached and \
       not train_state['training_complete']:
+    
     step_rng = prng.fold_in(rng, global_step)
     data_select_rng, update_rng, eval_rng = prng.split(step_rng, 3)
   
@@ -349,9 +352,10 @@ def train_once(
 
     train_step_end_time = time.time()
     if USE_PYTORCH_DDP:
-      train_step_end_time= sync_ddp_time(train_step_end_time, DEVICE)
+      train_step_end_time = sync_ddp_time(train_step_end_time, DEVICE)
 
-    train_state['accumulated_submission_time'] +=  train_step_end_time - train_step_start_time
+    train_state[
+        'accumulated_submission_time'] += train_step_end_time - train_step_start_time
     train_state['is_time_remaining'] = (
         train_state['accumulated_submission_time'] <
         workload.max_allowed_runtime_sec)
@@ -381,16 +385,22 @@ def train_once(
           eval_end_time = time.time()
           if USE_PYTORCH_DDP:
             eval_end_time = sync_ddp_time(eval_end_time, DEVICE)
-          
+
           # Accumulate eval time
-          train_state['accumulated_eval_time'] += eval_end_time - eval_start_time
-          
+          train_state[
+              'accumulated_eval_time'] += eval_end_time - eval_start_time
+
           # Add times to eval results for logging
-          latest_eval_result['score'] = (train_state['accumulated_submission_time'])
-          latest_eval_result['total_duration'] = eval_end_time - global_start_time
-          latest_eval_result['accumulated_submission_time'] = train_state['accumulated_submission_time']
-          latest_eval_result['accumulated_eval_time'] = train_state['accumulated_eval_time']
-          latest_eval_result['accumulated_logging_time'] = train_state['accumulated_logging_time']
+          latest_eval_result['score'] = (
+              train_state['accumulated_submission_time'])
+          latest_eval_result[
+              'total_duration'] = eval_end_time - global_start_time
+          latest_eval_result['accumulated_submission_time'] = train_state[
+              'accumulated_submission_time']
+          latest_eval_result['accumulated_eval_time'] = train_state[
+              'accumulated_eval_time']
+          latest_eval_result['accumulated_logging_time'] = train_state[
+              'accumulated_logging_time']
           time_since_start = latest_eval_result['total_duration']
           logging.info(f'Time since start: {time_since_start:.2f}s, '
                        f'\tStep: {global_step}, \t{latest_eval_result}')
@@ -422,7 +432,8 @@ def train_once(
             logging_end_time = sync_ddp_time(checkpoint_end_time, DEVICE)
 
           train_state['last_eval_time'] = logging_end_time
-          train_state['accumulated_logging_time'] += logging_end_time - logging_start_time
+          train_state[
+              'accumulated_logging_time'] += logging_end_time - logging_start_time
 
         except RuntimeError as e:
           logging.exception(f'Eval step {global_step} error.\n')
@@ -604,17 +615,18 @@ def main(_):
                                               experiment_name,
                                               FLAGS.resume_last_run)
 
-  score = score_submission_on_workload(workload=workload,
-                                       workload_name=FLAGS.workload,
-                                       submission_path=FLAGS.submission_path,
-                                       data_dir=FLAGS.data_dir,
-                                       tuning_ruleset=FLAGS.tuning_ruleset,
-                                       profiler=profiler,
-                                       max_global_steps=FLAGS.max_global_steps,
-                                       imagenet_v2_data_dir=FLAGS.imagenet_v2_data_dir,
-                                       tuning_search_space=FLAGS.tuning_search_space,
-                                       num_tuning_trials=FLAGS.num_tuning_trials,
-                                       log_dir=logging_dir_path)
+  score = score_submission_on_workload(
+      workload=workload,
+      workload_name=FLAGS.workload,
+      submission_path=FLAGS.submission_path,
+      data_dir=FLAGS.data_dir,
+      tuning_ruleset=FLAGS.tuning_ruleset,
+      profiler=profiler,
+      max_global_steps=FLAGS.max_global_steps,
+      imagenet_v2_data_dir=FLAGS.imagenet_v2_data_dir,
+      tuning_search_space=FLAGS.tuning_search_space,
+      num_tuning_trials=FLAGS.num_tuning_trials,
+      log_dir=logging_dir_path)
   logging.info(f'Final {FLAGS.workload} score: {score}')
 
   if FLAGS.profile:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -445,16 +445,17 @@ def score_submission_on_workload(workload: spec.Workload,
                                  workload_name: str,
                                  submission_path: str,
                                  data_dir: str,
-                                 imagenet_v2_data_dir: str,
-                                 profiler: Profiler,
                                  tuning_ruleset: str,
-                                 max_global_steps: int,
+                                 profiler: Optional[Profiler] = None,
+                                 max_global_steps: Optional[int] = None,
+                                 imagenet_v2_data_dir: Optional[str] = None,
                                  tuning_search_space: Optional[str] = None,
                                  num_tuning_trials: Optional[int] = None,
                                  log_dir: Optional[str] = None):
   # Expand paths because '~' may not be recognized
   data_dir = os.path.expanduser(data_dir)
-  imagenet_v2_data_dir = os.path.expanduser(imagenet_v2_data_dir)
+  if imagenet_v2_data_dir:
+    imagenet_v2_data_dir = os.path.expanduser(imagenet_v2_data_dir)
 
   # Remove the trailing '.py' and convert the filepath to a Python module.
   submission_module_path = convert_filepath_to_module(submission_path)
@@ -589,17 +590,17 @@ def main(_):
                                               experiment_name,
                                               FLAGS.resume_last_run)
 
-  score = score_submission_on_workload(workload,
-                                       FLAGS.workload,
-                                       FLAGS.submission_path,
-                                       FLAGS.data_dir,
-                                       FLAGS.imagenet_v2_data_dir,
-                                       profiler,
-                                       FLAGS.tuning_ruleset,
-                                       FLAGS.max_global_steps,
-                                       FLAGS.tuning_search_space,
-                                       FLAGS.num_tuning_trials,
-                                       logging_dir_path)
+  score = score_submission_on_workload(workload=workload,
+                                       workload_name=FLAGS.workload,
+                                       submission_path=FLAGS.submission_path,
+                                       data_dir=FLAGS.data_dir,
+                                       tuning_ruleset=FLAGS.tuning_ruleset,
+                                       profiler=profiler,
+                                       max_global_steps=FLAGS.max_global_steps,
+                                       imagenet_v2_data_dir=FLAGS.imagenet_v2_data_dir,
+                                       tuning_search_space=FLAGS.tuning_search_space,
+                                       num_tuning_trials=FLAGS.num_tuning_trials,
+                                       log_dir=logging_dir_path)
   logging.info(f'Final {FLAGS.workload} score: {score}')
 
   if FLAGS.profile:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -262,7 +262,6 @@ def train_once(
       'last_eval_time': 0,
       'training_complete': False,
       'accumulated_submission_time': 0,
-      'training_complete': False,
       'accumulated_eval_time': 0,
       'accumulated_logging_time': 0,
   }
@@ -367,7 +366,7 @@ def train_once(
         try:
           eval_start_time = time.time()
           if USE_PYTORCH_DDP:
-            eval_start_time = sync_ddp_time(eval_step_end_time, DEVICE)
+            eval_start_time = sync_ddp_time(eval_start_time, DEVICE)
           latest_eval_result = workload.eval_model(global_eval_batch_size,
                                                    model_params,
                                                    model_state,
@@ -430,7 +429,7 @@ def train_once(
                   .save_intermediate_checkpoints)
           logging_end_time = time.time()
           if USE_PYTORCH_DDP:
-            logging_end_time = sync_ddp_time(checkpoint_end_time, DEVICE)
+            logging_end_time = sync_ddp_time(logging_end_time, DEVICE)
 
           train_state['last_eval_time'] = logging_end_time
           train_state[

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -13,7 +13,6 @@ python3 submission_runner.py \
     --experiment_dir=/home/znado/experiment_dir \
     --experiment_name=baseline
 """
-import psutil
 import datetime
 import importlib
 import inspect
@@ -493,8 +492,7 @@ def score_submission_on_workload(workload: spec.Workload,
     all_metrics = []
     for hi, hyperparameters in enumerate(tuning_search_space):
       # Generate a new seed from hardware sources of randomness for each trial.
-      # rng_seed = struct.unpack('I', os.urandom(4))[0]
-      rng_seed = 1
+      rng_seed = struct.unpack('I', os.urandom(4))[0]
       logging.info('Using RNG seed %d', rng_seed)
       rng = prng.PRNGKey(rng_seed)
       # Because we initialize the PRNGKey with only a single 32 bit int, in the

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -354,7 +354,7 @@ def train_once(
         workload.max_allowed_runtime_sec)
     # Check if submission is eligible for an untimed eval.
     if ((train_step_end_time - train_state['last_eval_time']) >=
-        workload.eval_period_time_sec or train_state['training_complete']) or (global_step == 1):
+        workload.eval_period_time_sec or train_state['training_complete']):
       with profiler.profile('Evaluation'):
         try:
           latest_eval_result = workload.eval_model(global_eval_batch_size,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -314,11 +314,12 @@ def train_once(
   while train_state['is_time_remaining'] and \
       not goals_reached and \
       not train_state['training_complete']:
-    
+
+    train_step_start_time = time.time()
+
     step_rng = prng.fold_in(rng, global_step)
     data_select_rng, update_rng, eval_rng = prng.split(step_rng, 3)
-  
-    train_step_start_time = time.time()
+
     if USE_PYTORCH_DDP:
       train_step_start_time = sync_ddp_time(train_step_start_time, DEVICE)
     with profiler.profile('Data selection'):

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -354,8 +354,8 @@ def train_once(
     if USE_PYTORCH_DDP:
       train_step_end_time = sync_ddp_time(train_step_end_time, DEVICE)
 
-    train_state[
-        'accumulated_submission_time'] += train_step_end_time - train_step_start_time
+    train_state['accumulated_submission_time'] += (
+        train_step_end_time - train_step_start_time)
     train_state['is_time_remaining'] = (
         train_state['accumulated_submission_time'] <
         workload.max_allowed_runtime_sec)

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -13,6 +13,7 @@ python3 submission_runner.py \
     --experiment_dir=/home/znado/experiment_dir \
     --experiment_name=baseline
 """
+
 import datetime
 import importlib
 import inspect
@@ -224,8 +225,9 @@ def train_once(
     max_global_steps: int = None,
     log_dir: Optional[str] = None) -> Tuple[spec.Timing, Dict[str, Any]]:
   data_rng, opt_init_rng, model_init_rng, rng = prng.split(rng, 4)
+
   # Workload setup.
-  logging.info(f'Initializing dataset.')
+  logging.info('Initializing dataset.')
   with profiler.profile('Initializing dataset'):
     input_queue = workload._build_input_queue(
         data_rng,
@@ -290,21 +292,23 @@ def train_once(
     flag_file_name = os.path.join(log_dir, f'flags_{preemption_count}.json')
     logging.info(f'Saving flags to {flag_file_name}.')
     logger_utils.write_json(flag_file_name, flags.FLAGS.flag_values_dict())
-    metrics_logger = logger_utils.set_up_loggers(log_dir, flags.FLAGS)
+    metrics_logger = logger_utils.set_up_loggers(log_dir,
+                                                 flags.FLAGS,
+                                                 hyperparameters)
     workload.attach_metrics_logger(metrics_logger)
-  # Get global start time
+
   global_start_time = time.time()
   if USE_PYTORCH_DDP:
     # Make sure all processes start training at the same time.
     global_start_time = sync_ddp_time(global_start_time, DEVICE)
 
   logging.info('Starting training loop.')
+  goals_reached = (
+      train_state['validation_goal_reached'] and
+      train_state['test_goal_reached'])
   while train_state['is_time_remaining'] and \
-      not train_state['validation_goal_reached'] and \
-      not train_state['test_goal_reached'] and \
-      not train_state['training_complete']:      
-    if USE_PYTORCH_DDP:
-      start_time = sync_ddp_time(start_time, DEVICE)
+      not goals_reached and \
+      not train_state['training_complete']:
     step_rng = prng.fold_in(rng, global_step)
     data_select_rng, update_rng, eval_rng = prng.split(step_rng, 3)
   
@@ -320,7 +324,6 @@ def train_once(
                              hyperparameters,
                              global_step,
                              data_select_rng)
-    
     try:
       with profiler.profile('Update parameters'):
         optimizer_state, model_params, model_state = update_params(
@@ -349,7 +352,6 @@ def train_once(
     train_state['is_time_remaining'] = (
         train_state['accumulated_submission_time'] <
         workload.max_allowed_runtime_sec)
-
     # Check if submission is eligible for an untimed eval.
     if ((train_step_end_time - train_state['last_eval_time']) >=
         workload.eval_period_time_sec or train_state['training_complete']) or (global_step == 1):
@@ -375,7 +377,6 @@ def train_once(
             # Make sure all processes finish evaluation at the same time.
             train_state['last_eval_time'] = sync_ddp_time(
                 train_state['last_eval_time'], DEVICE)
-
           
           # Add times to eval results for logging
           latest_eval_result['score'] = (train_state['acccumulated_submission_time'])
@@ -387,23 +388,22 @@ def train_once(
                        f'\tStep: {global_step}, \t{latest_eval_result}')
           eval_results.append((global_step, latest_eval_result))
           if log_dir is not None:
-           metrics_logger.append_scalar_metrics(
-               latest_eval_result,
-               global_step=global_step,
-               preemption_count=preemption_count)
-          # Disable checkpointing
-          checkpoint_utils.save_checkpoint(
-              framework=FLAGS.framework,
-              optimizer_state=optimizer_state,
-              model_params=model_params,
-              model_state=model_state,
-              train_state=train_state,
-              eval_results=eval_results,
-              global_step=global_step,
-              preemption_count=preemption_count,
-              checkpoint_dir=log_dir,
-              save_intermediate_checkpoints=FLAGS
-              .save_intermediate_checkpoints)
+            metrics_logger.append_scalar_metrics(
+                latest_eval_result,
+                global_step=global_step,
+                preemption_count=preemption_count)
+            checkpoint_utils.save_checkpoint(
+                framework=FLAGS.framework,
+                optimizer_state=optimizer_state,
+                model_params=model_params,
+                model_state=model_state,
+                train_state=train_state,
+                eval_results=eval_results,
+                global_step=global_step,
+                preemption_count=preemption_count,
+                checkpoint_dir=log_dir,
+                save_intermediate_checkpoints=FLAGS
+                .save_intermediate_checkpoints)
 
         except RuntimeError as e:
           logging.exception(f'Eval step {global_step} error.\n')
@@ -412,7 +412,7 @@ def train_once(
                             f'{global_step}, error : {str(e)}.')
             if torch.cuda.is_available():
               torch.cuda.empty_cache()
-  
+
   metrics = {'eval_results': eval_results, 'global_step': global_step}
 
   if log_dir is not None:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -433,7 +433,8 @@ def train_once(
 
           train_state['last_eval_time'] = logging_end_time
           train_state[
-              'accumulated_logging_time'] += logging_end_time - logging_start_time
+              'accumulated_logging_time'] += (
+                logging_end_time - logging_start_time)
 
         except RuntimeError as e:
           logging.exception(f'Eval step {global_step} error.\n')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -432,9 +432,8 @@ def train_once(
             logging_end_time = sync_ddp_time(logging_end_time, DEVICE)
 
           train_state['last_eval_time'] = logging_end_time
-          train_state[
-              'accumulated_logging_time'] += (
-                logging_end_time - logging_start_time)
+          train_state['accumulated_logging_time'] += (
+              logging_end_time - logging_start_time)
 
         except RuntimeError as e:
           logging.exception(f'Eval step {global_step} error.\n')

--- a/tests/submission_runner_test.py
+++ b/tests/submission_runner_test.py
@@ -13,8 +13,8 @@ from absl import logging
 from absl.testing import absltest
 from absl.testing import parameterized
 
-import submission_runner
 from algorithmic_efficiency.profiler import PassThroughProfiler
+import submission_runner
 
 FLAGS = flags.FLAGS
 # Needed to avoid UnparsedFlagAccessError

--- a/tests/submission_runner_test.py
+++ b/tests/submission_runner_test.py
@@ -16,7 +16,6 @@ from absl.testing import parameterized
 import submission_runner
 from algorithmic_efficiency.profiler import PassThroughProfiler
 
-
 FLAGS = flags.FLAGS
 # Needed to avoid UnparsedFlagAccessError
 # (see https://github.com/google/model_search/pull/8).
@@ -69,7 +68,8 @@ class SubmissionRunnerTest(parameterized.TestCase):
         tuning_search_space=tuning_search_space,
         num_tuning_trials=1,
         profiler=PassThroughProfiler(),
-        max_global_steps=500,)
+        max_global_steps=500,
+    )
     logging.info(score)
 
   def test_convert_filepath_to_module(self):

--- a/tests/submission_runner_test.py
+++ b/tests/submission_runner_test.py
@@ -14,6 +14,8 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import submission_runner
+from algorithmic_efficiency.profiler import PassThroughProfiler
+
 
 FLAGS = flags.FLAGS
 # Needed to avoid UnparsedFlagAccessError
@@ -56,8 +58,8 @@ class SubmissionRunnerTest(parameterized.TestCase):
         'workload.py')
     workload_obj = submission_runner.import_workload(
         workload_path=workload_metadata['workload_path'],
-        workload_class_name=workload_metadata['workload_class_name'])
-
+        workload_class_name=workload_metadata['workload_class_name'],
+        workload_init_kwargs={})
     score = submission_runner.score_submission_on_workload(
         workload_obj,
         workload,
@@ -65,7 +67,9 @@ class SubmissionRunnerTest(parameterized.TestCase):
         data_dir='~/tensorflow_datasets',  # The default in TFDS.
         tuning_ruleset='external',
         tuning_search_space=tuning_search_space,
-        num_tuning_trials=1)
+        num_tuning_trials=1,
+        profiler=PassThroughProfiler(),
+        max_global_steps=500,)
     logging.info(score)
 
   def test_convert_filepath_to_module(self):


### PR DESCRIPTION
Changes to submission_runner.py related to timing:
- Make train_state['total_duration'] include the eval_model time at the time that the total duration is logged (which is after the eval_model). Without this change the total_duration will include the time of all previous evals but exclude the eval time of the current step. 
- Add bookkeeping for accumulated eval time and accumulated logging time (which includes metrics logger and checkpointing).
- Move train_step_start time before prng split and fold_in. They take about 2ms per step and this adds up over thousands of steps so we want to include it in some measured accumulated time for sanity checks. The alternative is to make a separate key for accumulated_prng_processing time. But that's getting a bit superfluous for bookkeeping.
- Refactor timestamp names for clarity

Also fix sumbission_runner_test.py:
- Refactor score_submission_on_workload function signature such that imagenet_v2_data_dir and max_global_steps are optional.
- Add dummy profiler to test
- Add init_kwargs to workload importer (the test breaks without this).

