### PR TITLE
Refactor of `MultiheadAttention` module in PyTorch WMT workload

### DIFF
--- a/algorithmic_efficiency/param_utils.py
+++ b/algorithmic_efficiency/param_utils.py
@@ -41,6 +41,10 @@ def pytorch_param_types(
     elif 'attn' in name or 'attention' in name:
       if 'bias' in name:
         param_types[name] = spec.ParameterType.ATTENTION_BIAS
+      elif 'in_proj' in name:
+        param_types[name] = spec.ParameterType.ATTENTION_QKV
+      elif 'kv_proj' in name:
+        param_types[name] = spec.ParameterType.ATTENTION_KV
       elif 'k_proj' in name or 'key' in name:
         param_types[name] = spec.ParameterType.ATTENTION_K
       elif 'q_proj' in name or 'query' in name:
@@ -51,8 +55,6 @@ def pytorch_param_types(
         param_types[name] = spec.ParameterType.ATTENTION_OUT
       elif 'scale' in name:
         param_types[name] = spec.ParameterType.WEIGHT
-      elif 'in_proj_weight' in name:
-        param_types[name] = spec.ParameterType.ATTENTION_QKV
       else:
         raise ValueError(f'Unrecognized attention parameter: {name}.')
     elif 'bias' in name:

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -39,9 +39,10 @@ class ParameterType(enum.Enum):
   ATTENTION_V = 10
   ATTENTION_OUT = 11
   ATTENTION_QKV = 12  # This is used for implementations that fuse QKV together.
-  # We need to split this out because otherwise fused QKV models will have a
-  # different number of biases.
-  ATTENTION_BIAS = 13
+  ATTENTION_KV = 13  # This is used for implementations that fuse KV together.
+  # We sometimes need to split this out because otherwise fused models will have
+  # a different number of biases.
+  ATTENTION_BIAS = 14
 
 
 # Of course, Tensor knows its shape and dtype.

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -939,8 +939,8 @@ class MultiheadAttention(nn.Module):
       # not the remaining zero elements.
       if attn_mask is not None:
         raise ValueError('Attention mask has to be None for decode == True.')
-      attn_mask = (torch.arange(max_length, device=k.device)
-                   >= cache_index).reshape(1, max_length)
+      attn_mask = (torch.arange(max_length, device=k.device) >=
+                   cache_index).reshape(1, max_length)
 
     # Update sequence length to account for complete sequence.
     seq_len = k.size(1)

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/models.py
@@ -542,7 +542,7 @@ class TransformerEncoderLayer(nn.Module):
     return self.dropout2(x)
 
 
-# Modified to use cache for autoregressive decoding and custom 
+# Modified to use cache for autoregressive decoding and custom
 # MultiheadAttention modules.
 class TransformerDecoder(nn.Module):
   r"""TransformerDecoder is a stack of N decoder layers
@@ -626,7 +626,7 @@ class TransformerDecoder(nn.Module):
     return output
 
 
-# Modified to use cache for autoregressive decoding and custom 
+# Modified to use cache for autoregressive decoding and custom
 # MultiheadAttention modules.
 class TransformerDecoderLayer(nn.Module):
   r"""TransformerDecoderLayer is made up of self-attn, multi-head-attn and
@@ -939,8 +939,8 @@ class MultiheadAttention(nn.Module):
       # not the remaining zero elements.
       if attn_mask is not None:
         raise ValueError('Attention mask has to be None for decode == True.')
-      attn_mask = (torch.arange(max_length, device=k.device) >=
-                   cache_index).reshape(1, max_length)
+      attn_mask = (torch.arange(max_length, device=k.device)
+                   >= cache_index).reshape(1, max_length)
 
     # Update sequence length to account for complete sequence.
     seq_len = k.size(1)


### PR DESCRIPTION
This is supposed to help with #467. I refactored the `MultiheadAttention` module to remove a lot of unnecessary code and fused the parameter matrices for the linear input projection, which leads to a slight improvement in speed.

**Timing results**
(note that all timings but the one of this refactor alone are just run once and there is probably a significant variance over multiple runs)

Original score (Juhan's timing): 4379
Score with this refactor: 4196/4253/4265
Score with `torch.compile` (Juhan's timing): 4236
Score with this refactor and `torch.compile`: 4163
Score with `torch.compile` and nightly (Juhan's timing): 4161
Score with this refactor, `torch.compile`, and nightly: error -> the last validation set batch size is different which causes this error. Can easily be fixed but since we are going to stick to stable for now I would defer making any changes until we decide to upgrade.

Clearly, all improvements are very minor and are not enough to bridge the gap to Jax.

@pomonam Can you please review my refactor of the `MultiheadAttention` module?
@znado Can you please review my changes to the `test_param_types` test?

*Note: This breaks the traindiffs code for WMT, will be fixed in a follow up PR.*