### PR TITLE
Update setup.cfg to work locally

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,8 @@ setup_requires =
 # Dependencies of the project:
 install_requires =
   absl-py==1.4.0
-  numpy==1.23
-  pandas==2.0.1
-  protobuf==4.23.*
-  six==1.16.0
+  numpy>=1.23
+  pandas>=2.0.1
   tensorflow==2.12.0
   tensorflow-datasets==4.9.2
   tensorflow-probability==0.20.0


### PR DESCRIPTION
Could not run `pip install -e '.[full]'` locally unless these changes were made.

I don't believe we _directly_ depend on six or protobuf, and I'm fine with letting numpy and pandas have min instead of exact values.

I don't expect this should break anything (famous last words), but we should check that this doesn't break our docker setup before merging to main (which we will anyways).