### PR TITLE
Criteo input pipeline changes & tcmalloc

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
@@ -22,7 +22,7 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
 
   @property
   def eval_batch_size(self) -> int:
-    return 65536
+    return 524_288
 
   def _per_example_sigmoid_binary_cross_entropy(
       self, logits: spec.Tensor, targets: spec.Tensor) -> spec.Tensor:

--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -116,15 +116,6 @@ def get_criteo1tb_dataset(split: str,
     ds = ds.shuffle(buffer_size=1024)
   ds = ds.flat_map(tf.data.TextLineDataset)
 
-  # ds = ds.interleave(
-  #     tf.data.TextLineDataset,
-  #     cycle_length=128,
-  #     block_length=global_batch_size // 8,
-  #     num_parallel_calls=128,
-  #     deterministic=False)
-  # if shuffle:
-  #   ds = ds.shuffle(buffer_size=524_288 * 100, seed=shuffle_rng[1])
-
   ds = ds.batch(global_batch_size, drop_remainder=is_training)
   parse_fn = functools.partial(_parse_example_fn, num_dense_features)
   ds = ds.map(parse_fn, num_parallel_calls=16)

--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -112,14 +112,19 @@ def get_criteo1tb_dataset(split: str,
   ds = tf.data.Dataset.list_files(
       file_paths, shuffle=shuffle, seed=shuffle_rng[0])
 
-  ds = ds.interleave(
-      tf.data.TextLineDataset,
-      cycle_length=128,
-      block_length=global_batch_size // 8,
-      num_parallel_calls=128,
-      deterministic=False)
   if shuffle:
-    ds = ds.shuffle(buffer_size=524_288 * 100, seed=shuffle_rng[1])
+    ds = ds.shuffle(buffer_size=1024)
+  ds = ds.flat_map(tf.data.TextLineDataset)
+
+  # ds = ds.interleave(
+  #     tf.data.TextLineDataset,
+  #     cycle_length=128,
+  #     block_length=global_batch_size // 8,
+  #     num_parallel_calls=128,
+  #     deterministic=False)
+  # if shuffle:
+  #   ds = ds.shuffle(buffer_size=524_288 * 100, seed=shuffle_rng[1])
+
   ds = ds.batch(global_batch_size, drop_remainder=is_training)
   parse_fn = functools.partial(_parse_example_fn, num_dense_features)
   ds = ds.map(parse_fn, num_parallel_calls=16)

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -78,7 +78,7 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
 
   @property
   def eval_period_time_sec(self) -> int:
-    return 9 * 60
+    return 2 * 60
 
   def _build_input_queue(self,
                          data_rng: jax.random.PRNGKey,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,8 @@ RUN echo "Setting up machine"
 RUN apt-get update
 RUN apt-get install -y curl tar
 RUN apt-get install -y git python3 pip wget
+RUN apt-get install libtcmalloc-minimal4
+RUN export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
 
 # Install GCP tools
 RUN echo "Setting up gsutil"

--- a/docker/scripts/cloud-startup.sh
+++ b/docker/scripts/cloud-startup.sh
@@ -30,6 +30,10 @@ echo "Configuring Docker daemon to recognize and install NVIDIA Container Runtim
 sudo nvidia-ctk runtime configure --runtime=docker
 sudo systemctl restart docker
 
+# Override libcmalloc
+sudo apt-get install libtcmalloc-minimal4
+sudo export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
+
 # Run gcloud credential helper for Google Container Repository
 echo "Running gcloud credential helper"
 yes | gcloud auth configure-docker us-central1-docker.pkg.dev


### PR DESCRIPTION
Changes to criteo pipeline:
- remove interleave between sharded files
- shuffle over files instead

Reduce eval time interval from 9 to 2 min so that we get approx 50 evals. W new pipeline and old eval time interval we got 11 evals. Expected now to get 9/2 * 11 ~ 50.

Add tcmalloc to docker and vm environments. 

