### PR TITLE
FastMRI workload variants

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/models.py
@@ -72,13 +72,13 @@ class DLRMResNet(nn.Module):
     # Ideally, we should use the pooled embedding implementation from
     # `TorchRec`. However, in order to have identical implementation
     # with that of Jax, we define a single embedding matrix.
-    num_chucks = 4
-    assert vocab_size % num_chucks == 0
+    num_chunks = 4
+    assert vocab_size % num_chunks == 0
     self.embedding_table_chucks = []
     scale = 1.0 / torch.sqrt(self.vocab_size)
-    for i in range(num_chucks):
+    for i in range(num_chunks):
       chunk = nn.Parameter(
-          torch.Tensor(self.vocab_size // num_chucks, self.embed_dim))
+          torch.Tensor(self.vocab_size // num_chunks, self.embed_dim))
       chunk.data.uniform_(0, 1)
       chunk.data = scale * chunk.data
       self.register_parameter(f'embedding_chunk_{i}', chunk)
@@ -194,8 +194,8 @@ class DlrmSmall(nn.Module):
     # Ideally, we should use the pooled embedding implementation from
     # `TorchRec`. However, in order to have identical implementation
     # with that of Jax, we define a single embedding matrix.
-    num_chucks = 4
-    assert vocab_size % num_chucks == 0
+    num_chunks = 4
+    assert vocab_size % num_chunks == 0
     self.embedding_table_chucks = []
 
     if self.embedding_init_multiplier is None:
@@ -203,9 +203,9 @@ class DlrmSmall(nn.Module):
     else:
       scale = self.embedding_init_multiplier
 
-    for i in range(num_chucks):
+    for i in range(num_chunks):
       chunk = nn.Parameter(
-          torch.Tensor(self.vocab_size // num_chucks, self.embed_dim))
+          torch.Tensor(self.vocab_size // num_chunks, self.embed_dim))
       chunk.data.uniform_(0, 1)
       chunk.data = scale * chunk.data
       self.register_parameter(f'embedding_chunk_{i}', chunk)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
@@ -65,7 +65,7 @@ class UNet(nn.Module):
     if dropout_rate is None:
       dropout_rate = 0.0
 
-    # pylint: disable=C0103
+    # pylint: disable=invalid-name
     _ConvBlock = functools.partial(
         ConvBlock,
         dropout_rate=dropout_rate,

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
@@ -28,7 +28,7 @@ def _instance_norm2d(x, axes, epsilon=1e-5):
   mean2 = jnp.mean(jnp.square(x), axes)
   # mean2 - _abs_sq(mean) is not guaranteed to be non-negative due
   # to floating point round-off errors.
-  var = jnp.maximum(0., mean2 - jnp.square(mean))  
+  var = jnp.maximum(0., mean2 - jnp.square(mean))
   stats_shape = list(x.shape)
   for axis in axes:
     stats_shape[axis] = 1
@@ -128,7 +128,7 @@ class UNet(nn.Module):
     output = nn.Conv(out_channels, kernel_size=(1, 1), strides=(1, 1))(output)
     return output.squeeze(-1)
 
-    
+
 class ConvBlock(nn.Module):
   """A Convolutional Block.
   out_channels: Number of channels in the output.
@@ -153,7 +153,8 @@ class ConvBlock(nn.Module):
         features=self.out_channels,
         kernel_size=(3, 3),
         strides=(1, 1),
-        use_bias=False)(x)
+        use_bias=False)(
+            x)
     if self.use_layer_norm:
       x = nn.LayerNorm(reduction_axes=(1, 2, 3))(x)
     else:
@@ -169,19 +170,22 @@ class ConvBlock(nn.Module):
     # Ref code uses dropout2d which applies the same mask for the entire channel
     # Replicated by using broadcast dims to have the same filter on HW
     x = nn.Dropout(
-        self.dropout_rate, broadcast_dims=(1, 2), deterministic=not train)(x)
+        self.dropout_rate, broadcast_dims=(1, 2), deterministic=not train)(
+            x)
     x = nn.Conv(
         features=self.out_channels,
         kernel_size=(3, 3),
         strides=(1, 1),
-        use_bias=False)(x)
+        use_bias=False)(
+            x)
     if self.use_layer_norm:
       x = nn.LayerNorm(reduction_axes=(1, 2, 3))(x)
     else:
       x = _instance_norm2d(x, (1, 2))
     x = activation_fn(x)
     x = nn.Dropout(
-        self.dropout_rate, broadcast_dims=(1, 2), deterministic=not train)(x)
+        self.dropout_rate, broadcast_dims=(1, 2), deterministic=not train)(
+            x)
     return x
 
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
@@ -155,7 +155,7 @@ class ConvBlock(nn.Module):
         strides=(1, 1),
         use_bias=False)(x)
     if self.use_layer_norm:
-      x = nn.LayerNorm()(x)
+      x = nn.LayerNorm(reduction_axes=(1, 2, 3))(x)
     else:
       # DO NOT SUBMIT check that this comment edit is correct
       # InstanceNorm2d was run with no learnable params in reference code
@@ -176,7 +176,7 @@ class ConvBlock(nn.Module):
         strides=(1, 1),
         use_bias=False)(x)
     if self.use_layer_norm:
-      x = nn.LayerNorm()(x)
+      x = nn.LayerNorm(reduction_axes=(1, 2, 3))(x)
     else:
       x = _instance_norm2d(x, (1, 2))
     x = activation_fn(x)
@@ -205,7 +205,7 @@ class TransposeConvBlock(nn.Module):
         self.out_channels, kernel_size=(2, 2), strides=(2, 2), use_bias=False)(
             x)
     if self.use_layer_norm:
-      x = nn.LayerNorm()(x)
+      x = nn.LayerNorm(reduction_axes=(1, 2, 3))(x)
     else:
       x = _instance_norm2d(x, (1, 2))
     if self.use_tanh:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
@@ -55,6 +55,7 @@ class UNet(nn.Module):
   """
   num_channels: int = 32
   num_pool_layers: int = 4
+  out_channels = 1
   dropout_rate: Optional[float] = 0.0  # If None, defaults to 0.0.
   use_tanh: bool = False
   use_layer_norm: bool = False
@@ -125,8 +126,7 @@ class UNet(nn.Module):
       output = jnp.concatenate((output, downsample_layer), axis=-1)
       output = conv(output, train)
 
-    out_channels = 1
-    output = nn.Conv(out_channels, kernel_size=(1, 1), strides=(1, 1))(output)
+    output = nn.Conv(self.out_channels, kernel_size=(1, 1), strides=(1, 1))(output)
     return output.squeeze(-1)
 
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
@@ -65,33 +65,34 @@ class UNet(nn.Module):
     if dropout_rate is None:
       dropout_rate = 0.0
 
-    PreconfiguredConvBlock = functools.partial(
+    # pylint: disable=C0103
+    _ConvBlock = functools.partial(
         ConvBlock,
         dropout_rate=dropout_rate,
         use_tanh=self.use_tanh,
         use_layer_norm=self.use_layer_norm)
-    PreconfiguredTransposeConvBlock = functools.partial(
+    _TransposeConvBlock = functools.partial(
         TransposeConvBlock,
         use_tanh=self.use_tanh,
         use_layer_norm=self.use_layer_norm)
 
-    down_sample_layers = [PreconfiguredConvBlock(self.num_channels)]
+    down_sample_layers = [_ConvBlock(self.num_channels)]
 
     ch = self.num_channels
     for _ in range(self.num_pool_layers - 1):
-      down_sample_layers.append(PreconfiguredConvBlock(ch * 2))
+      down_sample_layers.append(_ConvBlock(ch * 2))
       ch *= 2
-    conv = PreconfiguredConvBlock(ch * 2)
+    conv = _ConvBlock(ch * 2)
 
     up_conv = []
     up_transpose_conv = []
     for _ in range(self.num_pool_layers - 1):
-      up_transpose_conv.append(PreconfiguredTransposeConvBlock(ch))
-      up_conv.append(PreconfiguredConvBlock(ch))
+      up_transpose_conv.append(_TransposeConvBlock(ch))
+      up_conv.append(_ConvBlock(ch))
       ch //= 2
 
-    up_transpose_conv.append(PreconfiguredTransposeConvBlock(ch))
-    up_conv.append(PreconfiguredConvBlock(ch))
+    up_transpose_conv.append(_TransposeConvBlock(ch))
+    up_conv.append(_ConvBlock(ch))
 
     stack = []
     output = jnp.expand_dims(x, axis=-1)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
@@ -204,10 +204,7 @@ class TransposeConvBlock(nn.Module):
     x = nn.ConvTranspose(
         self.out_channels, kernel_size=(2, 2), strides=(2, 2), use_bias=False)(
             x)
-    if self.use_layer_norm:
-      x = nn.LayerNorm(reduction_axes=(1, 2, 3))(x)
-    else:
-      x = _instance_norm2d(x, (1, 2))
+    x = _instance_norm2d(x, (1, 2))
     if self.use_tanh:
       activation_fn = nn.tanh
     else:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
@@ -65,33 +65,33 @@ class UNet(nn.Module):
     if dropout_rate is None:
       dropout_rate = 0.0
 
-    _ConvBlock = functools.partial(
+    PreconfiguredConvBlock = functools.partial(
         ConvBlock,
         dropout_rate=dropout_rate,
         use_tanh=self.use_tanh,
         use_layer_norm=self.use_layer_norm)
-    _TransposeConvBlock = functools.partial(
+    PreconfiguredTransposeConvBlock = functools.partial(
         TransposeConvBlock,
         use_tanh=self.use_tanh,
         use_layer_norm=self.use_layer_norm)
 
-    down_sample_layers = [_ConvBlock(self.num_channels)]
+    down_sample_layers = [PreconfiguredConvBlock(self.num_channels)]
 
     ch = self.num_channels
     for _ in range(self.num_pool_layers - 1):
-      down_sample_layers.append(_ConvBlock(ch * 2))
+      down_sample_layers.append(PreconfiguredConvBlock(ch * 2))
       ch *= 2
-    conv = _ConvBlock(ch * 2)
+    conv = PreconfiguredConvBlock(ch * 2)
 
     up_conv = []
     up_transpose_conv = []
     for _ in range(self.num_pool_layers - 1):
-      up_transpose_conv.append(_TransposeConvBlock(ch))
-      up_conv.append(_ConvBlock(ch))
+      up_transpose_conv.append(PreconfiguredTransposeConvBlock(ch))
+      up_conv.append(PreconfiguredConvBlock(ch))
       ch //= 2
 
-    up_transpose_conv.append(_TransposeConvBlock(ch))
-    up_conv.append(_ConvBlock(ch))
+    up_transpose_conv.append(PreconfiguredTransposeConvBlock(ch))
+    up_conv.append(PreconfiguredConvBlock(ch))
 
     stack = []
     output = jnp.expand_dims(x, axis=-1)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/models.py
@@ -126,7 +126,9 @@ class UNet(nn.Module):
       output = jnp.concatenate((output, downsample_layer), axis=-1)
       output = conv(output, train)
 
-    output = nn.Conv(self.out_channels, kernel_size=(1, 1), strides=(1, 1))(output)
+    output = nn.Conv(
+        self.out_channels, kernel_size=(1, 1), strides=(1, 1))(
+            output)
     return output.squeeze(-1)
 
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
 import algorithmic_efficiency.random_utils as prng
-from algorithmic_efficiency.workloads.fastmri.fastmri_jax.models import Unet
+from algorithmic_efficiency.workloads.fastmri.fastmri_jax.models import UNet
 from algorithmic_efficiency.workloads.fastmri.fastmri_jax.ssim import ssim
 from algorithmic_efficiency.workloads.fastmri.workload import \
     BaseFastMRIWorkload

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -34,7 +34,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         use_tanh=self.use_tanh,
         use_layer_norm=self.use_layer_norm,
         dropout_rate=dropout_rate)
-    
+
     variables = jax.jit(self._model.init)({'params': rng}, fake_batch)
     params = variables['params']
     self._param_shapes = param_utils.jax_param_shapes(params)
@@ -192,4 +192,3 @@ class FastMRILayerNormWorkload(FastMRIWorkload):
   def use_layer_norm(self) -> bool:
     """Whether or not to use tanh activations in the model."""
     return True
-

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
 import algorithmic_efficiency.random_utils as prng
-from algorithmic_efficiency.workloads.fastmri.fastmri_jax import models
+from algorithmic_efficiency.workloads.fastmri.fastmri_jax.models import Unet
 from algorithmic_efficiency.workloads.fastmri.fastmri_jax.ssim import ssim
 from algorithmic_efficiency.workloads.fastmri.workload import \
     BaseFastMRIWorkload
@@ -27,7 +27,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
     """aux_dropout_rate is unused."""
     del aux_dropout_rate
     fake_batch = jnp.zeros((13, 320, 320))
-    self._model = models.UNet(
+    self._model = UNet(
         num_pool_layers=self.num_pool_layers,
         num_channels=self.num_channels,
         use_tanh=self.use_tanh,
@@ -165,7 +165,6 @@ class FastMRIWorkload(BaseFastMRIWorkload):
 
 
 class FastMRIModelSizeWorkload(FastMRIWorkload):
-
   @property
   def num_pool_layers(self) -> bool:
     """Whether or not to use tanh activations in the model."""

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -35,13 +35,6 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         use_layer_norm=self.use_layer_norm,
         dropout_rate=dropout_rate)
     
-    tabulate_fn = nn.tabulate(
-    self._model,
-    jax.random.PRNGKey(0),
-    console_kwargs={
-        'force_terminal': False, 'force_jupyter': False, 'width': 240},
-    )
-    print(tabulate_fn(fake_batch, train=False))
     variables = jax.jit(self._model.init)({'params': rng}, fake_batch)
     params = variables['params']
     self._param_shapes = param_utils.jax_param_shapes(params)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -5,6 +5,7 @@ import math
 from typing import Dict, Optional, Tuple
 
 from flax import jax_utils
+import flax.linen as nn
 import jax
 import jax.numpy as jnp
 
@@ -35,6 +36,14 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         dropout_rate=dropout_rate)
     variables = jax.jit(self._model.init)({'params': rng}, fake_batch)
     params = variables['params']
+    tabulate_fn = nn.tabulate(
+      self._model,
+      jax.random.PRNGKey(0),
+      console_kwargs={
+        'force_terminal': False, 'force_jupyter':False, 'width':240
+      }
+    )
+    print(tabulate_fn(fake_batch, train=False))
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
     params = jax_utils.replicate(params)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -5,7 +5,6 @@ import math
 from typing import Dict, Optional, Tuple
 
 from flax import jax_utils
-import flax.linen as nn
 import jax
 import jax.numpy as jnp
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -165,6 +165,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
 
 
 class FastMRIModelSizeWorkload(FastMRIWorkload):
+
   @property
   def num_pool_layers(self) -> bool:
     """Whether or not to use tanh activations in the model."""

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -36,14 +36,6 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         dropout_rate=dropout_rate)
     variables = jax.jit(self._model.init)({'params': rng}, fake_batch)
     params = variables['params']
-    tabulate_fn = nn.tabulate(
-      self._model,
-      jax.random.PRNGKey(0),
-      console_kwargs={
-        'force_terminal': False, 'force_jupyter':False, 'width':240
-      }
-    )
-    print(tabulate_fn(fake_batch, train=False))
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
     params = jax_utils.replicate(params)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -34,6 +34,14 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         use_tanh=self.use_tanh,
         use_layer_norm=self.use_layer_norm,
         dropout_rate=dropout_rate)
+    
+    tabulate_fn = nn.tabulate(
+    self._model,
+    jax.random.PRNGKey(0),
+    console_kwargs={
+        'force_terminal': False, 'force_jupyter': False, 'width': 240},
+    )
+    print(tabulate_fn(fake_inputs, train=False))
     variables = jax.jit(self._model.init)({'params': rng}, fake_batch)
     params = variables['params']
     self._param_shapes = param_utils.jax_param_shapes(params)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -41,7 +41,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
     console_kwargs={
         'force_terminal': False, 'force_jupyter': False, 'width': 240},
     )
-    print(tabulate_fn(fake_inputs, train=False))
+    print(tabulate_fn(fake_batch, train=False))
     variables = jax.jit(self._model.init)({'params': rng}, fake_batch)
     params = variables['params']
     self._param_shapes = param_utils.jax_param_shapes(params)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -114,7 +114,7 @@ class ConvBlock(nn.Module):
     super().__init__()
 
     if use_layer_norm:
-      norm_layer = nn.LayerNorm()
+      norm_layer = nn.LayerNorm([out_chans, 320, 320])
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
@@ -148,7 +148,7 @@ class TransposeConvBlock(nn.Module):
               ):
     super().__init__()
     if use_layer_norm:
-      norm_layer = nn.LayerNorm()
+      norm_layer = nn.LayerNorm([out_chans, 320, 320)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -173,7 +173,7 @@ class TransposeConvBlock(nn.Module):
     super().__init__()
     if use_layer_norm:
       size = int(size)
-      norm_layer = nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6)
+      norm_layer = partial(nn.GroupNorm, 1, eps=1e-6)
     else:
       norm_layer = nn.InstanceNorm2d
     if use_tanh:
@@ -183,7 +183,6 @@ class TransposeConvBlock(nn.Module):
     self.layers = nn.Sequential(
         nn.ConvTranspose2d(
             in_chans, out_chans, kernel_size=2, stride=2, bias=False),
-        nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6),
         norm_layer(out_chans),
         activation_fn,
     )

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -41,13 +41,13 @@ class UNet(nn.Module):
     self.size = size
     self.down_sample_layers = nn.ModuleList(
         [ConvBlock(in_chans, num_channels, dropout_rate, use_tanh, use_layer_norm, size)])
-    size = size/2
+    size = int(size / 2)
     ch = num_channels
     for _ in range(num_pool_layers - 1):
       self.down_sample_layers.append(
           ConvBlock(ch, ch * 2, dropout_rate, use_tanh, use_layer_norm, size))
       ch *= 2
-      size = size/2
+      size = int(size / 2)
     self.conv = ConvBlock(ch, ch * 2, dropout_rate, use_tanh, use_layer_norm, size)
     size = size/2
 
@@ -56,14 +56,14 @@ class UNet(nn.Module):
     for _ in range(num_pool_layers - 1):
       self.up_transpose_conv.append(
           TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm, size))
-      size = size * 2
+      size = int(size * 2)
       self.up_conv.append(
           ConvBlock(ch * 2, ch, dropout_rate, use_tanh, use_layer_norm, size))
       ch //= 2
 
     self.up_transpose_conv.append(
         TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm))
-    size = size * 2
+    size = int(size * 2)
     self.up_conv.append(
         nn.Sequential(
             ConvBlock(ch * 2, ch, dropout_rate, use_tanh, use_layer_norm, size),

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -137,7 +137,7 @@ class ConvBlock(nn.Module):
 
     if use_layer_norm:
       size = int(size)
-      norm_layer = partial(nn.GroupNorm, num_groups=1, eps=1e-6)
+      norm_layer = partial(nn.GroupNorm, 1, eps=1e-6)
     else:
       norm_layer = nn.InstanceNorm2d
     if use_tanh:
@@ -146,11 +146,11 @@ class ConvBlock(nn.Module):
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6),
+        norm_layer(out_chans),
         activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6),
+        norm_layer(out_chans),
         activation_fn,
         nn.Dropout2d(dropout_rate),
     )
@@ -184,6 +184,7 @@ class TransposeConvBlock(nn.Module):
         nn.ConvTranspose2d(
             in_chans, out_chans, kernel_size=2, stride=2, bias=False),
         nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6),
+        norm_layer,
         activation_fn,
     )
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -184,7 +184,7 @@ class TransposeConvBlock(nn.Module):
         nn.ConvTranspose2d(
             in_chans, out_chans, kernel_size=2, stride=2, bias=False),
         nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6),
