### PR TITLE
Revert "Update pytorch package to 2.1.0 nightly 20230820"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=fastmri     --framework=pytorch     --global_batch_size=8     --submission_path=reference_algorithms/target_setting_algorithms/pytorch_momentum.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/fastmri/tuning_search_space.json
@@ -34,7 +34,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=wmt     --framework=jax     --global_batch_size=2     --submission_path=reference_algorithms/target_setting_algorithms/jax_nadamw.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/wmt/tuning_search_space.json
@@ -51,7 +51,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=wmt     --framework=pytorch     --global_batch_size=2     --submission_path=reference_algorithms/target_setting_algorithms/pytorch_nadamw.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/wmt/tuning_search_space.json
@@ -68,7 +68,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=imagenet_vit     --framework=jax     --global_batch_size=2     --submission_path=reference_algorithms/target_setting_algorithms/jax_adamw.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/imagenet_vit/tuning_search_space.json
@@ -86,7 +86,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=imagenet_resnet     --framework=pytorch     --global_batch_size=2     --submission_path=reference_algorithms/target_setting_algorithms/pytorch_momentum.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/imagenet_resnet/tuning_search_space.json
@@ -105,7 +105,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=criteo1tb_test     --framework=jax     --global_batch_size=1     --submission_path=reference_algorithms/target_setting_algorithms/jax_adamw.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/criteo1tb/tuning_search_space.json
@@ -122,7 +122,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=criteo1tb_test     --framework=pytorch     --global_batch_size=1     --submission_path=reference_algorithms/target_setting_algorithms/pytorch_adamw.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/criteo1tb/tuning_search_space.json
@@ -139,7 +139,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=librispeech_conformer     --framework=jax     --global_batch_size=2     --submission_path=reference_algorithms/target_setting_algorithms/jax_adamw.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/librispeech_conformer/tuning_search_space.json
@@ -157,7 +157,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=librispeech_deepspeech     --framework=pytorch     --global_batch_size=2     --submission_path=reference_algorithms/target_setting_algorithms/pytorch_adamw.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/librispeech_deepspeech/tuning_search_space.json
@@ -175,7 +175,7 @@ jobs:
     - name: Install Modules and Run
       run: |
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
         pip install .[full]
         pip install -e .
         python tests/reference_algorithm_tests.py --workload=ogbg     --framework=pytorch     --global_batch_size=8     --submission_path=reference_algorithms/target_setting_algorithms/pytorch_nesterov.py     --tuning_search_space=reference_algorithms/target_setting_algorithms/ogbg/tuning_search_space.json
@@ -196,7 +196,7 @@ jobs:
         pip install pytest
         pip install .[full]
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
     - name: Run pytest tests
       run: |
         pytest -vx tests/version_test.py
@@ -220,7 +220,7 @@ jobs:
         pip install pytest
         pip install .[full]
         pip install .[jax_cpu]
-        pip install .[pytorch_cpu] --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+        pip install .[pytorch_cpu]
     - name: Run baseline tests
       run: |
         pytest --verbosity=1 tests/test_baselines.py

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can install this package and dependences in a [python virtual environment](#
   *TL;DR to install the Jax version for GPU run:*
 
    ```bash
-   pip3 install -e '.[pytorch_cpu]' --index-url 'https://download.pytorch.org/whl/nightly/cpu'
+   pip3 install -e '.[pytorch_cpu]'
    pip3 install -e '.[jax_gpu]' -f 'https://storage.googleapis.com/jax-releases/jax_cuda_releases.html'
    pip3 install -e '.[full]'
    ```
@@ -47,7 +47,7 @@ You can install this package and dependences in a [python virtual environment](#
 
    ```bash
    pip3 install -e '.[jax_cpu]'
-   pip3 install -e '.[pytorch_gpu]' --index-url 'https://download.pytorch.org/whl/nightly/cu118'
+   pip3 install -e '.[pytorch_gpu]' -f 'https://download.pytorch.org/whl/torch_stable.html'
    pip3 install -e '.[full]'
    ```
 ##  Python virtual environment

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,18 +43,17 @@ RUN if [ "$framework" = "jax" ] ; then \
         echo "Installing Jax GPU" \
         && cd algorithmic-efficiency \
         && pip install -e '.[jax_gpu]' -f 'https://storage.googleapis.com/jax-releases/jax_cuda_releases.html' \
-        && pip install -e '.[pytorch_cpu]' --index-url 'https://download.pytorch.org/whl/nightly/cpu'; \
+        && pip install -e '.[pytorch_cpu]' -f 'https://download.pytorch.org/whl/torch_stable.html'; \
     elif [ "$framework" = "pytorch" ] ; then \
         echo "Installing Pytorch GPU" \
         && cd algorithmic-efficiency \
         && pip install -e '.[jax_cpu]' \
-        # && pip install -e '.[pytorch_gpu]' -f 'https://download.pytorch.org/whl/torch_stable.html'; \
-        && pip install -e '.[pytorch_gpu]' --index-url 'https://download.pytorch.org/whl/nightly/cu118'; \
+        && pip install -e '.[pytorch_gpu]' -f 'https://download.pytorch.org/whl/torch_stable.html'; \
     elif [ "$framework" = "both" ] ; then \
         echo "Installing Jax GPU and Pytorch GPU" \
         && cd algorithmic-efficiency \
         && pip install -e '.[jax_gpu]' -f 'https://storage.googleapis.com/jax-releases/jax_cuda_releases.html' \
-        && pip install -e '.[pytorch_gpu]' --index-url 'https://download.pytorch.org/whl/nightly/cu118'; \
+        && pip install -e '.[pytorch_gpu]' -f 'https://download.pytorch.org/whl/torch_stable.html'; \
     else \
         echo "Invalid build-arg $framework: framework should be either jax, pytorch or both." >&2 \
         && exit 1 ; \

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,13 +130,13 @@ jax_gpu =
 
 # PyTorch CPU
 pytorch_cpu =
-  torch==2.1.0.dev20230820
-  torchvision==0.16.0.dev20230821
+  torch==2.0.1
+  torchvision==0.15.2
 
 # PyTorch GPU
 pytorch_gpu =
-  torch==2.1.0.dev20230820+cu118
-  torchvision==0.16.0.dev20230821+cu118
+  torch==2.0.1+cu118
+  torchvision==0.15.2+cu118
 
 # wandb
 wandb =


### PR DESCRIPTION
Reverts mlcommons/algorithmic-efficiency#492 
Upgrading to torch nightly raises new issues for deepspeech and ViT.
https://github.com/mlcommons/algorithmic-efficiency/issues/496
https://github.com/mlcommons/algorithmic-efficiency/issues/498

Until these are resolved let's hold off upgrading to torch nightly in our main branch.