### PR TITLE
Add RNG seed flag to submission runner

### DIFF
--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -275,8 +275,8 @@ def get_meta_data(workload: spec.Workload) -> dict:
   return meta_data
 
 
-def save_meta_data(workload: spec.Workload, 
-                   rng_seed: int, 
+def save_meta_data(workload: spec.Workload,
+                   rng_seed: int,
                    meta_file_name: str):
   meta_data = get_meta_data(workload)
   meta_data.update({'rng_seed': rng_seed})

--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -279,7 +279,7 @@ def save_meta_data(workload: spec.Workload,
                    rng_seed: int, 
                    meta_file_name: str):
   meta_data = get_meta_data(workload)
-  meta_data.update({'rng_seed': rng_seed})
+  # meta_data.update({'rng_seed': rng_seed})
   write_json(meta_file_name, meta_data)
 
 class MetricLogger(object):

--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -275,6 +275,14 @@ def get_meta_data(workload: spec.Workload) -> dict:
   return meta_data
 
 
+def save_meta_data(workload: spec.Workload, 
+                   rng_seed: int, 
+                   preemption_count: int):
+  meta_data = get_meta_data(workload)
+  meta_data.update({'rng_seed': rng_seed})
+  meta_file_name = os.path.join(log_dir, f'meta_data_{preemption_count}.json')
+  write_json(meta_file_name, meta_data)
+
 class MetricLogger(object):
   """Used to log all measurements during training.
 

--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -275,12 +275,11 @@ def get_meta_data(workload: spec.Workload) -> dict:
   return meta_data
 
 
-def save_meta_data(workload: spec.Workload,
-                   rng_seed: int,
-                   meta_file_name: str):
+def save_meta_data(workload: spec.Workload, rng_seed: int, meta_file_name: str):
   meta_data = get_meta_data(workload)
   meta_data.update({'rng_seed': rng_seed})
   write_json(meta_file_name, meta_data)
+
 
 class MetricLogger(object):
   """Used to log all measurements during training.

--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -279,7 +279,7 @@ def save_meta_data(workload: spec.Workload,
                    rng_seed: int, 
                    meta_file_name: str):
   meta_data = get_meta_data(workload)
-  # meta_data.update({'rng_seed': rng_seed})
+  meta_data.update({'rng_seed': rng_seed})
   write_json(meta_file_name, meta_data)
 
 class MetricLogger(object):

--- a/algorithmic_efficiency/logger_utils.py
+++ b/algorithmic_efficiency/logger_utils.py
@@ -277,10 +277,9 @@ def get_meta_data(workload: spec.Workload) -> dict:
 
 def save_meta_data(workload: spec.Workload, 
                    rng_seed: int, 
-                   preemption_count: int):
+                   meta_file_name: str):
   meta_data = get_meta_data(workload)
   meta_data.update({'rng_seed': rng_seed})
