### PR TITLE
PyTorch Workload Fixes

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
@@ -1,4 +1,5 @@
 """Criteo1TB workload implemented in Jax."""
+
 import functools
 from typing import Dict, Optional, Tuple
 

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
@@ -1,4 +1,5 @@
 """Criteo1TB workload implemented in PyTorch."""
+
 import contextlib
 from typing import Dict, Optional, Tuple
 
@@ -79,6 +80,8 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
     """Only dropout is used."""
     del aux_dropout_rate
     torch.random.manual_seed(rng[0])
+    # Disable cudnn benchmark to avoid OOM errors.
+    torch.backends.cudnn.benchmark = False
     model = DlrmSmall(
         vocab_size=self.vocab_size,
         num_dense_features=self.num_dense_features,

--- a/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/input_pipeline.py
@@ -5,6 +5,7 @@ validation and test split (taking the first half for test and second half for
 validation). See here for the NVIDIA example:
 https://github.com/NVIDIA/DeepLearningExamples/blob/4e764dcd78732ebfe105fc05ea3dc359a54f6d5e/PyTorch/Recommendation/DLRM/preproc/run_spark_cpu.sh#L119.
 """
+
 import functools
 import os
 from typing import Optional

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -2,19 +2,15 @@
 
 import math
 import os
-from typing import Dict, Optional, Tuple, Iterator
+from typing import Dict, Iterator, Optional, Tuple
 
-import jax
+from absl import flags
 import torch.distributed as dist
 
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.criteo1tb import input_pipeline
 
-
-from absl import flags
-
 FLAGS = flags.FLAGS
-
 
 USE_PYTORCH_DDP = 'LOCAL_RANK' in os.environ
 

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/models.py
@@ -281,7 +281,7 @@ class BatchRNN(nn.Module):
 
   def forward(self, inputs, input_paddings):
     inputs = self.bn(inputs, input_paddings)
-    lengths = torch.sum(1 - input_paddings, dim=1).detach().cpu()
+    lengths = torch.sum(1 - input_paddings, dim=1).detach().cpu().numpy()
     packed_inputs = torch.nn.utils.rnn.pack_padded_sequence(
         inputs, lengths, batch_first=True, enforce_sorted=False)
     packed_outputs, _ = self.lstm(packed_inputs)

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -26,17 +26,21 @@ def make_causal_mask(x: Tensor,
   """
   idxs = torch.broadcast_to(
       torch.arange(x.shape[-1], dtype=torch.int32, device=device), x.shape)
-  return torch.greater_equal(idxs.unsqueeze(-1), idxs.unsqueeze(-2)).to(dtype=dtype)
+  return torch.greater_equal(idxs.unsqueeze(-1),
+                             idxs.unsqueeze(-2)).to(dtype=dtype)
 
 
 def make_src_mask(src, inputs_segmentation, nhead):
   """Utility for creating src mask and adjust it for PyTorch Transformer API."""
-  src_mask = torch.mul((src > 0).unsqueeze(-1), (src > 0).unsqueeze(-2)).to(dtype=torch.float32)
+  src_mask = torch.mul((src > 0).unsqueeze(-1),
+                       (src > 0).unsqueeze(-2)).to(dtype=torch.float32)
   # Add segmentation block-diagonal attention mask if using segmented data.
   if inputs_segmentation is not None:
     src_mask = torch.logical_and(
         src_mask,
-        torch.eq(inputs_segmentation.unsqueeze(-1), inputs_segmentation.unsqueeze(-2)).to(dtype=torch.float32))
+        torch.eq(
+            inputs_segmentation.unsqueeze(-1),
+            inputs_segmentation.unsqueeze(-2)).to(dtype=torch.float32))
   # Flip values and ensure numerical stability.
   src_mask = torch.repeat_interleave(
       torch.logical_not(src_mask), repeats=nhead, dim=0)
