### PR TITLE
Add baseline tests to CI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,3 +182,5 @@ jobs:
         pytest -vx tests/test_param_shapes.py
         pytest -vx tests/test_param_types.py
         pytest -vx tests/test_ssim.py
+        pytest -vx tests/submission_runner_test.py
+        pytest -vx tests/test_baselines.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,5 +182,3 @@ jobs:
         pytest -vx tests/test_param_shapes.py
         pytest -vx tests/test_param_types.py
         pytest -vx tests/test_ssim.py
-        pytest -vx tests/submission_runner_test.py
-        pytest -vx tests/test_baselines.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,4 +182,4 @@ jobs:
         pytest -vx tests/test_param_shapes.py
         pytest -vx tests/test_param_types.py
         pytest -vx tests/test_ssim.py
-        pytest -vx tests/test_baselines.py
+        pytest tests/test_baselines.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,3 +182,4 @@ jobs:
         pytest -vx tests/test_param_shapes.py
         pytest -vx tests/test_param_types.py
         pytest -vx tests/test_ssim.py
+        pytest -vx tests/test_baselines.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,4 +182,6 @@ jobs:
         pytest -vx tests/test_param_shapes.py
         pytest -vx tests/test_param_types.py
         pytest -vx tests/test_ssim.py
+    - name: Run baseline tests
+      run: |
         pytest tests/test_baselines.py

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -55,7 +55,10 @@ class MnistWorkload(BaseMnistWorkload):
       repeat_final_dataset: Optional[bool] = None,
       num_batches: Optional[int] = None) -> Iterator[Dict[str, spec.Tensor]]:
     del cache
-    per_device_batch_size = int(global_batch_size / N_GPUS)
+    if N_GPUS != 0:
+      per_device_batch_size = int(global_batch_size / N_GPUS)
+    else: 
+      per_device_batch_size = int(global_batch_size)
 
     # Only create and iterate over tf input pipeline in one Python process to
     # avoid creating too many threads.

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -57,7 +57,7 @@ class MnistWorkload(BaseMnistWorkload):
     del cache
     if N_GPUS != 0:
       per_device_batch_size = int(global_batch_size / N_GPUS)
-    else: 
+    else:
       per_device_batch_size = int(global_batch_size)
 
     # Only create and iterate over tf input pipeline in one Python process to

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -39,7 +39,7 @@ baselines = {
         'momentum',
         'nadamw',
         'nesterov',  # 'sam',
-  # 'shampoo',
+        # 'shampoo',
     ],
 }
 

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -32,19 +32,16 @@ baselines = {
         'nesterov',
         'sam',
         'shampoo',
-        ],
+    ],
     'pytorch': [
         # 'adafactor',
-        'adamw',
-        # 'lamb',
+        'adamw',  # 'lamb',
         'momentum',
         'nadamw',
-        'nesterov',
-        # 'sam',
-        # 'shampoo',
-        ],
+        'nesterov',  # 'sam',
+  # 'shampoo',
+    ],
 }
-
 
 frameworks = [
     'pytorch',

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -22,24 +22,39 @@ FLAGS(sys.argv)
 
 MAX_GLOBAL_STEPS = 500
 
-baselines = [
-    'adafactor',
-    'adamw',
-    'lamb',
-    'momentum',
-    'nadamw',
-    'nesterov',
-    'sam',
-    'shampoo',
+baselines = {
+    'jax': [
+        'adafactor',
+        'adamw',
+        'lamb',
+        'momentum',
+        'nadamw',
+        'nesterov',
+        'sam',
+        'shampoo',
+        ],
+    'pytorch': [
+        # 'adafactor',
+        'adamw',
+        # 'lamb',
+        'momentum',
+        'nadamw',
+        'nesterov',
+        # 'sam',
+        # 'shampoo',
+        ],
+    ]
 ]
+
+
 frameworks = [
-    # 'pytorch', # will enable this once all pytorch baselines are ready
+    'pytorch',
     'jax',
 ]
 
 named_parameters = []
 for f in frameworks:
-  for b in baselines:
+  for b in baselines[f]:
     named_parameters.append(
         dict(
             testcase_name=f'{b}_{f}',

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -43,8 +43,7 @@ baselines = {
         # 'sam',
         # 'shampoo',
         ],
-    ]
-]
+}
 
 
 frameworks = [

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -34,12 +34,10 @@ baselines = {
         'shampoo',
     ],
     'pytorch': [
-        # 'adafactor',
-        'adamw',  # 'lamb',
+        'adamw',
         'momentum',
         'nadamw',
-        'nesterov',  # 'sam',
-        # 'shampoo',
+        'nesterov',
     ],
 }
 


### PR DESCRIPTION
Add test_baselines.py to CI workflow, for 12 enabled baselines this adds about 4:37 minutes to the CI tests.
Also fix bug in mnist input_pipeline.