### PR TITLE
Version updates & PyTorch upgrade

### DIFF
--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -292,7 +292,7 @@ class MetricLogger(object):
     try:
       with open(self._csv_path, 'r') as csv_file:
         measurements = pd.read_csv(csv_file)
-        measurements = measurements.append([metrics])
+        measurements = pd.concat([measurements, pd.DataFrame([metrics])])
     except (pd.errors.EmptyDataError, FileNotFoundError) as e:
       measurements = pd.DataFrame([metrics], columns=sorted(metrics.keys()))
       if isinstance(e, pd.errors.EmptyDataError):

--- a/algorithmic_efficiency/workloads/wmt/bleu.py
+++ b/algorithmic_efficiency/workloads/wmt/bleu.py
@@ -35,7 +35,7 @@ def corpus_bleu(sys_stream: Sequence[str],
       :return: A BLEU object containing everything you'd want.
   """
 
-  # Add some robustness to the input arguments
+  # Add some robustness to the input arguments.
   if isinstance(sys_stream, str):
     sys_stream = [sys_stream]
   if isinstance(ref_streams, str):
@@ -47,7 +47,7 @@ def corpus_bleu(sys_stream: Sequence[str],
   correct = [0 for _ in range(sacrebleu.NGRAM_ORDER)]
   total = [0 for _ in range(sacrebleu.NGRAM_ORDER)]
 
-  # look for already-tokenized sentences
+  # Look for already-tokenized sentences.
   tokenized_count = 0
 
   fhs = [sys_stream] + ref_streams

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -253,49 +253,58 @@ class TransformerEncoder(nn.Module):
         see the docs in Transformer class.
     """
     if src_key_padding_mask is not None:
-      _skpm_dtype = src_key_padding_mask.dtype
+      _skpm_dtype = src_key_padding_mask.dtype  # pylint: disable=invalid-name
       if _skpm_dtype != torch.bool and not torch.is_floating_point(
           src_key_padding_mask):
         raise AssertionError(
-            "only bool and floating types of key_padding_mask are supported")
+            'only bool and floating types of key_padding_mask are supported')
     output = src
     convert_to_nested = False
     first_layer = self.layers[0]
     src_key_padding_mask_for_layers = src_key_padding_mask
     why_not_sparsity_fast_path = ''
-    str_first_layer = "self.layers[0]"
+    str_first_layer = 'self.layers[0]'
     if not isinstance(first_layer, torch.nn.TransformerEncoderLayer):
-      why_not_sparsity_fast_path = f"{str_first_layer} was not TransformerEncoderLayer"
+      why_not_sparsity_fast_path = \
+        f'{str_first_layer} was not TransformerEncoderLayer'
     elif first_layer.norm_first:
-      why_not_sparsity_fast_path = f"{str_first_layer}.norm_first was True"
+      why_not_sparsity_fast_path = f'{str_first_layer}.norm_first was True'
     elif first_layer.training:
-      why_not_sparsity_fast_path = f"{str_first_layer} was in training mode"
+      why_not_sparsity_fast_path = \
+        f'{str_first_layer} was in training mode'
     elif not first_layer.self_attn.batch_first:
-      why_not_sparsity_fast_path = f" {str_first_layer}.self_attn.batch_first was not True"
+      why_not_sparsity_fast_path = \
+        f' {str_first_layer}.self_attn.batch_first was not True'
     elif not first_layer.self_attn._qkv_same_embed_dim:
-      why_not_sparsity_fast_path = f"{str_first_layer}.self_attn._qkv_same_embed_dim was not True"
+      why_not_sparsity_fast_path = \
+        f'{str_first_layer}.self_attn._qkv_same_embed_dim was not True'
     elif not first_layer.activation_relu_or_gelu:
-      why_not_sparsity_fast_path = f" {str_first_layer}.activation_relu_or_gelu was not True"
+      why_not_sparsity_fast_path = \
+        f' {str_first_layer}.activation_relu_or_gelu was not True'
     elif not first_layer.norm1.eps == first_layer.norm2.eps:
-      why_not_sparsity_fast_path = f"{str_first_layer}.norm1.eps was not equal to {str_first_layer}.norm2.eps"
+      why_not_sparsity_fast_path = \
+        f'{str_first_layer}.norm1.eps was not equal to {str_first_layer}.norm2.eps'
     elif not src.dim() == 3:
-      why_not_sparsity_fast_path = f"input not batched; expected src.dim() of 3 but got {src.dim()}"
+      why_not_sparsity_fast_path = \
+        f'input not batched; expected src.dim() of 3 but got {src.dim()}'
     elif not self.enable_nested_tensor:
-      why_not_sparsity_fast_path = "enable_nested_tensor was not True"
+      why_not_sparsity_fast_path = 'enable_nested_tensor was not True'
     elif src_key_padding_mask is None:
-      why_not_sparsity_fast_path = "src_key_padding_mask was None"
-    elif (((not hasattr(self, "mask_check")) or self.mask_check) and
+      why_not_sparsity_fast_path = 'src_key_padding_mask was None'
+    elif (((not hasattr(self, 'mask_check')) or self.mask_check) and
           not torch._nested_tensor_from_mask_left_aligned(
               src, src_key_padding_mask.logical_not())):
-      why_not_sparsity_fast_path = "mask_check enabled, and src and src_key_padding_mask was not left aligned"
+      why_not_sparsity_fast_path = 'mask_check enabled, and src and ' \
+                                   'src_key_padding_mask was not left aligned'
     elif output.is_nested:
-      why_not_sparsity_fast_path = "NestedTensor input is not supported"
+      why_not_sparsity_fast_path = 'NestedTensor input is not supported'
     elif mask is not None:
-      why_not_sparsity_fast_path = "src_key_padding_mask and mask were both supplied"
+      why_not_sparsity_fast_path = \
+        'src_key_padding_mask and mask were both supplied'
     elif first_layer.self_attn.num_heads % 2 == 1:
-      why_not_sparsity_fast_path = "num_head is odd"
+      why_not_sparsity_fast_path = 'num_head is odd'
     elif torch.is_autocast_enabled():
-      why_not_sparsity_fast_path = "autocast is enabled"
+      why_not_sparsity_fast_path = 'autocast is enabled'
 
     if not why_not_sparsity_fast_path:
       tensor_args = (
@@ -315,14 +324,14 @@ class TransformerEncoder(nn.Module):
       )
 
       if torch.overrides.has_torch_function(tensor_args):
-        why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
+        why_not_sparsity_fast_path = 'some Tensor argument has_torch_function'
       elif not (src.is_cuda or 'cpu' in str(src.device)):
-        why_not_sparsity_fast_path = "src is neither CUDA nor CPU"
+        why_not_sparsity_fast_path = 'src is neither CUDA nor CPU'
       elif torch.is_grad_enabled() and any(
           x.requires_grad for x in tensor_args):
         why_not_sparsity_fast_path = (
-            "grad is enabled and at least one of query or the "
-            "input/output projection weights or biases requires_grad")
+            'grad is enabled and at least one of query or the '
+            'input/output projection weights or biases requires_grad')
 
       if (not why_not_sparsity_fast_path) and (src_key_padding_mask
                                                is not None):
@@ -593,9 +602,8 @@ class TransformerEncoderLayer(nn.Module):
     Shape:
         see the docs in Transformer class.
     """
-
     if src_key_padding_mask is not None:
-      _skpm_dtype = src_key_padding_mask.dtype
+      _skpm_dtype = src_key_padding_mask.dtype  # pylint: disable=invalid-name
       if _skpm_dtype != torch.bool and not torch.is_floating_point(
           src_key_padding_mask):
         raise AssertionError(
@@ -618,7 +626,8 @@ class TransformerEncoderLayer(nn.Module):
     elif src_mask is not None:
       why_not_sparsity_fast_path = '`src_mask` is not supported for fastpath'
     elif src.is_nested and src_key_padding_mask is not None:
-      why_not_sparsity_fast_path = '`src_key_padding_mask` is not supported with NestedTensor input for fastpath'
+      why_not_sparsity_fast_path = '`src_key_padding_mask` is not supported ' \
+                                   'with NestedTensor input for fastpath'
     elif self.self_attn.num_heads % 2 == 1:
       why_not_sparsity_fast_path = '`num_head` is odd'
     elif torch.is_autocast_enabled():
@@ -946,12 +955,18 @@ class TransformerDecoderLayer(nn.Module):
     return self.dropout1(x), cache
 
   # Multihead attention block:
-  def _mha_block(self, x: Tensor, mem: Tensor,
-                 attn_mask: Optional[Tensor], key_padding_mask: Optional[Tensor]) -> Tensor:
-    x = self.multihead_attn(x, mem, mem,
-                            attn_mask=attn_mask,
-                            key_padding_mask=key_padding_mask,
-                            need_weights=False)[0]
+  def _mha_block(self,
+                 x: Tensor,
+                 mem: Tensor,
+                 attn_mask: Optional[Tensor],
+                 key_padding_mask: Optional[Tensor]) -> Tensor:
+    x = self.multihead_attn(
+        x,
+        mem,
+        mem,
+        attn_mask=attn_mask,
+        key_padding_mask=key_padding_mask,
+        need_weights=False)[0]
     return self.dropout2(x)
 
   # Feed forward block.
@@ -1174,7 +1189,7 @@ def _in_projection(
   ensure embedding dimension uniformity in the projected outputs.
   Output is a triple containing projection tensors for query, key and value.
   """