-        norm_layer,
+        norm_layer(out_chans),
         activation_fn,
     )
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -49,10 +49,10 @@ class UNet(nn.Module):
       ch *= 2
       size = int(size / 2)
     self.conv = ConvBlock(ch, ch * 2, dropout_rate, use_tanh, use_layer_norm, size)
-    size = int( size / 2)
 
     self.up_conv = nn.ModuleList()
     self.up_transpose_conv = nn.ModuleList()
+    size = size * 2
     for _ in range(num_pool_layers - 1):
       self.up_transpose_conv.append(
           TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm, size))

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -115,19 +115,21 @@ class ConvBlock(nn.Module):
 
     if use_layer_norm:
       norm_layer = nn.LayerNorm(out_chans)
+      norm_layer = nn.InstanceNorm2d(out_chans)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
       activation_fn = nn.Tanh(inplace=True)
+      activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     else:
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        nn.InstanceNorm2d(out_chans),
-        nn.LeakyReLU(negative_slope=0.2, inplace=True),
+        norm_layer,
+        activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        nn.InstanceNorm2d(out_chans),
+        norm_layer,
         nn.LeakyReLU(negative_slope=0.2, inplace=True),
         nn.Dropout2d(dropout_rate),
     )
@@ -149,17 +151,19 @@ class TransposeConvBlock(nn.Module):
     super().__init__()
     if use_layer_norm:
       norm_layer = nn.LayerNorm(out_chans)
