### PR TITLE
Fix `_get_time`

### DIFF
--- a/submission_runner.py
+++ b/submission_runner.py
@@ -176,7 +176,8 @@ USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 
 
 def _get_time():
-  torch.cuda.synchronize()
+  if torch.cuda.is_available():
+    torch.cuda.synchronize()
   return time.time()
 
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -176,6 +176,7 @@ USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 
 
 def _get_time():
+  torch.cuda.synchronize()
   return time.time()
 
 


### PR DESCRIPTION
Unless I'm missing something we always need to call `torch.cuda.synchronize()` for timing, not only when DDP is used. Also, I think this shouldn't have unwanted side-effects for the Jax runs.