### PR TITLE
Fix tests for `criteo1tb` debugging

### DIFF
--- a/reference_algorithms/target_setting_algorithms/jax_submission_base.py
+++ b/reference_algorithms/target_setting_algorithms/jax_submission_base.py
@@ -101,7 +101,8 @@ def update_params(workload: spec.Workload,
       label_smoothing)
 
   # Log loss, grad_norm.
-  if global_step % 100 == 0 and workload.metrics_logger is not None:
+  if ((global_step <= 100 or global_step % 500 == 0) and
+      workload.metrics_logger is not None):
     workload.metrics_logger.append_scalar_metrics(
         {
             'loss': loss[0],

--- a/tests/reference_algorithm_tests.py
+++ b/tests/reference_algorithm_tests.py
@@ -135,12 +135,11 @@ class _FakeMetricsLogger:
     self.scalars = []
     self.eval_results = []
 
-  def append_scalar_metrics(self, scalars, n_gpus):
+  def append_scalar_metrics(self, scalars, step):
     if USE_PYTORCH_DDP:
       for k in sorted(scalars):
         scalars[k] = torch.FloatTensor([scalars[k]]).to(PYTORCH_DEVICE)
-        dist.all_reduce(scalars[k])
-        scalars[k] = scalars[k].item() / n_gpus
+        dist.all_reduce(scalars[k], op=dist.ReduceOp.AVG)
     if RANK == 0:
       self.scalars.append(scalars)
       self.save()

--- a/tests/reference_algorithm_tests.py
+++ b/tests/reference_algorithm_tests.py
@@ -373,8 +373,12 @@ def _make_one_batch_workload(workload_class,
       # the BLEU score.
       if workload_name == 'wmt':
         num_batches *= 2
-      for _ in range(num_batches * FLAGS.num_train_steps):
-        yield fake_batch
+
+      def _data_gen():
+        for _ in range(num_batches * FLAGS.num_train_steps):
+          yield fake_batch
+
+      return _data_gen
 
     def eval_model(self, *args, **kwargs):
       eval_result = super().eval_model(*args, **kwargs)

--- a/tests/test_traindiffs.py
+++ b/tests/test_traindiffs.py
@@ -77,7 +77,7 @@ class ModelDiffTest(absltest.TestCase):
       fmt = lambda l: '|' + '|'.join(map(lambda x: f'{x:^20s}', l)) + '|'
       header = fmt(header)
       pad = (len(header) - len((name))) // 2
-      print("=" * pad, name, '=' * (len(header) - len(name) - pad), sep='')
+      print('=' * pad, name, '=' * (len(header) - len(name) - pad), sep='')
       print(header)
       print('=' * len(header))
       for i in range(NUM_TRAIN_STEPS):


### PR DESCRIPTION
Some fixes for the tests we use for debugging the `criteo1tb` workload. Also, set the metric logging frequency of train loss and grad norm equally for Jax and PyTorch runs.