### PR TITLE
Train tokenizer for WMT during dataset setup

### DIFF
--- a/algorithmic_efficiency/workloads/wmt/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/wmt/input_pipeline.py
@@ -283,9 +283,8 @@ def get_wmt_dataset(data_rng,
       functools.partial(normalize_feature_names, dataset_builder.info),
       num_parallel_calls=AUTOTUNE)
 
-  # Tokenize data.
-  sp_tokenizer = tokenizer.load_or_train_tokenizer(
-      ds, vocab_path=vocab_path, vocab_size=vocab_size, max_corpus_chars=10**7)
+  # Load tf-text SentencePiece tokenizer.
+  sp_tokenizer = tokenizer.load_tokenizer(vocab_path=vocab_path)
   ds = ds.map(tokenizer.TokenizeOp(sp_tokenizer), num_parallel_calls=AUTOTUNE)
 
   shuffle = split in ['train', 'eval_train']

--- a/algorithmic_efficiency/workloads/wmt/tokenizer.py
+++ b/algorithmic_efficiency/workloads/wmt/tokenizer.py
@@ -98,7 +98,6 @@ def _train_sentencepiece(dataset: tf.data.Dataset,
     while not tf.io.gfile.exists(abs_model_path):
       time.sleep(1)
     time.sleep(1)
-  return abs_model_path
 
 
 def _load_sentencepiece_tokenizer(model_path: str,
@@ -113,24 +112,25 @@ def _load_sentencepiece_tokenizer(model_path: str,
   return sp_tokenizer
 
 
-def load_or_train_tokenizer(dataset: tf.data.Dataset,
-                            *,
-                            vocab_path: str,
-                            vocab_size: int,
-                            max_corpus_chars: int,
-                            data_keys: Tuple[str, str] = ('inputs', 'targets')):
-  """Loads the tokenizer at `vocab_path` or trains a one from `dataset`."""
-  try:
-    return _load_sentencepiece_tokenizer(os.path.expanduser(vocab_path))
-  except tf.errors.NotFoundError:
-    logging.info('SentencePiece vocab not found, building one from data.')
-    vocab_path = _train_sentencepiece(
-        dataset,
-        vocab_size=vocab_size,
-        maxchars=max_corpus_chars,
-        model_path=vocab_path,
-        data_keys=data_keys)
-    return _load_sentencepiece_tokenizer(vocab_path)
+def train_tokenizer(dataset: tf.data.Dataset,
+                    *,
+                    vocab_path: str,
+                    vocab_size: int,
+                    max_corpus_chars: int,
+                    data_keys: Tuple[str, str] = ('inputs', 'targets')):
+  """Trains a tokenizer from `dataset`."""
+  logging.info('Building SentencePiece vocab from data.')
+  _train_sentencepiece(
+      dataset,
+      vocab_size=vocab_size,
+      maxchars=max_corpus_chars,
+      model_path=vocab_path,
+      data_keys=data_keys)
+
+
+def load_tokenizer(vocab_path: str):
+  """Loads the tokenizer at `vocab_path`."""
+  return _load_sentencepiece_tokenizer(os.path.expanduser(vocab_path))
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Addresses issue #104. Moves the training of the tokenizer for WMT to the dataset setup and just loads in the input pipeline. Should be functionally equivalent to previously.