### PR TITLE
Add options to torch.compile

### DIFF
--- a/submission_runner.py
+++ b/submission_runner.py
@@ -295,14 +295,14 @@ def train_once(
         logging.warning(
             'These workloads cannot be fully compiled under current '
             'PyTorch version. Proceeding with `backend=eager`.')
-        model_params = torch.compile(model_params, backend="eager")
+        model_params = torch.compile(model_params, backend='eager')
       elif FLAGS.workload in aot_eager_backend_workloads:
         logging.warning(
             'These workloads cannot be fully compiled under current '
             'PyTorch version. Proceeding with `backend=aot_eager`.')
-        model_params = torch.compile(model_params, backend="aot_eager")
+        model_params = torch.compile(model_params, backend='aot_eager')
       else:
-        logging.warning('Performing `torch.compile`.')
+        logging.info('Performing `torch.compile`.')
         model_params = torch.compile(model_params)
 
   logging.info('Initializing optimizer.')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -282,7 +282,24 @@ def train_once(
     model_params, model_state = workload.init_model_fn(
         model_init_rng, dropout_rate, aux_dropout_rate)
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
-      model_params = torch.compile(model_params)
+      compile_error_workloads = ['fastmri', 'ogbg', 'librispeech_deepspeech', 'wmt']
+      eager_backend_workloads = ['librispeech_conformer']
+      aot_eager_backend_workloads = ['criteo1tb']
+      if FLAGS.workload in compile_error_workloads:
+        logging.warning('These workloads cannot be fully compiled under current '
+                        'PyTorch version. Proceeding without `torch.compile`.')
+      elif FLAGS.workload in eager_backend_workloads:
+        logging.warning('These workloads cannot be fully compiled under current '
+                        'PyTorch version. Proceeding without `backend=eager`.')
+        model_params = torch.compile(model_params, backend="eager")
+      elif FLAGS.workload in aot_eager_backend_workloads:
+        logging.warning('These workloads cannot be fully compiled under current '
+                        'PyTorch version. Proceeding without `backend=aot_eager`.')
+        model_params = torch.compile(model_params, backend="aot_eager")
+      else:
+        logging.warning('Performing `torch.compile`.')
+        model_params = torch.compile(model_params)
+
   logging.info('Initializing optimizer.')
   with profiler.profile('Initializing optimizer'):
     optimizer_state = init_optimizer_state(workload,
@@ -453,7 +470,7 @@ def train_once(
                   save_intermediate_checkpoints=FLAGS
                   .save_intermediate_checkpoints)
 
-          if USE_PYTORCH_DDP:
+          if FLAGS.framework == 'pytorch' and torch.cuda.is_available():
             torch.cuda.empty_cache()
           logging_end_time = get_time()
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -132,7 +132,7 @@ flags.DEFINE_enum(
     'other things if the Jax or Numpy RNG library is used for RNG.')
 flags.DEFINE_boolean(
     'torch_compile',
-    False,
+    True,
     'Whether to use `torch.compile` to JIT-compile PyTorch code. '
     'This will only take effect when `framework`==pytorch.')
 
@@ -290,11 +290,11 @@ def train_once(
                         'PyTorch version. Proceeding without `torch.compile`.')
       elif FLAGS.workload in eager_backend_workloads:
         logging.warning('These workloads cannot be fully compiled under current '
-                        'PyTorch version. Proceeding without `backend=eager`.')
+                        'PyTorch version. Proceeding with `backend=eager`.')
         model_params = torch.compile(model_params, backend="eager")
       elif FLAGS.workload in aot_eager_backend_workloads:
         logging.warning('These workloads cannot be fully compiled under current '
-                        'PyTorch version. Proceeding without `backend=aot_eager`.')
+                        'PyTorch version. Proceeding with `backend=aot_eager`.')
         model_params = torch.compile(model_params, backend="aot_eager")
       else:
         logging.warning('Performing `torch.compile`.')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -282,19 +282,24 @@ def train_once(
     model_params, model_state = workload.init_model_fn(
         model_init_rng, dropout_rate, aux_dropout_rate)
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
-      compile_error_workloads = ['fastmri', 'ogbg', 'librispeech_deepspeech', 'wmt']
+      compile_error_workloads = [
+          'fastmri', 'ogbg', 'librispeech_deepspeech', 'wmt'
+      ]
       eager_backend_workloads = ['librispeech_conformer']
       aot_eager_backend_workloads = ['criteo1tb']
       if FLAGS.workload in compile_error_workloads:
-        logging.warning('These workloads cannot be fully compiled under current '
-                        'PyTorch version. Proceeding without `torch.compile`.')
+        logging.warning(
+            'These workloads cannot be fully compiled under current '
+            'PyTorch version. Proceeding without `torch.compile`.')
       elif FLAGS.workload in eager_backend_workloads:
-        logging.warning('These workloads cannot be fully compiled under current '
-                        'PyTorch version. Proceeding with `backend=eager`.')
+        logging.warning(
+            'These workloads cannot be fully compiled under current '
+            'PyTorch version. Proceeding with `backend=eager`.')
         model_params = torch.compile(model_params, backend="eager")
       elif FLAGS.workload in aot_eager_backend_workloads:
-        logging.warning('These workloads cannot be fully compiled under current '
-                        'PyTorch version. Proceeding with `backend=aot_eager`.')
+        logging.warning(
+            'These workloads cannot be fully compiled under current '
+            'PyTorch version. Proceeding with `backend=aot_eager`.')
         model_params = torch.compile(model_params, backend="aot_eager")
       else:
         logging.warning('Performing `torch.compile`.')


### PR DESCRIPTION
Some workloads cause issues when enabling `torch.compile`. This PR implements several if-conditions so that workloads that cause issues for `torch.compile` get automatically disabled (or compiled with a different backend).