### PR TITLE
FastMRI correct num_test_examples

### DIFF
--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -51,7 +51,7 @@ class BaseFastMRIWorkload(spec.Workload):
 
   @property
   def num_test_examples(self) -> int:
-    return 3581
+    return 3548
 
   @property
   def eval_batch_size(self) -> int:


### PR DESCRIPTION
We had an incorrect number for number test examples checked in externally and internally and have verified at least 2 ways that this is the correct number.