+      norm_layer = nn.InstanceNorm2d(out_chans)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
       activation_fn = nn.Tanh(inplace=True)
+      activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     else:
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.layers = nn.Sequential(
         nn.ConvTranspose2d(
             in_chans, out_chans, kernel_size=2, stride=2, bias=False),
-        nn.InstanceNorm2d(out_chans),
-        nn.LeakyReLU(negative_slope=0.2, inplace=True),
+        norm_layer,
+        activation_fn,
     )
 
   def forward(self, x: Tensor) -> Tensor:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -148,7 +148,7 @@ class TransposeConvBlock(nn.Module):
               ):
     super().__init__()
     if use_layer_norm:
-      norm_layer = nn.LayerNorm([out_chans, 320, 320)
+      norm_layer = nn.LayerNorm([out_chans, 320, 320])
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -115,12 +115,11 @@ class ConvBlock(nn.Module):
 
     if use_layer_norm:
       norm_layer = nn.LayerNorm(out_chans)
-      norm_layer = nn.InstanceNorm2d(out_chans)
+      # norm_layer = nn.InstanceNorm2d(out_chans)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
       activation_fn = nn.Tanh(inplace=True)
-      activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     else:
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
@@ -151,7 +150,7 @@ class TransposeConvBlock(nn.Module):
     super().__init__()
     if use_layer_norm:
       norm_layer = nn.LayerNorm(out_chans)
-      norm_layer = nn.InstanceNorm2d(out_chans)
+      # norm_layer = nn.InstanceNorm2d(out_chans)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -131,11 +131,11 @@ class ConvBlock(nn.Module):
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer(out_chans, eps=1e-06),
+        norm_layer([out_chans, size, size], eps=1e-06),
         activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer(out_chans, eps=1e-06),
+        norm_layer([out_chans, size, size], eps=1e-06),
         activation_fn,
         nn.Dropout2d(dropout_rate),
     )
@@ -158,7 +158,7 @@ class TransposeConvBlock(nn.Module):
     super().__init__()
     if use_layer_norm:
       size = int(size)
-      norm_layer = nn.LayerNorm(out_chans, eps=1e-06)
+      norm_layer = nn.LayerNorm([out_chans, size, size], eps=1e-06)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -20,12 +20,12 @@ class LayerNorm(nn.Module):
     super().__init__()
     self.normalized_shape = normalized_shape
 
