### PR TITLE
update fastmri targets

### DIFF
--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -19,14 +19,14 @@ class BaseFastMRIWorkload(spec.Workload):
 
   @property
   def validation_target_value(self) -> float:
-    return 0.726999
+    return 0.727120
 
   def has_reached_test_target(self, eval_result: float) -> bool:
     return eval_result['test/ssim'] > self.test_target_value
 
   @property
   def test_target_value(self) -> float:
-    return 0.744254
+    return 0.744296
 
   @property
   def loss_type(self) -> spec.LossType:

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -51,7 +51,7 @@ class BaseFastMRIWorkload(spec.Workload):
 
   @property
   def num_test_examples(self) -> int:
-    return 3548
+    return 3581
 
   @property
   def eval_batch_size(self) -> int:


### PR DESCRIPTION
Update FastMRI targets based on corrected number of test examples:
```
---- SORTED MEASUREMENTS BY VALIDATION METRIC ----
+-----------------------------------------------------------------+---------------+----------------+---------------------+---------------+
|                                                                 | metric_name   |   train/metric |   validation/metric |   test/metric |
|-----------------------------------------------------------------+---------------+----------------+---------------------+---------------|
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-11-45-15.log | ssim          |       0.749591 |            0.726839 |      0.744069 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-13-45-51.log | ssim          |       0.750584 |            0.726903 |      0.744125 |
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-17-46-26.log | ssim          |       0.751957 |            0.726912 |      0.74416  |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-17-41-38.log | ssim          |       0.751188 |            0.726937 |      0.744126 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-21-42-27.log | ssim          |       0.753246 |            0.726939 |      0.744193 |
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-15-46-02.log | ssim          |       0.751911 |            0.726949 |      0.744167 |
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-03-43-39.log | ssim          |       0.747191 |            0.726967 |      0.744231 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-23-42-51.log | ssim          |       0.749425 |            0.727074 |      0.744305 |
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-07-44-27.log | ssim          |       0.750128 |            0.727101 |      0.74423  |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-05-44-14.log | ssim          |       0.750307 |            0.727112 |      0.744321 |
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-09-44-51.log | ssim          |       0.749914 |            0.727128 |      0.744385 |
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-05-44-03.log | ssim          |       0.751453 |            0.727143 |      0.744296 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-11-45-27.log | ssim          |       0.748626 |            0.72716  |      0.744346 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-09-45-02.log | ssim          |       0.750953 |            0.727224 |      0.744413 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-19-42-02.log | ssim          |       0.753171 |            0.727242 |      0.744451 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-15-41-15.log | ssim          |       0.7497   |            0.727251 |      0.744458 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-03-43-49.log | ssim          |       0.750767 |            0.727297 |      0.744479 |
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-13-45-39.log | ssim          |       0.748218 |            0.727313 |      0.744511 |
| logs/target_setting_fastmri/fastmri_jax_10-07-2023-07-44-38.log | ssim          |       0.750641 |            0.727367 |      0.744502 |
| logs/target_setting_fastmri/fastmri_jax_10-08-2023-01-43-15.log | ssim          |       0.751668 |            0.727578 |      0.744698 |
+-----------------------------------------------------------------+---------------+----------------+---------------------+---------------+
VALIDATION TARGET: 0.7271200597588106
TEST TARGET: 0.7442955905516965
```