### PR TITLE
Criteo and Deepspeech Comparators

### DIFF
--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/models.py
@@ -24,7 +24,7 @@ class DeepspeechConfig:
   """Global hyperparameters used to minimize obnoxious kwarg plumbing."""
   vocab_size: int = 1024
   encoder_dim: int = 512
-  num_lstm_layers: int = 4
+  num_lstm_layers: int = 6
   num_ffn_layers: int = 3
   conv_subsampling_factor: int = 2
   conv_subsampling_layers: int = 2

--- a/tests/modeldiffs/criteo1tb/compare.py
+++ b/tests/modeldiffs/criteo1tb/compare.py
@@ -1,0 +1,74 @@
+import os
+
+# Disable GPU access for both jax and pytorch.
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
+
+import jax
+import numpy as np
+import torch
+
+from algorithmic_efficiency import spec
+from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_jax.workload import \
+    Criteo1TbDlrmSmallWorkload as JaxWorkload
+from algorithmic_efficiency.workloads.criteo1tb.criteo1tb_pytorch.workload import \
+    Criteo1TbDlrmSmallWorkload as PytWorkload
+from tests.modeldiffs.diff import out_diff
+
+
+def key_transform(k):
+  new_key = []
+  s_count = None
+  for i in k:
+    if 'Sequential' in i:
+      s_count = int(i.split('_')[1])
+      continue
+    if 'Embedding' in i:
+      return ('embedding_table',)
+    if 'Linear' in i:
+      i = i.replace('Linear', 'Dense')
+      name, count = i.split('_')
+      i = name + '_' + str(s_count * 3 + int(count))
+    elif 'weight' in i:
+      i = i.replace('weight', 'kernel')
+
+    new_key.append(i)
+  return tuple(new_key)
+
+
+sd_transform = None
+
+if __name__ == '__main__':
+  # pylint: disable=locally-disabled, not-callable
+
+  jax_workload = JaxWorkload()
+  pytorch_workload = PytWorkload()
+
+  pyt_batch = {
+      'inputs': torch.ones((2, 13 + 26)),
+      'targets': torch.randint(low=0, high=1, size=(2,)),
+      'weights': torch.ones(2),
+  }
+  jax_batch = {k: np.array(v) for k, v in pyt_batch.items()}
+
+  # Test outputs for identical weights and inputs.
+  pytorch_model_kwargs = dict(
+      augmented_and_preprocessed_input_batch=pyt_batch,
+      model_state=None,
+      mode=spec.ForwardPassMode.EVAL,
+      rng=None,
+      update_batch_norm=False)
+
+  jax_model_kwargs = dict(
+      augmented_and_preprocessed_input_batch=jax_batch,
+      mode=spec.ForwardPassMode.EVAL,
+      rng=jax.random.PRNGKey(0),
+      update_batch_norm=False)
+
+  out_diff(
+      jax_workload=jax_workload,
+      pytorch_workload=pytorch_workload,
+      jax_model_kwargs=jax_model_kwargs,
+      pytorch_model_kwargs=pytorch_model_kwargs,
+      key_transform=key_transform,
+      sd_transform=sd_transform,
+      out_transform=None)

--- a/tests/modeldiffs/librispeech_deepspeech/compare.py
+++ b/tests/modeldiffs/librispeech_deepspeech/compare.py
@@ -57,7 +57,7 @@ def sd_transform(sd):
         out[k] = sd[k]
     elif 'LSTM' in ''.join(k):
       l = out.get(k[:-1], dict())
-      l[k[-1]] = (sd[k])
+      l[k[-1]] = sd[k]
       out[k[:-1]] = l
     else:
       out[k] = sd[k]

--- a/tests/reference_algorithm_tests.py
+++ b/tests/reference_algorithm_tests.py
@@ -254,7 +254,17 @@ def _make_one_batch_workload(workload_class,
           fake_batch['inputs'] = fake_batch['inputs'].transpose(
               (*range(num_dims - 3), num_dims - 1, num_dims - 3, num_dims - 2))
       elif 'librispeech' in workload_name:
-        inputs = np.random.normal(size=(*batch_shape, 320000))
+        rate = 16000
+        l = None
+        while l is None or l.shape[-1] < 320000:
+          duration = 0.5
+          freq = 2**(np.random.rand(*batch_shape, 1) * 13)
+          wav = np.sin(2 * np.pi * freq * np.arange(rate * duration) / rate)
+          if l is None:
+            l = wav
+          else:
+            l = np.concatenate([l, wav], axis=-1)
+        inputs = l
         targets = np.random.randint(low=1, high=1024, size=(*batch_shape, 256))
         tgt_pad = np.arange(0, 256)[tuple([None] * len(batch_shape))]
         tgt_lengths = np.random.randint(

--- a/tests/test_traindiffs.py
+++ b/tests/test_traindiffs.py
@@ -24,6 +24,7 @@ WORKLOADS = [
     'librispeech_deepspeech',
     'fastmri',
     'ogbg',
+    'criteo1tb'
 ]
 GLOBAL_BATCH_SIZE = 16
 


### PR DESCRIPTION
This PR includes:
* An update to deepspeech comparator so that it can use the jax cudnn lstm. 
* I also updated the generation of fake test-data for deepspeech and this reduces the variance of test-results between runs and makes it closer to the test results obtained with real data samples. 
* Criteo comparator: using fake data, the test could not catch any diff. The plan is to use this comparator for running tests with a real data dump (and, possibly the appropriate optimizer for this workload instead of the default sgd). 