-  eq, ek, ev = q.size(-1), k.size(-1), v.size(-1)
+  eq, ek = q.size(-1), k.size(-1)
   assert w_q.shape == (eq, eq), \
     f'Expecting query weights shape of {(eq, eq)}, but got {w_q.shape}'
   assert w_k.shape == (eq, ek), \
@@ -1274,27 +1289,27 @@ def multi_head_attention_forward(query: Tensor,
   tgt_len, bsz, embed_dim = query.shape
   src_len, _, _ = key.shape
   assert embed_dim == embed_dim_to_check, \
-      f"was expecting dimension of {embed_dim_to_check}, but got {embed_dim}"
+      f'was expecting dimension of {embed_dim_to_check}, but got {embed_dim}'
   if isinstance(embed_dim, torch.Tensor):
     # `embed_dim` can be a tensor when JIT tracing.
     head_dim = embed_dim.div(num_heads, rounding_mode='trunc')
   else:
     head_dim = embed_dim // num_heads
   assert head_dim * num_heads == embed_dim, \
-      f"embed_dim {embed_dim} not divisible by num_heads {num_heads}"
+      f'embed_dim {embed_dim} not divisible by num_heads {num_heads}'
   # Allow MHA to have different embedding dimensions when separate projection
   # weights are used.
   assert key.shape[:2] == value.shape[:2], \
       (f"key's sequence and batch dims {key.shape[:2]} do not match value's "
-       f"{value.shape[:2]}")
+       f'{value.shape[:2]}')
 
   # Compute in-projection.
   assert q_proj_weight is not None, \
-      "use_separate_proj_weight is True but q_proj_weight is None"
+      'use_separate_proj_weight is True but q_proj_weight is None'
   assert k_proj_weight is not None, \
-      "use_separate_proj_weight is True but k_proj_weight is None"
+      'use_separate_proj_weight is True but k_proj_weight is None'
   assert v_proj_weight is not None, \
-      "use_separate_proj_weight is True but v_proj_weight is None"
+      'use_separate_proj_weight is True but v_proj_weight is None'
   if in_proj_bias is None:
     b_q = b_k = b_v = None
   else:
@@ -1351,25 +1366,25 @@ def multi_head_attention_forward(query: Tensor,
   if not decode and attn_mask is not None:
     if attn_mask.dtype == torch.uint8:
       warnings.warn(
-          "Byte tensor for attn_mask in nn.MultiheadAttention is deprecated."
-          "Use bool tensor instead.")
+          'Byte tensor for attn_mask in nn.MultiheadAttention is deprecated.'
+          'Use bool tensor instead.')
       attn_mask = attn_mask.to(torch.bool)
     else:
       assert attn_mask.is_floating_point() or attn_mask.dtype == torch.bool, \
-          f"float, byte, and bool types are supported, not {attn_mask.dtype}"
+          f'float, byte, and bool types are supported, not {attn_mask.dtype}'
     # ensure attn_mask's dim is 3
     if attn_mask.dim() == 2:
       correct_2d_size = (tgt_len, src_len)
       if attn_mask.shape != correct_2d_size:
         raise RuntimeError(
-            f"The shape of the 2D attn_mask is {attn_mask.shape}, "
-            f"but should be {correct_2d_size}.")
+            f'The shape of the 2D attn_mask is {attn_mask.shape}, '
+            f'but should be {correct_2d_size}.')
       attn_mask = attn_mask.unsqueeze(0)
     elif attn_mask.dim() == 3:
       correct_3d_size = (bsz * num_heads, tgt_len, src_len)
       if attn_mask.shape != correct_3d_size:
-        raise RuntimeError(f"The shape of attn_mask is {attn_mask.shape}, "
-                           f"should be {correct_3d_size}.")
+        raise RuntimeError(f'The shape of attn_mask is {attn_mask.shape}, '
+                           f'should be {correct_3d_size}.')
     else:
       raise RuntimeError(
           f"attn_mask's dimension {attn_mask.dim()} is not supported")
