### PR TITLE
update fastmri targets

### DIFF
--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -19,14 +19,14 @@ class BaseFastMRIWorkload(spec.Workload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.7344
+    return 0.727120
 
   def has_reached_test_target(self, eval_result: float) -> bool:
     return eval_result['test/ssim'] > self.test_target_value
 
   @property
   def test_target_value(self) -> float:
-    return 0.741652
+    return 0.744295
 
   @property
   def loss_type(self) -> spec.LossType:

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -19,14 +19,14 @@ class BaseFastMRIWorkload(spec.Workload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.726965
+    return 0.726999
 
   def has_reached_test_target(self, eval_result: float) -> bool:
     return eval_result['test/ssim'] > self.test_target_value
 
   @property
   def test_target_value(self) -> float:
-    return 0.744150
+    return 0.744254
 
   @property
   def loss_type(self) -> spec.LossType:

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -19,14 +19,14 @@ class BaseFastMRIWorkload(spec.Workload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.727120
+    return 0.726965
 
   def has_reached_test_target(self, eval_result: float) -> bool:
     return eval_result['test/ssim'] > self.test_target_value
 
   @property
   def test_target_value(self) -> float:
-    return 0.744295
+    return 0.744150
 
   @property
   def loss_type(self) -> spec.LossType:


### PR DESCRIPTION
Reset FastMRI targets. Our internal measurements used the validation metric measured over the full original validation set as opposed to the split validation set for validation and testing.
```
---- SORTED MEASUREMENTS BY VALIDATION METRIC ----
+-------------------------------------------------------------------------+---------------+----------------+---------------------+---------------+
|                                                                         | metric_name   |   train/metric |   validation/metric |   test/metric |
|-------------------------------------------------------------------------+---------------+----------------+---------------------+---------------|
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-07-26-28.log | ssim          |       0.748013 |            0.725668 |      0.749724 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-09-27-43.log | ssim          |       0.750506 |            0.726441 |      0.743615 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-01-25-23.log | ssim          |       0.746487 |            0.726512 |      0.750555 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-07-27-20.log | ssim          |       0.7517   |            0.726562 |      0.74373  |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-01-25-50.log | ssim          |       0.748298 |            0.726674 |      0.7508   |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-07-26-54.log | ssim          |       0.751501 |            0.726879 |      0.751037 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-09-27-16.log | ssim          |       0.752028 |            0.726959 |      0.751113 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-03-26-36.log | ssim          |       0.749248 |            0.726965 |      0.74415  |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-23-44-35.log | ssim          |       0.749099 |            0.726981 |      0.751137 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-25-2023-03-45-19.log | ssim          |       0.748694 |            0.726984 |      0.751104 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-03-25-44.log | ssim          |       0.74972  |            0.727013 |      0.751143 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-19-43-49.log | ssim          |       0.749071 |            0.727047 |      0.751163 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-25-2023-01-44-57.log | ssim          |       0.751292 |            0.727059 |      0.751161 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-01-26-14.log | ssim          |       0.750565 |            0.72706  |      0.744254 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-05-26-33.log | ssim          |       0.751529 |            0.72708  |      0.751179 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-05-26-58.log | ssim          |       0.753475 |            0.727101 |      0.744284 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-21-44-11.log | ssim          |       0.750792 |            0.727153 |      0.751206 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-05-26-06.log | ssim          |       0.751039 |            0.727155 |      0.751265 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-03-26-12.log | ssim          |       0.74932  |            0.727284 |      0.751413 |
| logs/target_resetting_fastmri_fixed/fastmri_jax_10-24-2023-09-26-50.log | ssim          |       0.75096  |            0.727433 |      0.751485 |
+-------------------------------------------------------------------------+---------------+----------------+---------------------+---------------+
VALIDATION TARGET: 0.7269988137815665
TEST TARGET: 0.7442540027881528
```