### PR TITLE
Upgrade torch and torchvision

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -131,13 +131,13 @@ jax_gpu =
 
 # PyTorch CPU
 pytorch_cpu =
-  torch==2.0.1
-  torchvision==0.15.2
+  torch==2.1.0
+  torchvision=0.16.0
 
 # PyTorch GPU
 pytorch_gpu =
-  torch==2.0.1+cu118
-  torchvision==0.15.2+cu118
+  torch==2.1.0+cu118
+  torchvision==0.16.0+cu118
 
 # wandb
 wandb =

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,7 +132,7 @@ jax_gpu =
 # PyTorch CPU
 pytorch_cpu =
   torch==2.1.0
-  torchvision=0.16.0
+  torchvision==0.16.0
 
 # PyTorch GPU
 pytorch_gpu =

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -220,7 +220,7 @@ def train_once(
     model_params, model_state = workload.init_model_fn(
         model_init_rng, dropout_rate, aux_dropout_rate)
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
-      compile_error_workloads = ['librispeech_conformer', 'ogbg', 'criteo1tb']
+      compile_error_workloads = ['librispeech_conformer', 'ogbg', 'criteo1tb', 'imagenet_vit']
       eager_backend_workloads = ['librispeech_deepspeech']
       aot_eager_backend_workloads = []
       if FLAGS.workload in compile_error_workloads:
@@ -603,7 +603,10 @@ def main(_):
 
   # Prevent OOM on librispeech conformer.
   if FLAGS.workload == 'librispeech_conformer':
-    os.environ['XLA_PYTHON_CLIENT_MEM_FRACTION'] = '0.85'
+    if FLAGS.framework = 'jax'
+      os.environ['XLA_PYTHON_CLIENT_MEM_FRACTION'] = '0.85'
+    elif FLAGS.framework == 'pytorch' and torch.cuda.is_available():
+      torch.cuda.memory._set_allocator_settings('expandable_segments:True')
 
   if FLAGS.set_pytorch_max_split_size:
     os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'max_split_size_mb:256'

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -603,7 +603,7 @@ def main(_):
 
   # Prevent OOM on librispeech conformer.
   if FLAGS.workload == 'librispeech_conformer':
-    if FLAGS.framework = 'jax'
+    if FLAGS.framework == 'jax':
       os.environ['XLA_PYTHON_CLIENT_MEM_FRACTION'] = '0.85'
     elif FLAGS.framework == 'pytorch' and torch.cuda.is_available():
       torch.cuda.memory._set_allocator_settings('expandable_segments:True')

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -220,7 +220,9 @@ def train_once(
     model_params, model_state = workload.init_model_fn(
         model_init_rng, dropout_rate, aux_dropout_rate)
     if FLAGS.framework == 'pytorch' and FLAGS.torch_compile:
-      compile_error_workloads = ['librispeech_conformer', 'ogbg', 'criteo1tb', 'imagenet_vit']
+      compile_error_workloads = [
+          'librispeech_conformer', 'ogbg', 'criteo1tb', 'imagenet_vit'
+      ]
       eager_backend_workloads = ['librispeech_deepspeech']
       aot_eager_backend_workloads = []
       if FLAGS.workload in compile_error_workloads:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -605,10 +605,7 @@ def main(_):
 
   # Prevent OOM on librispeech conformer.
   if FLAGS.workload == 'librispeech_conformer':
-    if FLAGS.framework == 'jax':
-      os.environ['XLA_PYTHON_CLIENT_MEM_FRACTION'] = '0.85'
-    elif FLAGS.framework == 'pytorch' and torch.cuda.is_available():
-      torch.cuda.memory._set_allocator_settings('expandable_segments:True')
+    os.environ['XLA_PYTHON_CLIENT_MEM_FRACTION'] = '0.85'
 
   if FLAGS.set_pytorch_max_split_size:
     os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'max_split_size_mb:256'


### PR DESCRIPTION
Disable torch compile ViT due to https://github.com/mlcommons/algorithmic-efficiency/issues/496.
Triggered regression test and checked that everything passed here: https://github.com/mlcommons/algorithmic-efficiency/actions/runs/6820449633/job/18577174826.

I have retimed the pytorch workloads w the NVIDIA driver update on 2.0.1 and 2.1.0 and the workloads are roughly the same, most < 1% diff.  Measured percentage difference of new vs old (projected) submission times on adamw:

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
  | 2.0.1 | 2.1.0 | 2.0.1 | 2.1.0 | speedup (%)
-- | -- | -- | -- | -- | --
  | submission time (s) | submission time (s) | (h) | (h) |  
criteo1tb_adamw | 7393.555594 | 7279.994981 | 2.053765443 | 2.022220828 | -1.54
fastmri_adamw | 9606.619108 | 9699.320933 | 2.668505308 | 2.694255815 | 0.96
imagenet_resnet_adamw | 65771.35937 | 67761.1296 | 18.26982205 | 18.822536 | 3.03
imagenet_vit_adamw | 74314.54125 | 74500.57515 | 20.64292812 | 20.69460421 | 0.25
librispeech_conformer_adamw | 84465.78128 | 83725.16328 | 23.46271702 | 23.2569898 | -0.88
librispeech_deepspeech_adamw | 57857.49604 | 57557.82885 | 16.07152668 | 15.98828579 | -0.52
ogbg_adamw | 26449.03248 | 26557.22344 | 7.346953466 | 7.377006511 | 0.41
wmt_adamw | 55315.73472 | 54366.63234 | 15.36548187 | 15.10184232 | -1.72