-    self.scale = nn.Parameter(torch.zeros(self.dim))
-    self.bias = nn.Parameter(torch.zeros(self.dim))
+    self.scale = nn.Parameter(torch.zeros(self.normalized_shape[0]))
+    self.bias = nn.Parameter(torch.zeros(self.normalized_shape[0]))
     self.epsilon = epsilon
 
   def forward(self, x):
-    return F.layer_norm(x, normalized_shape, 1 + self.scale, self.bias, self.epsilon)
+    return F.layer_norm(x, self.normalized_shape, 1 + self.scale, self.bias, self.epsilon)
   
 
 class UNet(nn.Module):

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -52,18 +52,18 @@ class UNet(nn.Module):
 
     self.up_conv = nn.ModuleList()
     self.up_transpose_conv = nn.ModuleList()
-    # size = size * 2
+
     for _ in range(num_pool_layers - 1):
+      size = int(size * 2)
       self.up_transpose_conv.append(
           TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm, size))
-      size = int(size * 2)
       self.up_conv.append(
           ConvBlock(ch * 2, ch, dropout_rate, use_tanh, use_layer_norm, size))
       ch //= 2
 
+    size = int(size * 2)
     self.up_transpose_conv.append(
         TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm, size))
-    size = int(size * 2)
     self.up_conv.append(
         nn.Sequential(
             ConvBlock(ch * 2, ch, dropout_rate, use_tanh, use_layer_norm, size),

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -130,7 +130,7 @@ class ConvBlock(nn.Module):
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
         norm_layer,
-        nn.LeakyReLU(negative_slope=0.2, inplace=True),
+        activation_fn,
         nn.Dropout2d(dropout_rate),
     )
 
@@ -156,7 +156,6 @@ class TransposeConvBlock(nn.Module):
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
       activation_fn = nn.Tanh(inplace=True)
-      activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     else:
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.layers = nn.Sequential(

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -124,7 +124,7 @@ class ConvBlock(nn.Module):
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
         norm_layer,
-        activations_fn,
+        activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
         norm_layer,

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -41,27 +41,27 @@ class UNet(nn.Module):
     self.size = size
     self.down_sample_layers = nn.ModuleList(
         [ConvBlock(in_chans, num_channels, dropout_rate, use_tanh, use_layer_norm, size)])
-    size = int(size / 2)
+    size = size / 2
     ch = num_channels
     for _ in range(num_pool_layers - 1):
       self.down_sample_layers.append(
           ConvBlock(ch, ch * 2, dropout_rate, use_tanh, use_layer_norm, size))
       ch *= 2
-      size = int(size / 2)
+      size = size / 2
     self.conv = ConvBlock(ch, ch * 2, dropout_rate, use_tanh, use_layer_norm, size)
 
     self.up_conv = nn.ModuleList()
     self.up_transpose_conv = nn.ModuleList()
 
     for _ in range(num_pool_layers - 1):
-      size = int(size * 2)
+      size = size * 2
       self.up_transpose_conv.append(
           TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm, size))
       self.up_conv.append(
           ConvBlock(ch * 2, ch, dropout_rate, use_tanh, use_layer_norm, size))
       ch //= 2
 
-    size = int(size * 2)
+    size = size * 2
     self.up_transpose_conv.append(
         TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm, size))
     self.up_conv.append(

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -49,7 +49,7 @@ class UNet(nn.Module):
       ch *= 2
       size = int(size / 2)
     self.conv = ConvBlock(ch, ch * 2, dropout_rate, use_tanh, use_layer_norm, size)
-    size = size/2
+    size = int( size / 2)
 
     self.up_conv = nn.ModuleList()
     self.up_transpose_conv = nn.ModuleList()

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -16,16 +16,16 @@ from algorithmic_efficiency import init_utils
 
 class LayerNorm(nn.Module):
 
-  def __init__(self, dim, epsilon=1e-6):
+  def __init__(self, normalized_shape, epsilon=1e-6):
     super().__init__()
-    self.dim = dim
+    self.normalized_shape = normalized_shape
 
     self.scale = nn.Parameter(torch.zeros(self.dim))
     self.bias = nn.Parameter(torch.zeros(self.dim))
     self.epsilon = epsilon
 
   def forward(self, x):
-    return F.layer_norm(x, (self.dim,), 1 + self.scale, self.bias, self.epsilon)
+    return F.layer_norm(x, normalized_shape, 1 + self.scale, self.bias, self.epsilon)
   
 
 class UNet(nn.Module):
@@ -137,19 +137,21 @@ class ConvBlock(nn.Module):
     if use_layer_norm:
       size = int(size)
       norm_layer = LayerNorm
+      normalized_shape = (out_chans, size, size)
     else:
       norm_layer = nn.InstanceNorm2d
+      normalized_shape = out_chans
     if use_tanh:
       activation_fn = nn.Tanh()
     else:
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer(out_chans),
+        norm_layer(normalized_shape),
         activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer(out_chans),
+        norm_layer(normalized_shape),
         activation_fn,
         nn.Dropout2d(dropout_rate),
     )
@@ -173,8 +175,10 @@ class TransposeConvBlock(nn.Module):
     if use_layer_norm:
       size = int(size)
       norm_layer = LayerNorm
+      normalized_shape = (out_chans, size, size)
     else:
       norm_layer = nn.InstanceNorm2d
+      normalized_shape = out_chans
     if use_tanh:
       activation_fn = nn.Tanh()
     else:
@@ -182,7 +186,7 @@ class TransposeConvBlock(nn.Module):
     self.layers = nn.Sequential(
         nn.ConvTranspose2d(
             in_chans, out_chans, kernel_size=2, stride=2, bias=False),
-        norm_layer(out_chans),
+        norm_layer(normalized_shape),
         activation_fn,
     )
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -114,7 +114,7 @@ class ConvBlock(nn.Module):
     super().__init__()
 
     if use_layer_norm:
-      norm_layer = nn.LayerNorm([out_chans, 160, 160])
+      norm_layer = nn.LayerNorm([out_chans, 160, 160], eps=1e-06)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
@@ -148,7 +148,7 @@ class TransposeConvBlock(nn.Module):
               ):
     super().__init__()
     if use_layer_norm:
-      norm_layer = nn.LayerNorm([out_chans, 320, 320])
+      norm_layer = nn.LayerNorm([out_chans, 320, 320], eps=1e-06)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -121,6 +121,7 @@ class ConvBlock(nn.Module):
     super().__init__()
 
     if use_layer_norm:
+      size = int(size)
       norm_layer = nn.LayerNorm([out_chans, size, size], eps=1e-06)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
@@ -156,6 +157,7 @@ class TransposeConvBlock(nn.Module):
               ):
     super().__init__()
     if use_layer_norm:
+      size = int(size)
       norm_layer = nn.LayerNorm([out_chans, size, size], eps=1e-06)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -122,7 +122,7 @@ class ConvBlock(nn.Module):
 
     if use_layer_norm:
       size = int(size)
-      norm_layer = nn.LayerNorm([out_chans, size, size], eps=1e-06)
+      norm_layer = nn.LayerNorm
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
@@ -131,11 +131,11 @@ class ConvBlock(nn.Module):
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer,
+        norm_layer([out_chans, size, size], eps=1e-06),
         activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer,
+        norm_layer([out_chans, size, size], eps=1e-06),
         activation_fn,
         nn.Dropout2d(dropout_rate),
     )

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -43,8 +43,7 @@ class UNet(nn.Module):
                num_pool_layers: int = 4,
                dropout_rate: Optional[float] = 0.0,
                use_tanh: bool = False,
-               use_layer_norm: bool = False,
-               size: int = 320) -> None:
+               use_layer_norm: bool = False) -> None:
     super().__init__()
 
     self.in_chans = in_chans
@@ -130,7 +129,6 @@ class ConvBlock(nn.Module):
     super().__init__()
 
     if use_layer_norm:
-      size = int(size)
       norm_layer = partial(nn.GroupNorm, 1, eps=1e-6)
     else:
       norm_layer = nn.InstanceNorm2d

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -12,6 +12,7 @@ from torch import Tensor
 from torch.nn import functional as F
 
 from algorithmic_efficiency import init_utils
+from functools import partial
 
 
 class LayerNorm(nn.Module):
@@ -136,22 +137,20 @@ class ConvBlock(nn.Module):
 
     if use_layer_norm:
       size = int(size)
-      norm_layer = nn.GroupNorm
-      normalized_shape = (1, out_chans)
+      norm_layer = partial(nn.GroupNorm, num_groups=1, eps=1e-6)
     else:
       norm_layer = nn.InstanceNorm2d
-      normalized_shape = out_chans
     if use_tanh:
       activation_fn = nn.Tanh()
     else:
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer(normalized_shape),
+        norm_layer(out_chans),
         activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer(normalized_shape),
+        norm_layer(out_chans),
         activation_fn,
         nn.Dropout2d(dropout_rate),
     )
@@ -174,11 +173,9 @@ class TransposeConvBlock(nn.Module):
     super().__init__()
     if use_layer_norm:
       size = int(size)
-      norm_layer = nn.GroupNorm
-      normalized_shape = (1, out_chans)
+      norm_layer = partial(nn.GroupNorm, num_groups=1, eps=1e-6)
     else:
       norm_layer = nn.InstanceNorm2d
-      normalized_shape = out_chans
     if use_tanh:
       activation_fn = nn.Tanh()
     else:
@@ -186,7 +183,7 @@ class TransposeConvBlock(nn.Module):
     self.layers = nn.Sequential(
         nn.ConvTranspose2d(
             in_chans, out_chans, kernel_size=2, stride=2, bias=False),
-        norm_layer(normalized_shape),
+        norm_layer(out_chans),
         activation_fn,
     )
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -123,12 +123,12 @@ class ConvBlock(nn.Module):
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer,
-        activation_fn,
+        nn.InstanceNorm2d(out_chans),
+        nn.LeakyReLU(negative_slope=0.2, inplace=True),
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer,
-        activation_fn,
+        nn.InstanceNorm2d(out_chans),
+        nn.LeakyReLU(negative_slope=0.2, inplace=True),
         nn.Dropout2d(dropout_rate),
     )
 
@@ -158,8 +158,8 @@ class TransposeConvBlock(nn.Module):
     self.layers = nn.Sequential(
         nn.ConvTranspose2d(
             in_chans, out_chans, kernel_size=2, stride=2, bias=False),
-        norm_layer,
-        activation_fn,
+        nn.InstanceNorm2d(out_chans),
+        nn.LeakyReLU(negative_slope=0.2, inplace=True),
     )
 
   def forward(self, x: Tensor) -> Tensor:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -26,8 +26,12 @@ class LayerNorm(nn.Module):
     self.epsilon = epsilon
 
   def forward(self, x):
-    return F.layer_norm(x, self.normalized_shape, 1 + self.scale, self.bias, self.epsilon)
-  
+    return F.layer_norm(x,
+                        self.normalized_shape,
+                        1 + self.scale,
+                        self.bias,
+                        self.epsilon)
+
 
 class UNet(nn.Module):
   r"""U-Net model from
@@ -52,8 +56,13 @@ class UNet(nn.Module):
     self.num_pool_layers = num_pool_layers
     if dropout_rate is None:
       dropout_rate = 0.0
-    self.down_sample_layers = nn.ModuleList(
-        [ConvBlock(in_chans, num_channels, dropout_rate, use_tanh, use_layer_norm)])
+    self.down_sample_layers = nn.ModuleList([
+        ConvBlock(in_chans,
+                  num_channels,
+                  dropout_rate,
+                  use_tanh,
+                  use_layer_norm)
+    ])
     ch = num_channels
     for _ in range(num_pool_layers - 1):
       self.down_sample_layers.append(
@@ -155,12 +164,13 @@ class TransposeConvBlock(nn.Module):
   # A Transpose Convolutional Block that consists of one convolution transpose
   # layers followed by instance normalization and LeakyReLU activation.
 
-  def __init__(self, 
-              in_chans: int, 
-              out_chans: int,
-              use_tanh: bool, 
-              use_layer_norm: bool,
-              ):
+  def __init__(
+      self,
+      in_chans: int,
+      out_chans: int,
+      use_tanh: bool,
+      use_layer_norm: bool,
+  ):
     super().__init__()
     if use_tanh:
       activation_fn = nn.Tanh()

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -131,11 +131,11 @@ class ConvBlock(nn.Module):
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer([out_chans, size, size], eps=1e-06),
+        norm_layer(out_chans, eps=1e-06),
         activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer([out_chans, size, size], eps=1e-06),
+        norm_layer(out_chans, eps=1e-06),
         activation_fn,
         nn.Dropout2d(dropout_rate),
     )
@@ -158,7 +158,7 @@ class TransposeConvBlock(nn.Module):
     super().__init__()
     if use_layer_norm:
       size = int(size)
-      norm_layer = nn.LayerNorm([out_chans, size, size], eps=1e-06)
+      norm_layer = nn.LayerNorm(out_chans, eps=1e-06)
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -114,8 +114,7 @@ class ConvBlock(nn.Module):
     super().__init__()
 
     if use_layer_norm:
-      norm_layer = nn.LayerNorm(out_chans)
-      # norm_layer = nn.InstanceNorm2d(out_chans)
+      norm_layer = nn.LayerNorm()
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
@@ -149,8 +148,7 @@ class TransposeConvBlock(nn.Module):
               ):
     super().__init__()
     if use_layer_norm:
-      norm_layer = nn.LayerNorm(out_chans)
-      # norm_layer = nn.InstanceNorm2d(out_chans)
+      norm_layer = nn.LayerNorm()
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -85,7 +85,7 @@ class UNet(nn.Module):
     self.up_conv.append(
         nn.Sequential(
             ConvBlock(ch * 2, ch, dropout_rate, use_tanh, use_layer_norm),
-            nn.Conv2d(ch, 1, kernel_size=1, stride=1),
+            nn.Conv2d(ch, self.out_chans, kernel_size=1, stride=1),
         ))
 
     for m in self.modules():

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -136,8 +136,8 @@ class ConvBlock(nn.Module):
 
     if use_layer_norm:
       size = int(size)
-      norm_layer = LayerNorm
-      normalized_shape = (out_chans, size, size)
+      norm_layer = nn.GroupNorm
+      normalized_shape = (1, out_chans)
     else:
       norm_layer = nn.InstanceNorm2d
       normalized_shape = out_chans
@@ -174,8 +174,8 @@ class TransposeConvBlock(nn.Module):
     super().__init__()
     if use_layer_norm:
       size = int(size)
-      norm_layer = LayerNorm
-      normalized_shape = (out_chans, size, size)
+      norm_layer = nn.GroupNorm
+      normalized_shape = (1, out_chans)
     else:
       norm_layer = nn.InstanceNorm2d
       normalized_shape = out_chans

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -146,11 +146,11 @@ class ConvBlock(nn.Module):
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
         nn.Conv2d(in_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer(out_chans),
+        nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6),
         activation_fn,
         nn.Dropout2d(dropout_rate),
         nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False),
-        norm_layer(out_chans),
+        nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6),
         activation_fn,
         nn.Dropout2d(dropout_rate),
     )
@@ -173,7 +173,7 @@ class TransposeConvBlock(nn.Module):
     super().__init__()
     if use_layer_norm:
       size = int(size)
-      norm_layer = partial(nn.GroupNorm, num_groups=1, eps=1e-6)
+      norm_layer = nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6)
     else:
       norm_layer = nn.InstanceNorm2d
     if use_tanh:
@@ -183,7 +183,7 @@ class TransposeConvBlock(nn.Module):
     self.layers = nn.Sequential(
         nn.ConvTranspose2d(
             in_chans, out_chans, kernel_size=2, stride=2, bias=False),
-        norm_layer(out_chans),
+        nn.GroupNorm(num_groups=1, num_channels=out_chans, eps=1e-6),
         activation_fn,
     )
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -114,11 +114,11 @@ class ConvBlock(nn.Module):
     super().__init__()
 
     if use_layer_norm:
-      norm_layer = nn.LayerNorm([out_chans, 320, 320])
+      norm_layer = nn.LayerNorm([out_chans, 160, 160])
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
-      activation_fn = nn.Tanh(inplace=True)
+      activation_fn = nn.Tanh()
     else:
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.conv_layers = nn.Sequential(
@@ -152,7 +152,7 @@ class TransposeConvBlock(nn.Module):
     else:
       norm_layer = nn.InstanceNorm2d(out_chans)
     if use_tanh:
-      activation_fn = nn.Tanh(inplace=True)
+      activation_fn = nn.Tanh()
     else:
       activation_fn = nn.LeakyReLU(negative_slope=0.2, inplace=True)
     self.layers = nn.Sequential(

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -52,7 +52,7 @@ class UNet(nn.Module):
 
     self.up_conv = nn.ModuleList()
     self.up_transpose_conv = nn.ModuleList()
-    size = size * 2
+    # size = size * 2
     for _ in range(num_pool_layers - 1):
       self.up_transpose_conv.append(
           TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm, size))

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -4,6 +4,7 @@ Adapted from fastMRI:
 https://github.com/facebookresearch/fastMRI/blob/main/fastmri/models/unet.py
 """
 
