### PR TITLE
Remove unused hparam from ogbg target-setting run config

### DIFF
--- a/reference_algorithms/target_setting_algorithms/ogbg/tuning_search_space.json
+++ b/reference_algorithms/target_setting_algorithms/ogbg/tuning_search_space.json
@@ -9,11 +9,6 @@
             0.9449369031171744
         ]
     },
-    "beta2": {
-        "feasible_points": [
-            0.9978504782314613
-        ]
-    },
     "warmup_steps": {
         "feasible_points": [
             3000


### PR DESCRIPTION
See the title; I believe this was introduced [here](https://github.com/mlcommons/algorithmic-efficiency/commit/a9b939ee77630d012b4cd7f11925bfad68330a68).