### PR TITLE
Set criteo test targets based on external runs

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -35,14 +35,14 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.123649
+    return 0.12364747752808988
 
   def has_reached_test_target(self, eval_result: Dict[str, float]) -> bool:
     return eval_result['test/loss'] < self.test_target_value
 
   @property
   def test_target_value(self) -> float:
-    return 0.126060
+    return 0.1267424139736351
 
   @property
   def loss_type(self) -> spec.LossType:

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -35,14 +35,14 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.12364747752808988
+    return 0.123647
 
   def has_reached_test_target(self, eval_result: Dict[str, float]) -> bool:
     return eval_result['test/loss'] < self.test_target_value
 
   @property
   def test_target_value(self) -> float:
-    return 0.1267424139736351
+    return 0.126742
 
   @property
   def loss_type(self) -> spec.LossType:

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -35,14 +35,14 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.123647
+    return 0.123735
 
   def has_reached_test_target(self, eval_result: Dict[str, float]) -> bool:
     return eval_result['test/loss'] < self.test_target_value
 
   @property
   def test_target_value(self) -> float:
-    return 0.126742
+    return 0.126041
 
   @property
   def loss_type(self) -> spec.LossType:


### PR DESCRIPTION
Recalibrate Criteo1TB targets based on external runs. 

For the record the target setting procedure: 
1. order the 20 trials in terms of the best validation error achieved by each target
2. Validation Target = median of the above list (i.e. average of 10th and 11th)
3. Take the 1st 10 trials in the above list (i.e. the 10 trials that achieve the validation target)
4. In this set of 10 trials, reorder the trials by the best test error achieved by each trial
5. Set the test target to be the highest(worst) test error in the above list

```
---- SORTED MEASUREMENTS BY VALIDATION METRIC ----
+------------------------------------------------------------------+---------------+----------------+---------------------+---------------+
|                                                                  | metric_name   |   train/metric |   validation/metric |   test/metric |
|------------------------------------------------------------------+---------------+----------------+---------------------+---------------|
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-22-47-30.log | loss          |       0.12046  |            0.123634 |      0.125946 |
| logs/target_setting_criteo/criteo1tb_jax_10-03-2023-20-02-40.log | loss          |       0.121351 |            0.123655 |      0.125971 |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-12-04-56.log | loss          |       0.11975  |            0.123665 |      0.125949 |
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-06-54-36.log | loss          |       0.120754 |            0.123671 |      0.12598  |
| logs/target_setting_criteo/criteo1tb_jax_10-03-2023-22-38-08.log | loss          |       0.122095 |            0.123684 |      0.126021 |
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-14-41-03.log | loss          |       0.120848 |            0.123703 |      0.126031 |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-14-40-25.log | loss          |       0.121955 |            0.123707 |      0.125992 |
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-01-13-37.log | loss          |       0.120357 |            0.123722 |      0.126041 |
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-20-12-01.log | loss          |       0.120846 |            0.123729 |      0.126031 |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-01-33-00.log | loss          |       0.121191 |            0.123734 |      0.126    |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-09-24-27.log | loss          |       0.12155  |            0.123736 |      0.126038 |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-19-46-24.log | loss          |       0.121923 |            0.123739 |      0.126067 |
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-03-59-06.log | loss          |       0.120963 |            0.123757 |      0.126056 |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-22-26-53.log | loss          |       0.120403 |            0.123761 |      0.126054 |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-17-15-55.log | loss          |       0.121335 |            0.123768 |      0.126049 |
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-17-36-32.log | loss          |       0.122189 |            0.123771 |      0.126076 |
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-12-05-34.log | loss          |       0.121143 |            0.123805 |      0.126168 |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-06-43-58.log | loss          |       0.122832 |            0.123815 |      0.126107 |
| logs/target_setting_criteo/criteo1tb_jax_10-05-2023-04-08-29.log | loss          |       0.1208   |            0.123823 |      0.126119 |
| logs/target_setting_criteo/criteo1tb_jax_10-04-2023-09-30-06.log | loss          |       0.121909 |            0.123828 |      0.126141 |
+------------------------------------------------------------------+---------------+----------------+---------------------+---------------+
VALIDATION TARGET: 0.12373518962322225
TEST TARGET: 0.12604096842105264
```