+from functools import partial
 from typing import Optional
 
 import torch
@@ -12,7 +13,6 @@ from torch import Tensor
 from torch.nn import functional as F
 
 from algorithmic_efficiency import init_utils
-from functools import partial
 
 
 class LayerNorm(nn.Module):

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -15,24 +15,6 @@ from torch.nn import functional as F
 from algorithmic_efficiency import init_utils
 
 
-class LayerNorm(nn.Module):
-
-  def __init__(self, normalized_shape, epsilon=1e-6):
-    super().__init__()
-    self.normalized_shape = normalized_shape
-
-    self.scale = nn.Parameter(torch.zeros(self.normalized_shape[0]))
-    self.bias = nn.Parameter(torch.zeros(self.normalized_shape[0]))
-    self.epsilon = epsilon
-
-  def forward(self, x):
-    return F.layer_norm(x,
-                        self.normalized_shape,
-                        1 + self.scale,
-                        self.bias,
-                        self.epsilon)
-
-
 class UNet(nn.Module):
   r"""U-Net model from
     `"U-net: Convolutional networks

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/models.py
@@ -62,7 +62,7 @@ class UNet(nn.Module):
       ch //= 2
 
     self.up_transpose_conv.append(
-        TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm))
+        TransposeConvBlock(ch * 2, ch, use_tanh, use_layer_norm, size))
     size = int(size * 2)
     self.up_conv.append(
         nn.Sequential(

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/ssim.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/ssim.py
@@ -2,7 +2,6 @@
 
 import functools
 
-import functorch
 import torch
 import torch.nn.functional as F
 from torchvision.transforms.functional import pad as pad_fn

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/ssim.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/ssim.py
@@ -46,7 +46,7 @@ def ssim(logits, targets, mean=None, std=None, volume_max=None):
   std = std.view((-1,) + (1,) * (len(logits.shape) - 1))
   logits = logits * std + mean
   targets = targets * std + mean
-  ssims = functorch.vmap(structural_similarity)(logits, targets, volume_max)
+  ssims = torch.vmap(structural_similarity)(logits, targets, volume_max)
   return ssims
 
 

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -13,7 +13,7 @@ from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import pytorch_utils
 from algorithmic_efficiency import spec
 import algorithmic_efficiency.random_utils as prng
-from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.models import Unet
+from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.models import UNet
 from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.ssim import ssim
 from algorithmic_efficiency.workloads.fastmri.workload import \
     BaseFastMRIWorkload

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -13,7 +13,8 @@ from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import pytorch_utils
 from algorithmic_efficiency import spec
 import algorithmic_efficiency.random_utils as prng
-from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.models import UNet
+from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.models import \
+    UNet
 from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.ssim import ssim
 from algorithmic_efficiency.workloads.fastmri.workload import \
     BaseFastMRIWorkload

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -13,7 +13,7 @@ from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import pytorch_utils
 from algorithmic_efficiency import spec
 import algorithmic_efficiency.random_utils as prng
-from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch import models
+from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.models import Unet
 from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.ssim import ssim
 from algorithmic_efficiency.workloads.fastmri.workload import \
     BaseFastMRIWorkload
@@ -113,7 +113,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
       aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
     del aux_dropout_rate
     torch.random.manual_seed(rng[0])
-    model = models.UNet(
+    model = UNet(
         num_pool_layers=self.num_pool_layers,
         num_channels=self.num_channels,
         use_tanh=self.use_tanh,

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -13,7 +13,7 @@ class BaseFastMRIWorkload(spec.Workload):
   def target_metric_name(self) -> str:
     """The name of the target metric (useful for scoring/processing code)."""
     return 'ssim'
-  
+
   @property
   def use_layer_norm(self) -> bool:
     """Whether or not to use LayerNorm in the model."""

--- a/algorithmic_efficiency/workloads/fastmri/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/workload.py
@@ -13,6 +13,8 @@ class BaseFastMRIWorkload(spec.Workload):
   def target_metric_name(self) -> str:
     """The name of the target metric (useful for scoring/processing code)."""
     return 'ssim'
+  
+  @property
   def use_layer_norm(self) -> bool:
     """Whether or not to use LayerNorm in the model."""
     return False

--- a/algorithmic_efficiency/workloads/workloads.py
+++ b/algorithmic_efficiency/workloads/workloads.py
@@ -90,7 +90,7 @@ WORKLOADS = {
 BASE_WORKLOADS = [
     'criteo1tb',
     'fastmri',
-    ' imagenet_resnet',
+    'imagenet_resnet',
     'imagenet_vit',
     'librispeech_conformer',
     'librispeech_deepspeech',

--- a/docker/scripts/startup.sh
+++ b/docker/scripts/startup.sh
@@ -119,7 +119,6 @@ VALID_WORKLOADS=("criteo1tb" "imagenet_resnet" "imagenet_vit" "fastmri" "ogbg" \
                  "conformer_gelu" "fastmri_model_size" "fastmri_tanh" \
                  "fastmri_layernorm")
 
-
 # Set data and experiment paths
 ROOT_DATA_BUCKET="gs://mlcommons-data"
 ROOT_DATA_DIR="${HOME_DIR}/data"

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -226,6 +226,7 @@ def train_once(
           'ogbg',
           'criteo1tb',
           'imagenet_vit',
+          'fastmri'
       ]
       eager_backend_workloads = ['librispeech_deepspeech']
       aot_eager_backend_workloads = []

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -226,7 +226,6 @@ def train_once(
           'ogbg',
           'criteo1tb',
           'imagenet_vit',
-          'fastmri'
       ]
       eager_backend_workloads = ['librispeech_deepspeech']
       aot_eager_backend_workloads = []

--- a/tests/modeldiffs/fastmri/compare.py
+++ b/tests/modeldiffs/fastmri/compare.py
@@ -30,6 +30,7 @@ def sd_transform(sd):
   c = 0
   for idx, k in enumerate(keys):
     new_key = []
+    print(k)
     for idx2, i in enumerate(k):
       if 'ModuleList' in i or 'Sequential' in i:
         continue

--- a/tests/modeldiffs/fastmri/compare.py
+++ b/tests/modeldiffs/fastmri/compare.py
@@ -30,7 +30,6 @@ def sd_transform(sd):
   c = 0
   for idx, k in enumerate(keys):
     new_key = []
-    print(k)
     for idx2, i in enumerate(k):
       if 'ModuleList' in i or 'Sequential' in i:
         continue

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -52,7 +52,6 @@ def sd_transform(sd):
           i = i.replace('weight', 'kernel')
       new_key.append(i)
     new_key = tuple(new_key)
-    print(new_key)
     sd[new_key] = sd[k]
     del sd[k]
   return sd

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -43,7 +43,8 @@ def sd_transform(sd):
         i = i.replace('Conv2d', 'Conv')
       if 'ConvTranspose2d' in i:
         i = i.replace('ConvTranspose2d', 'ConvTranspose')
-      if 'LayerNorm' in i:
+      if 'GroupNorm' in i:
+        i = i.replace('GroupNorm', 'LayerNorm')
         layernorm = True
       if 'weight' in i:
         if layernorm:

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -8,9 +8,9 @@ import torch
 
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.fastmri.fastmri_jax.workload import \
-    FastMRIWorkload as JaxWorkload
+    FastMRILayerNormWorkload as JaxWorkload
 from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.workload import \
-    FastMRIWorkload as PytWorkload
+    FastMRILayerNormWorkload as PytWorkload
 from tests.modeldiffs.diff import out_diff
 
 

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -28,9 +28,9 @@ def sd_transform(sd):
 
   keys = sorted(sd.keys(), key=sort_key)
   c = 0
-  jax_weights_name = 'kernel'
   for idx, k in enumerate(keys):
     new_key = []
+    jax_weights_name = 'kernel'
     for idx2, i in enumerate(k):
       if 'ModuleList' in i or 'Sequential' in i:
         continue
@@ -44,6 +44,7 @@ def sd_transform(sd):
         i = i.replace('ConvTranspose2d', 'ConvTranspose')
       if 'LayerNorm' in i:
         jax_weights_name = 'scale'
+        continue
       if 'weight' in i:
         i = i.replace('weight', jax_weights_name)
       new_key.append(i)

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -1,0 +1,86 @@
+import os
+
+# Disable GPU access for both jax and pytorch.
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
+
+import jax
+import torch
+
+from algorithmic_efficiency import spec
+from algorithmic_efficiency.workloads.fastmri.fastmri_jax.workload import \
+    FastMRIWorkload as JaxWorkload
+from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.workload import \
+    FastMRIWorkload as PytWorkload
+from tests.modeldiffs.diff import out_diff
+
+
+def sd_transform(sd):
+
+  def sort_key(k):
+    if k[0] == 'ModuleList_0':
+      return (0, *k)
+    if k[0] == 'ConvBlock_0':
+      return (1, *k)
+    if k[0] == 'ModuleList_1':
+      return (2, *k)
+    if k[0] == 'ModuleList_2':
+      return (3, *k)
+
+  keys = sorted(sd.keys(), key=sort_key)
+  c = 0
+  for idx, k in enumerate(keys):
+    new_key = []
+    for idx2, i in enumerate(k):
+      if 'ModuleList' in i or 'Sequential' in i:
+        continue
+      if i.startswith('ConvBlock'):
+        if idx != 0 and keys[idx - 1][:idx2 + 1] != k[:idx2 + 1]:
+          c += 1
+        i = f'ConvBlock_{c}'
+      if 'Conv2d' in i:
+        i = i.replace('Conv2d', 'Conv')
+      if 'ConvTranspose2d' in i:
+        i = i.replace('ConvTranspose2d', 'ConvTranspose')
+      if 'weight' in i:
+        i = i.replace('weight', 'kernel')
+      new_key.append(i)
+    new_key = tuple(new_key)
+    sd[new_key] = sd[k]
+    del sd[k]
+  return sd
+
+
+key_transform = None
+if __name__ == '__main__':
+  # pylint: disable=locally-disabled, not-callable
+
+  jax_workload = JaxWorkload()
+  pytorch_workload = PytWorkload()
+
+  # Test outputs for identical weights and inputs.
+  image = torch.randn(2, 320, 320)
+
+  jax_batch = {'inputs': image.detach().numpy()}
+  pyt_batch = {'inputs': image}
+
+  pytorch_model_kwargs = dict(
+      augmented_and_preprocessed_input_batch=pyt_batch,
+      model_state=None,
+      mode=spec.ForwardPassMode.EVAL,
+      rng=None,
+      update_batch_norm=False)
+
+  jax_model_kwargs = dict(
+      augmented_and_preprocessed_input_batch=jax_batch,
+      mode=spec.ForwardPassMode.EVAL,
+      rng=jax.random.PRNGKey(0),
+      update_batch_norm=False)
+
+  out_diff(
+      jax_workload=jax_workload,
+      pytorch_workload=pytorch_workload,
+      jax_model_kwargs=jax_model_kwargs,
+      pytorch_model_kwargs=pytorch_model_kwargs,
+      key_transform=None,
+      sd_transform=sd_transform,
+  )

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -29,6 +29,7 @@ def sd_transform(sd):
   keys = sorted(sd.keys(), key=sort_key)
   c = 0
   for idx, k in enumerate(keys):
+    print(k)
     new_key = []
     layernorm = False
     for idx2, i in enumerate(k):

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -29,7 +29,6 @@ def sd_transform(sd):
   keys = sorted(sd.keys(), key=sort_key)
   c = 0
   for idx, k in enumerate(keys):
-    print(k)
     new_key = []
     layernorm = False
     for idx2, i in enumerate(k):

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -28,6 +28,7 @@ def sd_transform(sd):
 
   keys = sorted(sd.keys(), key=sort_key)
   c = 0
+  jax_weights_name = 'kernel'
   for idx, k in enumerate(keys):
     new_key = []
     for idx2, i in enumerate(k):
@@ -41,8 +42,10 @@ def sd_transform(sd):
         i = i.replace('Conv2d', 'Conv')
       if 'ConvTranspose2d' in i:
         i = i.replace('ConvTranspose2d', 'ConvTranspose')
+      if 'LayerNorm' in i:
+        jax_weights_name = 'scale'
       if 'weight' in i:
-        i = i.replace('weight', 'kernel')
+        i = i.replace('weight', jax_weights_name)
       new_key.append(i)
     new_key = tuple(new_key)
     sd[new_key] = sd[k]

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -30,7 +30,7 @@ def sd_transform(sd):
   c = 0
   for idx, k in enumerate(keys):
     new_key = []
-    jax_weights_name = 'kernel'
+    layernorm = False
     for idx2, i in enumerate(k):
       if 'ModuleList' in i or 'Sequential' in i:
         continue
@@ -43,10 +43,13 @@ def sd_transform(sd):
       if 'ConvTranspose2d' in i:
         i = i.replace('ConvTranspose2d', 'ConvTranspose')
       if 'LayerNorm' in i:
-        jax_weights_name = 'scale'
+        layernorm = True
         continue
       if 'weight' in i:
-        i = i.replace('weight', jax_weights_name)
+        if layernorm:
+          i = i.replace('weight', 'scale')
+        else:
+          i = i.replace('weight', 'dense')
       new_key.append(i)
     new_key = tuple(new_key)
     sd[new_key] = sd[k]

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -53,6 +53,7 @@ def sd_transform(sd):
           i = i.replace('weight', 'kernel')
       new_key.append(i)
     new_key = tuple(new_key)
+    print(new_key)
     sd[new_key] = sd[k]
     del sd[k]
   return sd

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -49,7 +49,7 @@ def sd_transform(sd):
         if layernorm:
           i = i.replace('weight', 'scale')
         else:
-          i = i.replace('weight', 'dense')
+          i = i.replace('weight', 'kernel')
       new_key.append(i)
     new_key = tuple(new_key)
     sd[new_key] = sd[k]

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -45,7 +45,6 @@ def sd_transform(sd):
         i = i.replace('ConvTranspose2d', 'ConvTranspose')
       if 'LayerNorm' in i:
         layernorm = True
-        continue
       if 'weight' in i:
         if layernorm:
           i = i.replace('weight', 'scale')

--- a/tests/modeldiffs/fastmri_model_size/compare.py
+++ b/tests/modeldiffs/fastmri_model_size/compare.py
@@ -1,0 +1,86 @@
+import os
+
+# Disable GPU access for both jax and pytorch.
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
+
+import jax
+import torch
+
+from algorithmic_efficiency import spec
+from algorithmic_efficiency.workloads.fastmri.fastmri_jax.workload import \
+    FastMRIModelSizeWorkload as JaxWorkload
+from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.workload import \
+    FastMRIModelSizeWorkload as PytWorkload
+from tests.modeldiffs.diff import out_diff
+
+
+def sd_transform(sd):
+
+  def sort_key(k):
+    if k[0] == 'ModuleList_0':
+      return (0, *k)
+    if k[0] == 'ConvBlock_0':
+      return (1, *k)
+    if k[0] == 'ModuleList_1':
+      return (2, *k)
+    if k[0] == 'ModuleList_2':
+      return (3, *k)
+
+  keys = sorted(sd.keys(), key=sort_key)
+  c = 0
+  for idx, k in enumerate(keys):
+    new_key = []
+    for idx2, i in enumerate(k):
+      if 'ModuleList' in i or 'Sequential' in i:
+        continue
+      if i.startswith('ConvBlock'):
+        if idx != 0 and keys[idx - 1][:idx2 + 1] != k[:idx2 + 1]:
+          c += 1
+        i = f'ConvBlock_{c}'
+      if 'Conv2d' in i:
+        i = i.replace('Conv2d', 'Conv')
+      if 'ConvTranspose2d' in i:
+        i = i.replace('ConvTranspose2d', 'ConvTranspose')
+      if 'weight' in i:
+        i = i.replace('weight', 'kernel')
+      new_key.append(i)
+    new_key = tuple(new_key)
+    sd[new_key] = sd[k]
+    del sd[k]
+  return sd
+
+
+key_transform = None
+if __name__ == '__main__':
+  # pylint: disable=locally-disabled, not-callable
+
+  jax_workload = JaxWorkload()
+  pytorch_workload = PytWorkload()
+
+  # Test outputs for identical weights and inputs.
+  image = torch.randn(2, 320, 320)
+
+  jax_batch = {'inputs': image.detach().numpy()}
+  pyt_batch = {'inputs': image}
+
+  pytorch_model_kwargs = dict(
+      augmented_and_preprocessed_input_batch=pyt_batch,
+      model_state=None,
+      mode=spec.ForwardPassMode.EVAL,
+      rng=None,
+      update_batch_norm=False)
+
+  jax_model_kwargs = dict(
+      augmented_and_preprocessed_input_batch=jax_batch,
+      mode=spec.ForwardPassMode.EVAL,
+      rng=jax.random.PRNGKey(0),
+      update_batch_norm=False)
+
+  out_diff(
+      jax_workload=jax_workload,
+      pytorch_workload=pytorch_workload,
+      jax_model_kwargs=jax_model_kwargs,
+      pytorch_model_kwargs=pytorch_model_kwargs,
+      key_transform=None,
+      sd_transform=sd_transform,
+  )

--- a/tests/modeldiffs/fastmri_tanh/compare.py
+++ b/tests/modeldiffs/fastmri_tanh/compare.py
@@ -1,0 +1,86 @@
+import os
+
+# Disable GPU access for both jax and pytorch.
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
+
+import jax
+import torch
+
+from algorithmic_efficiency import spec
+from algorithmic_efficiency.workloads.fastmri.fastmri_jax.workload import \
+    FastMRIWorkload as JaxWorkload
+from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.workload import \
+    FastMRIWorkload as PytWorkload
+from tests.modeldiffs.diff import out_diff
+
+
+def sd_transform(sd):
+
+  def sort_key(k):
+    if k[0] == 'ModuleList_0':
+      return (0, *k)
+    if k[0] == 'ConvBlock_0':
+      return (1, *k)
+    if k[0] == 'ModuleList_1':
+      return (2, *k)
+    if k[0] == 'ModuleList_2':
+      return (3, *k)
+
+  keys = sorted(sd.keys(), key=sort_key)
+  c = 0
+  for idx, k in enumerate(keys):
+    new_key = []
+    for idx2, i in enumerate(k):
+      if 'ModuleList' in i or 'Sequential' in i:
+        continue
+      if i.startswith('ConvBlock'):
+        if idx != 0 and keys[idx - 1][:idx2 + 1] != k[:idx2 + 1]:
+          c += 1
+        i = f'ConvBlock_{c}'
+      if 'Conv2d' in i:
+        i = i.replace('Conv2d', 'Conv')
+      if 'ConvTranspose2d' in i:
+        i = i.replace('ConvTranspose2d', 'ConvTranspose')
+      if 'weight' in i:
+        i = i.replace('weight', 'kernel')
+      new_key.append(i)
+    new_key = tuple(new_key)
+    sd[new_key] = sd[k]
+    del sd[k]
+  return sd
+
+
+key_transform = None
+if __name__ == '__main__':
+  # pylint: disable=locally-disabled, not-callable
+
+  jax_workload = JaxWorkload()
+  pytorch_workload = PytWorkload()
+
+  # Test outputs for identical weights and inputs.
+  image = torch.randn(2, 320, 320)
+
+  jax_batch = {'inputs': image.detach().numpy()}
+  pyt_batch = {'inputs': image}
+
+  pytorch_model_kwargs = dict(
+      augmented_and_preprocessed_input_batch=pyt_batch,
+      model_state=None,
+      mode=spec.ForwardPassMode.EVAL,
+      rng=None,
+      update_batch_norm=False)
+
+  jax_model_kwargs = dict(
+      augmented_and_preprocessed_input_batch=jax_batch,
+      mode=spec.ForwardPassMode.EVAL,
+      rng=jax.random.PRNGKey(0),
+      update_batch_norm=False)
+
+  out_diff(
+      jax_workload=jax_workload,
+      pytorch_workload=pytorch_workload,
+      jax_model_kwargs=jax_model_kwargs,
+      pytorch_model_kwargs=pytorch_model_kwargs,
+      key_transform=None,
+      sd_transform=sd_transform,
+  )

--- a/tests/modeldiffs/fastmri_tanh/compare.py
+++ b/tests/modeldiffs/fastmri_tanh/compare.py
@@ -8,9 +8,9 @@ import torch
 
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.fastmri.fastmri_jax.workload import \
-    FastMRIWorkload as JaxWorkload
+    FastMRITanhWorkload as JaxWorkload
 from algorithmic_efficiency.workloads.fastmri.fastmri_pytorch.workload import \
-    FastMRIWorkload as PytWorkload
+    FastMRITanhWorkload as PytWorkload
 from tests.modeldiffs.diff import out_diff
 
 

--- a/tests/modeldiffs/torch2jax_utils.py
+++ b/tests/modeldiffs/torch2jax_utils.py
@@ -77,6 +77,7 @@ class Torch2Jax:
     }
 
   def value_transform(self, v_transform_fn):
+    print(self.flattened_jax_model.keys())
     self.pytorch_sd = {
         k: v_transform_fn(k, self.pytorch_sd[k], self.flattened_jax_model[k])
         for k in self.pytorch_sd

--- a/tests/modeldiffs/torch2jax_utils.py
+++ b/tests/modeldiffs/torch2jax_utils.py
@@ -77,7 +77,6 @@ class Torch2Jax:
     }
 
   def value_transform(self, v_transform_fn):
-    print(self.flattened_jax_model.keys())
     self.pytorch_sd = {
         k: v_transform_fn(k, self.pytorch_sd[k], self.flattened_jax_model[k])
         for k in self.pytorch_sd


### PR DESCRIPTION
Add FastMRI workload variants:
- channels & pooling
- tanh
- layernorm

Also added modeldiff tests and checked that they passed.

Note on LayerNorm variant: We use torch.nn.GroupNorm with num_groups=1, to get an equivalent LayerNorm to JAX LayerNorm. The torch.nn.LayerNorm implementation only provides element-wise affine transformations, involving (C x W x H) size weights, whereas the JAX LayerNorm uses (C) size scaling weights. The torch.nn.GroupNorm module uses per-channel affine parameters which is equivalent to the Jax implementation.