### PR TITLE
renaming first vit conv layer to "conv_patch_extract"

### DIFF
--- a/algorithmic_efficiency/param_utils.py
+++ b/algorithmic_efficiency/param_utils.py
@@ -32,7 +32,10 @@ def pytorch_param_types(
       else:
         raise ValueError(f'Unrecognized layer norm parameter: {name}.')
     elif 'conv' in name:
-      param_types[name] = spec.ParameterType.CONV_WEIGHT
+      if 'bias' in name:
+        param_types[name] = spec.ParameterType.BIAS
+      else:
+        param_types[name] = spec.ParameterType.CONV_WEIGHT
     elif ('embedding' in name or 'embed' in name) and 'weight' in name:
       param_types[name] = spec.ParameterType.EMBEDDING
     elif 'attn' in name or 'attention' in name:
@@ -90,7 +93,10 @@ def jax_param_types(param_shapes: spec.ParameterShapeTree,
           raise ValueError(
               f'Unrecognized layer norm parameter: {parent_name}/{name}.')
       elif 'conv' in parent_name:
-        param_types[name] = spec.ParameterType.CONV_WEIGHT
+        if 'bias' in name:
+          param_types[name] = spec.ParameterType.BIAS
+        else:
+          param_types[name] = spec.ParameterType.CONV_WEIGHT
       # Note that this is exact equality, not contained in, because
       # flax.linen.Embed names the embedding parameter "embedding"
       # https://github.com/google/flax/blob/main/flax/linen/linear.py#L604.

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
@@ -127,8 +127,7 @@ class ViT(nn.Module):
         self.patch_size,
         strides=self.patch_size,
         padding='VALID',
-        name='embedding')(
-            x)
+        name='conv_patch_extract')(x)
 
     n, h, w, c = x.shape
     x = jnp.reshape(x, [n, h * w, c])

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/models.py
@@ -127,7 +127,8 @@ class ViT(nn.Module):
         self.patch_size,
         strides=self.patch_size,
         padding='VALID',
-        name='conv_patch_extract')(x)
+        name='conv_patch_extract')(
+            x)
 
     n, h, w, c = x.shape
     x = jnp.reshape(x, [n, h * w, c])

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/models.py
@@ -221,7 +221,7 @@ class ViT(nn.Module):
       rep_size = self.width if self.rep_size is True else self.rep_size
       self.pre_logits = nn.Linear(self.width, rep_size)
 
-    self.embed = nn.Conv2d(
+    self.conv_patch_extract = nn.Conv2d(
         self.channels,
         self.width,
         self.patch_size,
@@ -241,7 +241,7 @@ class ViT(nn.Module):
     self.reset_parameters()
 
   def reset_parameters(self) -> None:
-    init_utils.pytorch_default_init(self.embed)
+    init_utils.pytorch_default_init(self.conv_patch_extract)
 
     if self.rep_size:
       init_utils.pytorch_default_init(self.pre_logits)
@@ -258,7 +258,7 @@ class ViT(nn.Module):
 
   def forward(self, x: spec.Tensor) -> spec.Tensor:
     # Patch extraction.
-    x = self.embed(x)
+    x = self.conv_patch_extract(x)
 
     # Add posemb before adding extra token.
     n, c, h, w = x.shape

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/decode.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/decode.py
@@ -115,16 +115,16 @@ def gather_topk_beams(nested, score_or_log_prob, batch_size, new_beam_size):
 class BeamState:
   """Holds beam search state data."""
   # The position of the decoding loop in the length dimension.
-  cur_index: jnp.DeviceArray  # scalar int32: current decoded length index
+  cur_index: jax.Array  # scalar int32: current decoded length index
   # The active sequence log probabilities and finished sequence scores.
-  live_logprobs: jnp.DeviceArray  # float32: [batch_size, beam_size]
-  finished_scores: jnp.DeviceArray  # float32: [batch_size, beam_size]
+  live_logprobs: jax.Array  # float32: [batch_size, beam_size]
+  finished_scores: jax.Array  # float32: [batch_size, beam_size]
   # The current active-beam-searching and finished sequences.
-  live_seqs: jnp.DeviceArray  # int32: [batch_size, beam_size, max_decode_len]
-  finished_seqs: jnp.DeviceArray  # int32: [batch_size, beam_size,
+  live_seqs: jax.Array  # int32: [batch_size, beam_size, max_decode_len]
+  finished_seqs: jax.Array  # int32: [batch_size, beam_size,
   #                                         max_decode_len]
   # Records which of the 'finished_seqs' is occupied and not a filler slot.
-  finished_flags: jnp.DeviceArray  # bool: [batch_size, beam_size]
+  finished_flags: jax.Array  # bool: [batch_size, beam_size]
   # The current state of the autoregressive decoding caches.
   cache: typing.Any  # Any pytree of arrays, e.g. flax attention Cache object
 

--- a/tests/test_param_types.py
+++ b/tests/test_param_types.py
@@ -29,16 +29,16 @@ from algorithmic_efficiency.workloads.wmt.wmt_pytorch.workload import WmtWorkloa
 # pylint:enable=line-too-long
 
 WORKLOADS = [
-    # 'cifar',
-    # 'criteo1tb',
-    # 'fastmri',
-    # 'imagenet_resnet',
+    'cifar',
+    'criteo1tb',
+    'fastmri',
+    'imagenet_resnet',
     'imagenet_vit',
-    # 'librispeech_conformer',
-    # 'librispeech_deepspeech',
-    # 'mnist',
-    # 'ogbg',
-    # 'wmt',
+    'librispeech_conformer',
+    'librispeech_deepspeech',
+    'mnist',
+    'ogbg',
+    'wmt',
 ]
 
 

--- a/tests/test_param_types.py
+++ b/tests/test_param_types.py
@@ -29,16 +29,16 @@ from algorithmic_efficiency.workloads.wmt.wmt_pytorch.workload import WmtWorkloa
 # pylint:enable=line-too-long
 
 WORKLOADS = [
-    'cifar',
-    'criteo1tb',
-    'fastmri',
-    'imagenet_resnet',
+    # 'cifar',
+    # 'criteo1tb',
+    # 'fastmri',
+    # 'imagenet_resnet',
     'imagenet_vit',
-    'librispeech_conformer',
-    'librispeech_deepspeech',
-    'mnist',
-    'ogbg',
-    'wmt',
+    # 'librispeech_conformer',
+    # 'librispeech_deepspeech',
+    # 'mnist',
+    # 'ogbg',
+    # 'wmt',
 ]
 
 


### PR DESCRIPTION
Will make it simpler to handle param types.

Also fixing `jax.numpy.DeviceArray` deprecation warnings.