### PR TITLE
cache pip deps for CI GH actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -27,6 +28,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -42,6 +44,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -57,6 +60,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -73,6 +77,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -90,6 +95,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -105,6 +111,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -120,6 +127,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -136,6 +144,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -152,6 +161,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -168,6 +178,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install pytest
       run: |
         python -m pip install --upgrade pip
@@ -190,6 +201,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+        cache: 'pip' # Cache pip dependencies.
     - name: Install pytest
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,12 +6,13 @@ jobs:
   fastmri:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -23,12 +24,13 @@ jobs:
   wmt_jax:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -39,12 +41,13 @@ jobs:
   wmt_pytorch:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -55,12 +58,13 @@ jobs:
   imagenet_jax:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -72,12 +76,13 @@ jobs:
   imagenet_pytorch:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -90,12 +95,13 @@ jobs:
   criteo_jax:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -106,12 +112,13 @@ jobs:
   criteo_pytorch:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -122,12 +129,13 @@ jobs:
   speech_jax:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -139,12 +147,13 @@ jobs:
   speech_pytorch:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -156,12 +165,13 @@ jobs:
   ogbg:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
@@ -173,12 +183,13 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install pytest
       run: |
         python -m pip install --upgrade pip
@@ -196,12 +207,13 @@ jobs:
   pytest-baselines:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'pip' # Cache pip dependencies.
+        cache: 'pip' # Cache pip dependencies\.
+        cache-dependency-path: '**/setup.py'
     - name: Install pytest
       run: |
         python -m pip install --upgrade pip

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -11,7 +11,7 @@ python3 submission_runner.py \
     --tuning_search_space=reference_algorithms/development_algorithms/mnist/tuning_search_space.json \
     --num_tuning_trials=3 \
     --experiment_dir=/home/znado/experiment_dir \
-    --experiment_name=baseline 
+    --experiment_name=baseline
 """
 
 import datetime
@@ -47,7 +47,7 @@ from algorithmic_efficiency.pytorch_utils import sync_ddp_time
 tf.config.set_visible_devices([], 'GPU')
 
 # disable only for deepspeech if it works fine for other workloads.
-os.environ["XLA_FLAGS"] = "--xla_gpu_enable_triton_gemm=false"
+os.environ['XLA_FLAGS'] = '--xla_gpu_enable_triton_gemm=false'
 
 # TODO(znado): make a nicer registry of workloads that lookup in.
 BASE_WORKLOADS_DIR = 'algorithmic_efficiency/workloads/'
@@ -627,7 +627,7 @@ def main(_):
 
   # Prevent OOM on librispeech conformer.
   if FLAGS.workload == 'librispeech_conformer':
-    os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.85"
+    os.environ['XLA_PYTHON_CLIENT_MEM_FRACTION'] = '0.85'
 
   # Extend path according to framework.
   workload_metadata['workload_path'] = os.path.join(


### PR DESCRIPTION
The "Install Modules and Run" phase of the checks is faster after they run for the first time and build the pip cache ([first run](https://github.com/mlcommons/algorithmic-efficiency/actions/runs/5649617793/job/15304320788), [second run](https://github.com/mlcommons/algorithmic-efficiency/actions/runs/5649740965/job/15304713846?pr=448)).