-  meta_file_name = os.path.join(log_dir, f'meta_data_{preemption_count}.json')
   write_json(meta_file_name, meta_data)
 
 class MetricLogger(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,6 +115,7 @@ jax_core_deps =
   # Todo(kasimbeg): verify if this is necessary after we
   # upgrade jax.
   chex==0.1.7
+  ml_dtypes==0.2.0
 
 # JAX CPU
 jax_cpu =

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -273,7 +273,7 @@ def train_once(
          checkpoint_dir=log_dir)
     meta_file_name = os.path.join(log_dir, f'meta_data_{preemption_count}.json')
     logging.info(f'Saving meta data to {meta_file_name}.')
-    logger_utils.save_meta_data(workload, rng_seed, preemption_count)
+    logger_utils.save_meta_data(workload, rng, preemption_count)
     flag_file_name = os.path.join(log_dir, f'flags_{preemption_count}.json')
     logging.info(f'Saving flags to {flag_file_name}.')
     logger_utils.write_json(flag_file_name, flags.FLAGS.flag_values_dict())

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -133,10 +133,11 @@ flags.DEFINE_boolean(
 flags.DEFINE_boolean('save_checkpoints',
                      True,
                      'Whether or not to checkpoint the model at every eval.')
-flags.DEFINE_integer('rng_seed',
-                     None,
-                     'Value of rng seed. If None, a random seed will'
-                     'be generated from hardware.')
+flags.DEFINE_integer(
+    'rng_seed',
+    None,
+    'Value of rng seed. If None, a random seed will'
+    'be generated from hardware.')
 FLAGS = flags.FLAGS
 USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -177,6 +177,7 @@ def train_once(
     update_params: spec.UpdateParamsFn,
     data_selection: spec.DataSelectionFn,
     hyperparameters: Optional[spec.Hyperparameters],
+    rng_seed: int, 
     rng: spec.RandomState,
     profiler: Profiler,
     max_global_steps: int = None,
@@ -273,7 +274,7 @@ def train_once(
          checkpoint_dir=log_dir)
     meta_file_name = os.path.join(log_dir, f'meta_data_{preemption_count}.json')
     logging.info(f'Saving meta data to {meta_file_name}.')
-    logger_utils.save_meta_data(workload, rng, preemption_count)
+    logger_utils.save_meta_data(workload, rng_seed, preemption_count)
     flag_file_name = os.path.join(log_dir, f'flags_{preemption_count}.json')
     logging.info(f'Saving flags to {flag_file_name}.')
     logger_utils.write_json(flag_file_name, flags.FLAGS.flag_values_dict())
@@ -533,7 +534,9 @@ def score_submission_on_workload(workload: spec.Workload,
                                      data_dir, imagenet_v2_data_dir,
                                      init_optimizer_state,
                                      update_params, data_selection,
-                                     hyperparameters, rng,
+                                     hyperparameters, 
+                                     rng_seed,
+                                     rng,
                                      profiler,
                                      max_global_steps,
                                      tuning_dir_name,
@@ -559,7 +562,7 @@ def score_submission_on_workload(workload: spec.Workload,
           workload, global_batch_size, global_eval_batch_size,
           data_dir, imagenet_v2_data_dir,
           init_optimizer_state, update_params, data_selection,
-          None, rng, profiler, max_global_steps, log_dir,
+          None, rng_seed, rng, profiler, max_global_steps, log_dir,
           save_checkpoints=save_checkpoints)
   return score
 

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -271,6 +271,7 @@ def train_once(
          global_step,
          preemption_count,
          checkpoint_dir=log_dir)
+    meta_file_name = os.path.join(log_dir, f'meta_data_{preemption_count}.json')
     logging.info(f'Saving meta data to {meta_file_name}.')
     logger_utils.save_meta_data(workload, rng_seed, preemption_count)
     flag_file_name = os.path.join(log_dir, f'flags_{preemption_count}.json')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -134,7 +134,7 @@ flags.DEFINE_boolean('save_checkpoints',
                      True,
                      'Whether or not to checkpoint the model at every eval.')
 flags.DEFINE_integer('rng_seed',
-                     None, 
+                     None,
                      'Value of rng seed. If None, a random seed will'
                      'be generated from hardware.')
 FLAGS = flags.FLAGS
@@ -177,7 +177,7 @@ def train_once(
     update_params: spec.UpdateParamsFn,
     data_selection: spec.DataSelectionFn,
     hyperparameters: Optional[spec.Hyperparameters],
-    rng_seed: int, 
+    rng_seed: int,
     rng: spec.RandomState,
     profiler: Profiler,
     max_global_steps: int = None,
@@ -534,7 +534,7 @@ def score_submission_on_workload(workload: spec.Workload,
                                      data_dir, imagenet_v2_data_dir,
                                      init_optimizer_state,
                                      update_params, data_selection,
-                                     hyperparameters, 
+                                     hyperparameters,
                                      rng_seed,
                                      rng,
                                      profiler,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -554,7 +554,8 @@ def score_submission_on_workload(workload: spec.Workload,
       logging.info(f'Total number of evals: {num_evals}')
       logging.info('=' * 20)
   else:
-    rng_seed = struct.unpack('q', os.urandom(8))[0]
+    if not rng_seed:
+      rng_seed = struct.unpack('q', os.urandom(8))[0]
     rng = prng.PRNGKey(rng_seed)
     # If the submission is responsible for tuning itself, we only need to run it
     # once and return the total time.


### PR DESCRIPTION
For https://github.com/mlcommons/algorithmic-efficiency/issues/279. 

Add rng_seed flag to submission runner.
Save rng_seed in metadata.json file.

Also pin ml_dtypes version as temporary work around for jax dependency issue https://github.com/google/jax/issues/17693. 