### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 1. Create new environment, e.g. via `conda` or `virtualenv`:
 
-   Python minimum requirement >= 3.7
+   Python minimum requirement >= 3.8
 
    ```bash
     sudo apt-get install python3-venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
   Intended Audience :: Science/Research
   License :: OSI Approved :: Apache Software License
   Operating System :: OS Independent
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
@@ -47,7 +46,7 @@ install_requires =
   gputil==1.4.0
   psutil==5.9.1
   clu==0.0.7
-python_requires = >=3.7
+python_requires = >=3.8
 
 
 ###############################################################################


### PR DESCRIPTION
Since some of the recently updated packages don't support Python `3.7` anymore (e.g. `optax`), it looks like we also have to bump the minimum required Python version to `3.8`.