@@ -55,20 +59,27 @@ def make_tgt_and_memory_mask(tgt,
   Transformer API."""
   if not decode:
     tgt_mask = torch.logical_and(
-        torch.mul((tgt > 0).unsqueeze(-1), (tgt > 0).unsqueeze(-2)).to(dtype=torch.float32),
+        torch.mul((tgt > 0).unsqueeze(-1),
+                  (tgt > 0).unsqueeze(-2)).to(dtype=torch.float32),
         make_causal_mask(tgt, device=tgt.device))
-    memory_mask = torch.mul((tgt > 0).unsqueeze(-1), (src > 0).unsqueeze(-2)).to(dtype=torch.float32)
+    memory_mask = torch.mul((tgt > 0).unsqueeze(-1),
+                            (src > 0).unsqueeze(-2)).to(dtype=torch.float32)
   else:
     tgt_mask = None
-    memory_mask = torch.mul((torch.ones_like(tgt) > 0).unsqueeze(-1), (src > 0).unsqueeze(-2)).to(dtype=torch.float32)
+    memory_mask = torch.mul((torch.ones_like(tgt) > 0).unsqueeze(-1),
+                            (src > 0).unsqueeze(-2)).to(dtype=torch.float32)
   # Add segmentation block-diagonal attention masks if using segmented data.
   if inputs_segmentation is not None:
     tgt_mask = torch.logical_and(
         tgt_mask,
-        torch.eq(targets_segmentation.unsqueeze(-1), targets_segmentation.unsqueeze(-2)).to(dtype=torch.float32))
+        torch.eq(
+            targets_segmentation.unsqueeze(-1),
+            targets_segmentation.unsqueeze(-2)).to(dtype=torch.float32))
     memory_mask = torch.logical_and(
         memory_mask,
-        torch.eq(targets_segmentation.unsqueeze(-1), inputs_segmentation.unsqueeze(-2)).to(dtype=torch.float32))
+        torch.eq(
+            targets_segmentation.unsqueeze(-1),
+            inputs_segmentation.unsqueeze(-2)).to(dtype=torch.float32))
   # Flip values and ensure numerical stability.
   memory_mask = torch.repeat_interleave(
       torch.logical_not(memory_mask), repeats=nhead, dim=0)

--- a/baselines/adamw/pytorch/submission.py
+++ b/baselines/adamw/pytorch/submission.py
@@ -106,7 +106,7 @@ def update_params(workload: spec.Workload,
   optimizer_state['scheduler'].step()
 
   # Log training metrics - loss, grad_norm, batch_size.
-  if global_step <= 100 or global_step % 500 == 0:
+  if global_step <= 10 or global_step % 500 == 0:
     with torch.no_grad():
       parameters = [p for p in current_model.parameters() if p.grad is not None]
       grad_norm = torch.norm(

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,12 +130,12 @@ jax_gpu =
 
 # PyTorch CPU
 pytorch_cpu =
-  torch==2.1.0.dev20230814
+  torch==2.1.0
   torchvision==0.15.2
 
 # PyTorch GPU
 pytorch_gpu =
-  torch==2.1.0.dev20230814+cu118
+  torch==2.1.0+cu118
   torchvision==0.15.2+cu118
 
 # wandb

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,12 +130,12 @@ jax_gpu =
 
 # PyTorch CPU
 pytorch_cpu =
-  torch==2.1.0
+  torch==2.0.1
   torchvision==0.15.2
 
 # PyTorch GPU
 pytorch_gpu =
-  torch==2.1.0+cu118
+  torch==2.0.1+cu118
   torchvision==0.15.2+cu118
 
 # wandb

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,13 +130,13 @@ jax_gpu =
 
 # PyTorch CPU
 pytorch_cpu =
-  torch==2.0.1
-  torchvision==0.15.2
+  torch==2.1.0.dev20230814
+  torchvision==0.15.2.dev20230814
 
 # PyTorch GPU
 pytorch_gpu =
-  torch==2.0.1+cu118
-  torchvision==0.15.2+cu118
+  torch==2.1.0.dev20230814+cu118
+  torchvision==0.15.2.dev20230814+cu118
 
 # wandb
 wandb =

--- a/setup.cfg
+++ b/setup.cfg
@@ -131,12 +131,12 @@ jax_gpu =
 # PyTorch CPU
 pytorch_cpu =
   torch==2.1.0.dev20230814
-  torchvision==0.15.2.dev20230814
+  torchvision==0.15.2
 
 # PyTorch GPU
 pytorch_gpu =
   torch==2.1.0.dev20230814+cu118
-  torchvision==0.15.2.dev20230814+cu118
+  torchvision==0.15.2+cu118
 
 # wandb
 wandb =

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -194,6 +194,7 @@ def train_once(
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
       compile_error_workloads = ['ogbg']
       eager_backend_workloads = ['librispeech_conformer', 'librispeech_deepspeech']
+      dynamic_workloads = ['wmt']
       aot_eager_backend_workloads = ['criteo1tb']
       if FLAGS.workload in compile_error_workloads:
         logging.warning(
@@ -211,7 +212,8 @@ def train_once(
         model_params = torch.compile(model_params, backend='aot_eager')
       else:
         logging.info('Performing `torch.compile`.')
-        model_params = torch.compile(model_params)
+        model_params = torch.compile(model_params, backend='inductor',
+                                     dynamic=FLAGS.workload in dynamic_workloads)
 
   logging.info('Initializing optimizer.')
   with profiler.profile('Initializing optimizer'):

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -194,7 +194,6 @@ def train_once(
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
       compile_error_workloads = ['ogbg']
       eager_backend_workloads = ['librispeech_conformer', 'librispeech_deepspeech']
-      dynamic_workloads = ['wmt']
       aot_eager_backend_workloads = ['criteo1tb']
       if FLAGS.workload in compile_error_workloads:
         logging.warning(

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -192,7 +192,7 @@ def train_once(
     model_params, model_state = workload.init_model_fn(
         model_init_rng, dropout_rate, aux_dropout_rate)
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
-      compile_error_workloads = ['ogbg', 'wmt']
+      compile_error_workloads = ['ogbg']
       eager_backend_workloads = ['librispeech_conformer', 'librispeech_deepspeech']
       aot_eager_backend_workloads = ['criteo1tb']
       if FLAGS.workload in compile_error_workloads:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -389,9 +389,6 @@ def train_once(
 
           if FLAGS.framework == 'pytorch' and torch.cuda.is_available():
             # Clean up the GPU cache after evaluation.
-            # See https://github.com/pytorch/pytorch/issues/99835.
-            torch._C._cuda_clearCublasWorkspaces()
-            torch._dynamo.reset()
             gc.collect()
             torch.cuda.empty_cache()
             logging.info(f'Released all unoccupied cached memory.')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -212,7 +212,7 @@ def train_once(
         model_params = torch.compile(model_params, backend='aot_eager')
       else:
         logging.info('Performing `torch.compile`.')
-        model_params = torch.compile(model_params, backend='inductor',
+        model_params = torch.compile(model_params,
                                      dynamic=FLAGS.workload in dynamic_workloads)
 
   logging.info('Initializing optimizer.')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -192,8 +192,8 @@ def train_once(
     model_params, model_state = workload.init_model_fn(
         model_init_rng, dropout_rate, aux_dropout_rate)
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
-      compile_error_workloads = ['ogbg', 'librispeech_deepspeech', 'wmt']
-      eager_backend_workloads = ['librispeech_conformer']
+      compile_error_workloads = ['ogbg', 'wmt']
+      eager_backend_workloads = ['librispeech_conformer', 'librispeech_deepspeech']
       aot_eager_backend_workloads = ['criteo1tb']
       if FLAGS.workload in compile_error_workloads:
         logging.warning(

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -393,7 +393,7 @@ def train_once(
             # Clean up the GPU cache after evaluation.
             gc.collect()
             torch.cuda.empty_cache()
-            logging.info(f'Released all unoccupied cached memory.')
+            logging.info('Released all unoccupied cached memory.')
 
           logging_end_time = get_time()
           train_state['accumulated_logging_time'] += (

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -15,12 +15,12 @@ python3 submission_runner.py \
 """
 
 import datetime
+import gc
 import importlib
 import json
 import os
 import struct
 import time
-import gc
 from typing import Any, Dict, Optional, Tuple
 
 from absl import app
@@ -193,7 +193,9 @@ def train_once(
         model_init_rng, dropout_rate, aux_dropout_rate)
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
       compile_error_workloads = ['ogbg']
-      eager_backend_workloads = ['librispeech_conformer', 'librispeech_deepspeech']
+      eager_backend_workloads = [
+          'librispeech_conformer', 'librispeech_deepspeech'
+      ]
       aot_eager_backend_workloads = ['criteo1tb']
       if FLAGS.workload in compile_error_workloads:
         logging.warning(

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -212,8 +212,7 @@ def train_once(
         model_params = torch.compile(model_params, backend='aot_eager')
       else:
         logging.info('Performing `torch.compile`.')
-        model_params = torch.compile(model_params,
-                                     dynamic=FLAGS.workload in dynamic_workloads)
+        model_params = torch.compile(model_params)
 
   logging.info('Initializing optimizer.')
   with profiler.profile('Initializing optimizer'):


### PR DESCRIPTION
This PR fixes several issues with PyTorch workloads. 

1. Criteo OOM issues are fixed on the nightlies (#425). However, it still shows an OOM error on the current version (2.0.1). 
2. WMT workload now works with `torch.compile` (both nightly and 2.0.1). It slightly improves the timing results.
3. Deepspeech workload now works with `torch.compile` (both nightly and 2.0.1). It slightly improves the timing results.
4. Minor style fixes.

Note: OGBG also runs with `torch.compile` on nightly but somehow slows down the training. The previous issue was that we used jgraph as inputs (instead of Tensors). So I am keeping its default behavior to be "not compiled". 