@@ -1385,9 +1400,12 @@ def multi_head_attention_forward(query: Tensor,
     assert bias_v is None
 
   # Reshape q, k, v for multihead attention and make em batch first.
-  q = q.contiguous().view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
-  k = k.contiguous().view(k.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
-  v = v.contiguous().view(v.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+  q = \
+    q.contiguous().view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
+  k = \
+    k.contiguous().view(k.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+  v = \
+    v.contiguous().view(v.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
 
   # Update source sequence length after adjustments.
   src_len = k.size(1)
@@ -1420,7 +1438,7 @@ def multi_head_attention_forward(query: Tensor,
     else:
       attn_output_weights = torch.bmm(q_scaled, k.transpose(-2, -1))
 
-    # Optionally average attention weights over heads
+    # Optionally average attention weights over heads.
     attn_output_weights = attn_output_weights.view(bsz,
                                                    num_heads,
                                                    tgt_len,

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -856,16 +856,17 @@ class MultiheadAttention(nn.MultiheadAttention):
     else:
       return attn_output, attn_output_weights, cache
 
+
 def _in_projection(
-        q: Tensor,
-        k: Tensor,
-        v: Tensor,
-        w_q: Tensor,
-        w_k: Tensor,
-        w_v: Tensor,
-        b_q: Optional[Tensor] = None,
-        b_k: Optional[Tensor] = None,
-        b_v: Optional[Tensor] = None,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    w_v: Tensor,
+    b_q: Optional[Tensor] = None,
+    b_k: Optional[Tensor] = None,
+    b_v: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
   r"""Performs the in-projection step of the attention operation. This is simply
   a triple of linear projections, with shape constraints on the weights which
@@ -883,28 +884,27 @@ def _in_projection(
 
 
 # Modified to create cache for autoregressive decoding.
-def multi_head_attention_forward(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    embed_dim_to_check: int,
-    num_heads: int,
-    in_proj_bias: Optional[Tensor],
-    bias_k: Optional[Tensor],
-    bias_v: Optional[Tensor],
-    dropout_rate: float,
-    out_proj_weight: Tensor,
-    out_proj_bias: Optional[Tensor],
-    training: bool = True,
-    need_weights: bool = True,
-    attn_mask: Optional[Tensor] = None,
-    q_proj_weight: Optional[Tensor] = None,
-    k_proj_weight: Optional[Tensor] = None,
-    v_proj_weight: Optional[Tensor] = None,
-    average_attn_weights: bool = True,
-    decode: bool = False,
-    cache: Optional[dict] = None,
-    max_len: Optional[int] = None) -> Any:
+def multi_head_attention_forward(query: Tensor,
+                                 key: Tensor,
+                                 value: Tensor,
+                                 embed_dim_to_check: int,
+                                 num_heads: int,
+                                 in_proj_bias: Optional[Tensor],
+                                 bias_k: Optional[Tensor],
+                                 bias_v: Optional[Tensor],
+                                 dropout_rate: float,
+                                 out_proj_weight: Tensor,
+                                 out_proj_bias: Optional[Tensor],
+                                 training: bool = True,
+                                 need_weights: bool = True,
+                                 attn_mask: Optional[Tensor] = None,
+                                 q_proj_weight: Optional[Tensor] = None,
+                                 k_proj_weight: Optional[Tensor] = None,
+                                 v_proj_weight: Optional[Tensor] = None,
+                                 average_attn_weights: bool = True,
+                                 decode: bool = False,
+                                 cache: Optional[dict] = None,
+                                 max_len: Optional[int] = None) -> Any:
   r"""
   Args:
     query, key, value: map a query and a set of key-value pairs to an output.

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -1,3 +1,4 @@
+import copy
 import math
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 import warnings
@@ -204,6 +205,148 @@ class Transformer(nn.Module):
     return output
 
 
+class TransformerEncoder(nn.Module):
+  r"""TransformerEncoder is a stack of N encoder layers. Users can build the
+  BERT(https://arxiv.org/abs/1810.04805) model with corresponding parameters.
+
+  Args:
+      encoder_layer: an instance of the TransformerEncoderLayer() class (required).
+      num_layers: the number of sub-encoder-layers in the encoder (required).
+      norm: the layer normalization component (optional).
+      enable_nested_tensor: if True, input will automatically convert to nested tensor
+          (and convert back on output). This will improve the overall performance of
+          TransformerEncoder when padding rate is high. Default: ``True`` (enabled).
+
+  Examples::
+      >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+      >>> transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6)
+      >>> src = torch.rand(10, 32, 512)
+      >>> out = transformer_encoder(src)
+  """
+  __constants__ = ['norm']
+
+  def __init__(self,
+               encoder_layer,
+               num_layers,
+               norm=None,
+               enable_nested_tensor=True,
+               mask_check=True):
+    super(TransformerEncoder, self).__init__()
+    self.layers = nn.ModuleList(
+        [copy.deepcopy(encoder_layer) for i in range(num_layers)])
+    self.num_layers = num_layers
+    self.norm = norm
+    self.enable_nested_tensor = enable_nested_tensor
+    self.mask_check = mask_check
+
+  def forward(self,
+              src: Tensor,
+              mask: Optional[Tensor] = None,
+              src_key_padding_mask: Optional[Tensor] = None) -> Tensor:
+    r"""Pass the input through the encoder layers in turn.
+
+    Args:
+        src: the sequence to the encoder (required).
+        mask: the mask for the src sequence (optional).
+        src_key_padding_mask: the mask for the src keys per batch (optional).
+
+    Shape:
+        see the docs in Transformer class.
+    """
+    if src_key_padding_mask is not None:
+      _skpm_dtype = src_key_padding_mask.dtype
+      if _skpm_dtype != torch.bool and not torch.is_floating_point(
+          src_key_padding_mask):
+        raise AssertionError(
+            "only bool and floating types of key_padding_mask are supported")
+    output = src
+    convert_to_nested = False
+    first_layer = self.layers[0]
+    src_key_padding_mask_for_layers = src_key_padding_mask
+    why_not_sparsity_fast_path = ''
+    str_first_layer = "self.layers[0]"
+    if not isinstance(first_layer, torch.nn.TransformerEncoderLayer):
+      why_not_sparsity_fast_path = f"{str_first_layer} was not TransformerEncoderLayer"
+    elif first_layer.norm_first:
+      why_not_sparsity_fast_path = f"{str_first_layer}.norm_first was True"
+    elif first_layer.training:
+      why_not_sparsity_fast_path = f"{str_first_layer} was in training mode"
+    elif not first_layer.self_attn.batch_first:
+      why_not_sparsity_fast_path = f" {str_first_layer}.self_attn.batch_first was not True"
+    elif not first_layer.self_attn._qkv_same_embed_dim:
+      why_not_sparsity_fast_path = f"{str_first_layer}.self_attn._qkv_same_embed_dim was not True"
+    elif not first_layer.activation_relu_or_gelu:
+      why_not_sparsity_fast_path = f" {str_first_layer}.activation_relu_or_gelu was not True"
+    elif not (first_layer.norm1.eps == first_layer.norm2.eps):
+      why_not_sparsity_fast_path = f"{str_first_layer}.norm1.eps was not equal to {str_first_layer}.norm2.eps"
+    elif not src.dim() == 3:
+      why_not_sparsity_fast_path = f"input not batched; expected src.dim() of 3 but got {src.dim()}"
+    elif not self.enable_nested_tensor:
+      why_not_sparsity_fast_path = "enable_nested_tensor was not True"
+    elif src_key_padding_mask is None:
+      why_not_sparsity_fast_path = "src_key_padding_mask was None"
+    elif (((not hasattr(self, "mask_check")) or self.mask_check) and
+          not torch._nested_tensor_from_mask_left_aligned(
+              src, src_key_padding_mask.logical_not())):
+      why_not_sparsity_fast_path = "mask_check enabled, and src and src_key_padding_mask was not left aligned"
+    elif output.is_nested:
+      why_not_sparsity_fast_path = "NestedTensor input is not supported"
+    elif mask is not None:
+      why_not_sparsity_fast_path = "src_key_padding_mask and mask were both supplied"
+    elif first_layer.self_attn.num_heads % 2 == 1:
+      why_not_sparsity_fast_path = "num_head is odd"
+    elif torch.is_autocast_enabled():
+      why_not_sparsity_fast_path = "autocast is enabled"
+
+    if not why_not_sparsity_fast_path:
+      tensor_args = (
+          src,
+          first_layer.self_attn.in_proj_weight,
+          first_layer.self_attn.in_proj_bias,
+          first_layer.self_attn.out_proj.weight,
+          first_layer.self_attn.out_proj.bias,
+          first_layer.norm1.weight,
+          first_layer.norm1.bias,
+          first_layer.norm2.weight,
+          first_layer.norm2.bias,
+          first_layer.linear1.weight,
+          first_layer.linear1.bias,
+          first_layer.linear2.weight,
+          first_layer.linear2.bias,
+      )
+
+      if torch.overrides.has_torch_function(tensor_args):
+        why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
+      elif not (src.is_cuda or 'cpu' in str(src.device)):
+        why_not_sparsity_fast_path = "src is neither CUDA nor CPU"
+      elif torch.is_grad_enabled() and any(
+          x.requires_grad for x in tensor_args):
+        why_not_sparsity_fast_path = (
+            "grad is enabled and at least one of query or the "
+            "input/output projection weights or biases requires_grad")
+
+      if (not why_not_sparsity_fast_path) and (src_key_padding_mask
+                                               is not None):
+        convert_to_nested = True
+        output = torch._nested_tensor_from_mask(
+            output, src_key_padding_mask.logical_not(), mask_check=False)
+        src_key_padding_mask_for_layers = None
+
+    for mod in self.layers:
+      output = mod(
+          output,
+          src_mask=mask,
+          src_key_padding_mask=src_key_padding_mask_for_layers)
+
+    if convert_to_nested:
+      output = output.to_padded_tensor(0.)
+
+    if self.norm is not None:
+      output = self.norm(output)
+
+    return output
+
+
 class Encoder(nn.Module):
 
   def __init__(self,
@@ -226,7 +369,7 @@ class Encoder(nn.Module):
         attention_dropout_rate=attention_dropout_rate,
         layer_norm_eps=layer_norm_eps)
     encoder_norm = nn.LayerNorm(d_model, eps=layer_norm_eps)
-    self.encoder = nn.TransformerEncoder(encoder_layer, nlayers, encoder_norm)
+    self.encoder = TransformerEncoder(encoder_layer, nlayers, encoder_norm)
 
   def forward(self,
               src: Tensor,

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -260,86 +260,7 @@ class TransformerEncoder(nn.Module):
             'only bool and floating types of key_padding_mask are supported')
     output = src
     convert_to_nested = False
-    first_layer = self.layers[0]
     src_key_padding_mask_for_layers = src_key_padding_mask
-    why_not_sparsity_fast_path = ''
-    str_first_layer = 'self.layers[0]'
-    if not isinstance(first_layer, torch.nn.TransformerEncoderLayer):
-      why_not_sparsity_fast_path = \
-        f'{str_first_layer} was not TransformerEncoderLayer'
-    elif first_layer.norm_first:
-      why_not_sparsity_fast_path = f'{str_first_layer}.norm_first was True'
-    elif first_layer.training:
-      why_not_sparsity_fast_path = \
-        f'{str_first_layer} was in training mode'
-    elif not first_layer.self_attn.batch_first:
-      why_not_sparsity_fast_path = \
-        f' {str_first_layer}.self_attn.batch_first was not True'
-    elif not first_layer.self_attn._qkv_same_embed_dim:
-      why_not_sparsity_fast_path = \
-        f'{str_first_layer}.self_attn._qkv_same_embed_dim was not True'
-    elif not first_layer.activation_relu_or_gelu:
-      why_not_sparsity_fast_path = \
-        f' {str_first_layer}.activation_relu_or_gelu was not True'
-    elif not first_layer.norm1.eps == first_layer.norm2.eps:
-      why_not_sparsity_fast_path = \
-        f'{str_first_layer}.norm1.eps was not equal ' \
-        f'to {str_first_layer}.norm2.eps'
-    elif not src.dim() == 3:
-      why_not_sparsity_fast_path = \
-        f'input not batched; expected src.dim() of 3 but got {src.dim()}'
-    elif not self.enable_nested_tensor:
-      why_not_sparsity_fast_path = 'enable_nested_tensor was not True'
-    elif src_key_padding_mask is None:
-      why_not_sparsity_fast_path = 'src_key_padding_mask was None'
-    elif (((not hasattr(self, 'mask_check')) or self.mask_check) and
-          not torch._nested_tensor_from_mask_left_aligned(
-              src, src_key_padding_mask.logical_not())):
-      why_not_sparsity_fast_path = 'mask_check enabled, and src and ' \
-                                   'src_key_padding_mask was not left aligned'
-    elif output.is_nested:
-      why_not_sparsity_fast_path = 'NestedTensor input is not supported'
-    elif mask is not None:
-      why_not_sparsity_fast_path = \
-        'src_key_padding_mask and mask were both supplied'
-    elif first_layer.self_attn.num_heads % 2 == 1:
-      why_not_sparsity_fast_path = 'num_head is odd'
-    elif torch.is_autocast_enabled():
-      why_not_sparsity_fast_path = 'autocast is enabled'
-
-    if not why_not_sparsity_fast_path:
-      tensor_args = (
-          src,
-          first_layer.self_attn.in_proj_weight,
-          first_layer.self_attn.in_proj_bias,
-          first_layer.self_attn.out_proj.weight,
-          first_layer.self_attn.out_proj.bias,
-          first_layer.norm1.weight,
-          first_layer.norm1.bias,
-          first_layer.norm2.weight,
-          first_layer.norm2.bias,
-          first_layer.linear1.weight,
-          first_layer.linear1.bias,
-          first_layer.linear2.weight,
-          first_layer.linear2.bias,
-      )
-
-      if torch.overrides.has_torch_function(tensor_args):
-        why_not_sparsity_fast_path = 'some Tensor argument has_torch_function'
-      elif not (src.is_cuda or 'cpu' in str(src.device)):
-        why_not_sparsity_fast_path = 'src is neither CUDA nor CPU'
-      elif torch.is_grad_enabled() and any(
-          x.requires_grad for x in tensor_args):
-        why_not_sparsity_fast_path = (
-            'grad is enabled and at least one of query or the '
-            'input/output projection weights or biases requires_grad')
-
-      if (not why_not_sparsity_fast_path) and (src_key_padding_mask
-                                               is not None):
-        convert_to_nested = True
-        output = torch._nested_tensor_from_mask(
-            output, src_key_padding_mask.logical_not(), mask_check=False)
-        src_key_padding_mask_for_layers = None
 
     for mod in self.layers:
       output = mod(
@@ -609,87 +530,6 @@ class TransformerEncoderLayer(nn.Module):
           src_key_padding_mask):
         raise AssertionError(
             'Only bool and floating types of key_padding_mask are supported')
-    # See Fig. 1 of https://arxiv.org/pdf/2002.04745v1.pdf.
-    why_not_sparsity_fast_path = ''
-    if not src.dim() == 3:
-      why_not_sparsity_fast_path = \
-        f'Input not batched; expected src.dim() of 3 but got {src.dim()}'
-    elif self.training:
-      why_not_sparsity_fast_path = 'Training is enabled'
-    elif not self.self_attn.batch_first:
-      why_not_sparsity_fast_path = '`self_attn.batch_first` was not True'
-    elif not self.self_attn._qkv_same_embed_dim:
-      why_not_sparsity_fast_path = \
-        '`self_attn._qkv_same_embed_dim` was not True'
-    elif not self.activation_relu_or_gelu:
-      why_not_sparsity_fast_path = '`activation_relu_or_gelu` was not True'
-    elif not self.norm1.eps == self.norm2.eps:
-      why_not_sparsity_fast_path = '`norm1.eps` is not equal to norm2.eps'
-    elif src_mask is not None:
-      why_not_sparsity_fast_path = '`src_mask` is not supported for fastpath'
-    elif src.is_nested and src_key_padding_mask is not None:
-      why_not_sparsity_fast_path = '`src_key_padding_mask` is not supported ' \
-                                   'with NestedTensor input for fastpath'
-    elif self.self_attn.num_heads % 2 == 1:
-      why_not_sparsity_fast_path = '`num_head` is odd'
-    elif torch.is_autocast_enabled():
-      why_not_sparsity_fast_path = 'autocast is enabled'
-
-    if not why_not_sparsity_fast_path:
-      tensor_args = (
-          src,
-          self.self_attn.in_proj_weight,
-          self.self_attn.in_proj_bias,
-          self.self_attn.out_proj.weight,
-          self.self_attn.out_proj.bias,
-          self.norm1.weight,
-          self.norm1.bias,
-          self.norm2.weight,
-          self.norm2.bias,
-          self.linear1.weight,
-          self.linear1.bias,
-          self.linear2.weight,
-          self.linear2.bias,
-      )
-
-      # We have to use list comprehensions below because TorchScript
-      # does not support generator expressions.
-      if torch.overrides.has_torch_function(tensor_args):
-        why_not_sparsity_fast_path = 'Some Tensor argument has_torch_function'
-      elif not all((x.is_cuda or 'cpu' in str(x.device)) for x in tensor_args):
-        why_not_sparsity_fast_path = \
-          'Some Tensor argument is neither CUDA nor CPU'
-      elif torch.is_grad_enabled() and any(
-          x.requires_grad for x in tensor_args):
-        why_not_sparsity_fast_path = (
-            'grad is enabled and at least one of query or the '
-            'input/output projection weights or biases requires_grad')
-
-      if not why_not_sparsity_fast_path:
-        return torch._transformer_encoder_layer_fwd(
-            src,
-            self.self_attn.embed_dim,
-            self.self_attn.num_heads,
-            self.self_attn.in_proj_weight,
-            self.self_attn.in_proj_bias,
-            self.self_attn.out_proj.weight,
-            self.self_attn.out_proj.bias,
-            self.activation_relu_or_gelu == 2,
-            self.norm_first,
-            self.norm1.eps,
-            self.norm1.weight,
-            self.norm1.bias,
-            self.norm2.weight,
-            self.norm2.bias,
-            self.linear1.weight,
-            self.linear1.bias,
-            self.linear2.weight,
-            self.linear2.bias,
-            src_mask if src_mask is not None else src_key_padding_mask,
-            1 if src_key_padding_mask is not None else
-            0 if src_mask is not None else None,
-        )
-
     x = src
     if self.norm_first:
       x = x + self._sa_block(self.norm1(x), src_mask, src_key_padding_mask)
@@ -1446,7 +1286,7 @@ def multi_head_attention_forward(query: Tensor,
                                                    tgt_len,
                                                    src_len)
     if average_attn_weights:
-      attn_output_weights = attn_output_weights.mean(dim=1) / num_heads
+      attn_output_weights = attn_output_weights.sum(dim=1) / num_heads
     return attn_output, attn_output_weights, cache
   else:
     return attn_output, None, cache

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -1,4 +1,5 @@
 """WMT workload implemented in PyTorch."""
+
 import contextlib
 from typing import Any, Dict, Optional, Tuple
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,17 +35,17 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project:
 install_requires =
-  absl-py==1.0.0
-  numpy==1.21.6
-  pandas==1.3.5
-  protobuf==3.20.*
+  absl-py==1.4.0
+  numpy==1.23
+  pandas==2.0.1
+  protobuf==4.23.*
   six==1.16.0
-  tensorflow==2.9.0
-  tensorflow_datasets==4.8.2
-  tensorflow_probability==0.17.0
-  tensorflow_addons==0.18.0
+  tensorflow==2.12.0
+  tensorflow-datasets==4.9.2
+  tensorflow-probability==0.20.0
+  tensorflow-addons==0.20.0
   gputil==1.4.0
-  psutil==5.9.1
+  psutil==5.9.5
   clu==0.0.7
 python_requires = >=3.7
 
@@ -78,31 +78,31 @@ full_dev =
 
 # Dependencies for developing the package
 dev =
-  isort==5.10.1
-  pylint==2.16.1
-  pytest==7.1.2
-  yapf==0.32.0
-  pre-commit==2.20.0
+  isort==5.12.0
+  pylint==2.17.4
+  pytest==7.3.1
+  yapf==0.33.0
+  pre-commit==3.3.1
 
 # Workloads #
 criteo1tb =
-  scikit-learn==1.0.1
+  scikit-learn==1.2.2
 
 fastmri =
-  h5py==3.7.0
-  scikit_image==0.19.3
+  h5py==3.8.0
+  scikit-image==0.20.0
 
 ogbg =
   jraph==0.0.6.dev0
-  scikit-learn==1.0.1
+  scikit-learn==1.2.2
 
 librispeech_conformer =
-  sentencepiece==0.1.97
-  tensorflow-text==2.9.0
+  sentencepiece==0.1.99
+  tensorflow-text==2.12.1
 
 wmt =
-  sentencepiece==0.1.97
-  tensorflow-text==2.9.0
+  sentencepiece==0.1.99
+  tensorflow-text==2.12.1
   sacrebleu==1.3.1
 
 # Frameworks #
@@ -132,17 +132,17 @@ jax_gpu =
 
 # PyTorch CPU
 pytorch_cpu =
-  torch==1.13.0
-  torchvision==0.14.0
+  torch==2.0.1
+  torchvision==0.15.2
 
 # PyTorch GPU
 pytorch_gpu =
-  torch==1.13.0+cu117
-  torchvision==0.14.0+cu117
+  torch==2.0.1+cu117
+  torchvision==0.15.2+cu117
 
 # wandb
 wandb =
-  wandb==0.13.4
+  wandb==0.15.2
 
 ###############################################################################
 #                           Linting Configurations                            #


### PR DESCRIPTION
This PR performs various version updates (so that we have up-to-date dependencies). This includes an update to PyTorch 2.0, where we can have a flag `--torch_compile` to enable JIT compile. 

Some notes:
- I have only tested `torch.compile` on smaller workloads; it would be great if we could test whether it works for all the workloads.
- I have to port almost all Transformer codes (for WMT) from PyTorch version 1.13 due to changes in the API. It would be useful to check this workload extra carefully. 