### PR TITLE
updating speech targets/timings to reduced budget

### DIFF
--- a/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/workload.py
@@ -19,14 +19,14 @@ class BaseLibrispeechWorkload(spec.Workload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.078477
+    return 0.084952
 
   def has_reached_test_target(self, eval_result: Dict[str, float]) -> bool:
     return eval_result['test/wer'] < self.test_target_value
 
   @property
   def test_target_value(self) -> float:
-    return 0.046973
+    return 0.053000
 
   @property
   def loss_type(self) -> spec.LossType:
@@ -67,13 +67,13 @@ class BaseLibrispeechWorkload(spec.Workload):
 
   @property
   def max_allowed_runtime_sec(self) -> int:
-    return 101_780  # ~28 hours
+    return 61_068  # ~17 hours
 
   @property
   def eval_period_time_sec(self) -> int:
-    return 40 * 60  # 40m
+    return 24 * 60
 
   @property
   def step_hint(self) -> int:
     """Max num steps the baseline algo was given to reach the target."""
-    return 133_333
+    return 80_000

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/workload.py
@@ -5,17 +5,17 @@ class BaseDeepspeechLibrispeechWorkload(workload.BaseLibrispeechWorkload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.1162
+    return 0.118232
 
   @property
   def test_target_value(self) -> float:
-    return 0.068093
+    return 0.073397
 
   @property
   def step_hint(self) -> int:
     """Max num steps the baseline algo was given to reach the target."""
-    return 80_000
+    return 48_000
 
   @property
   def max_allowed_runtime_sec(self) -> int:
-    return 92_509  # ~26 hours
+    return 55_506  # ~15.4 hours


### PR DESCRIPTION
multiplied speech timings by `0.6`, assuming the steps/sec is constant but we reduced the overall step budget by 40%