### PR TITLE
Update submission_runner.py to prevent torch Conformer OOM

### DIFF
--- a/submission_runner.py
+++ b/submission_runner.py
@@ -453,6 +453,8 @@ def train_once(
                   save_intermediate_checkpoints=FLAGS
                   .save_intermediate_checkpoints)
 
+          if USE_PYTORCH_DDP:
+            torch.cuda.empty_cache()
           logging_end_time = get_time()
 
           train_state['accumulated_logging_time'] += (


### PR DESCRIPTION
This is to fix the OOM error seen in https://github.com/mlcommons/algorithmic-efficiency/issues/426

We use torch.cuda.empty_cache() after evals so it doesn't run out of memory.