### PR TITLE
Change padding for Deepspeech LSTM layer

### DIFF
--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -144,7 +144,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       }
 
       padded_batch = data_utils.shard_and_maybe_pad_np(
-          numpy_batch, padding_value=1.0, global_batch_size=global_batch_size)
+          numpy_batch, padding_value=1.0)
       yield padded_batch
 
   # Does NOT apply regularization, which is left to the submitter to do in


### PR DESCRIPTION
Remove global_batch_size arg in call to shard_and_maybe_pad batch call. This will result in the final batch of the validation and test sets for librispeech being just padded just enough so that it can be split equally amongst the devices. So we will not have device batches containing all padding.  Workaround for https://github.com/mlcommons/algorithmic-efficiency/issues/523.