### PR TITLE
deepspeech pytorch should use 6 lstm layers

### DIFF
--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/models.py
@@ -24,7 +24,7 @@ class DeepspeechConfig:
   """Global hyperparameters used to minimize obnoxious kwarg plumbing."""
   vocab_size: int = 1024
   encoder_dim: int = 512
-  num_lstm_layers: int = 4
+  num_lstm_layers: int = 6
   num_ffn_layers: int = 3
   conv_subsampling_factor: int = 2
   conv_subsampling_layers: int = 2


### PR DESCRIPTION
We recently updated deepspeech jax to use 6 layers which is in line with what is used in paper and internal runs. This PR makes correction in torch version so everything now uses 6 lstm layers