### PR TITLE
Fix criteo1tb eval batch size for PyTorch

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
@@ -22,7 +22,7 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
 
   @property
   def eval_batch_size(self) -> int:
-    return 65_536
+    return 262_144
 
   def _per_example_sigmoid_binary_cross_entropy(
       self, logits: spec.Tensor, targets: spec.Tensor) -> spec.Tensor:

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -61,10 +61,6 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
     return 89_274_637
 
   @property
-  def eval_batch_size(self) -> int:
-    return 524_288
-
-  @property
   def train_mean(self):
     raise NotImplementedError
 


### PR DESCRIPTION
Set PyTorch eval batch size equal to training batch size and remove property from workload parent class to avoid confusion.