### PR TITLE
Update Dataset Setup

### DIFF
--- a/algorithmic_efficiency/__init__.py
+++ b/algorithmic_efficiency/__init__.py
@@ -1,3 +1,3 @@
 """Algorithmic Efficiency."""
 
-__version__ = '0.0.1'
+__version__ = '0.1.0'

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -359,10 +359,10 @@ Note, that this requries the [`pigz` library](https://zlib.net/pigz/) to be inst
 ```bash
 $DATA_DIR
 ├── criteo1tb
-│  ├── day_0_000.csv
-│  ├── day_0_001.csv
-│  ├── day_0_002.csv
-│  ├── day_0_003.csv
+│  ├── day_0_00
+│  ├── day_0_01
+│  ├── day_0_02
+│  ├── day_0_03
 │  ├── [...]
 ```
 
@@ -428,8 +428,8 @@ In total, it should contain 543,323 files (via `find -type f | wc -l`) for a tot
 
 #### Training SPM Tokenizer
 
- A simple sentence piece tokenizer is trained over librispeech training
- data. This tokenizer is then used in later preprocessing step to tokenize transcripts.
+During the above commands, a simple sentence piece tokenizer is trained over librispeech training data.
+This tokenizer is then used in later preprocessing step to tokenize transcripts.
 This command generates `spm_model.vocab` file in `$DATA_DIR/librispeech`:
 
 ```bash

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,74 +1,111 @@
-# Dataset Setup
-TL;DR: 
-Use `dataset_setup.py` to download datasets.
-Usage:
+# MLCommons™ AlgoPerf: Dataset Setup
+
+## Table of Contents <!-- omit from toc -->
+
+- [General Setup](#general-setup)
+  - [Set Data Directory (Docker Container)](#set-data-directory-docker-container)
+  - [Set Data Directory (on Host)](#set-data-directory-on-host)
+    - [Start tmux session (Recommended)](#start-tmux-session-recommended)
+  - [Clean up](#clean-up)
+- [Individual Dataset Instructions](#individual-dataset-instructions)
+  - [OGBG](#ogbg)
+  - [WMT](#wmt)
+  - [FastMRI](#fastmri)
+  - [ImageNet](#imagenet)
+  - [Criteo1TB](#criteo1tb)
+  - [LibriSpeech](#librispeech)
+    - [Training SPM Tokenizer](#training-spm-tokenizer)
+    - [Preprocessing Script](#preprocessing-script)
+
+## General Setup
+
+This document provides instructions on downloading and preparing all datasets utilized in the AlgoPerf benchmark. You can prepare the individual datasets one-by-one as needed. If your setup, such as your cloud or cluster environment, already contains these datasets, you may skip the dataset setup for this particular data (and directly specify the dataset location in the `submission_runner.py`). Just verify that you are using the same dataset version (and possible preprocessing).
+
+*TL;DR to download and prepare a dataset, run `dataset_setup.py`:*
+
 ```bash
 python3 datasets/dataset_setup.py \
   --data_dir=~/data \
   --<dataset_name>
-  --<optional_fags>
+  --<optional_flags>
 ```
-The complete benchmark uses 6 datasets:
-- OGBG
-- WMT
-- FastMRI
-- Imagenet 
-- Criteo 1TB
-- Librispeech
 
+The complete benchmark uses 6 different datasets:
 
-Some dataset setups will require you to sign a third party agreement with the dataset owners in order to get the donwload URLs.
+- [OGBG](#ogbg)
+- [WMT](#wmt)
+- [FastMRI](#fastmri)
+- [Imagenet](#imagenet)
+- [Criteo 1TB](#criteo1tb)
+- [Librispeech](#librispeech)
 
-# Per dataset instructions
-## Environment
+Some dataset setups will require you to sign a third-party agreement with the dataset owners in order to get the download URLs.
 
-### Set data directory (Docker container)
-If you are running the `dataset_setup.py` script from a Docker container, please 
+### Set Data Directory (Docker Container)
+
+If you are running the `dataset_setup.py` script from a Docker container, please
 make sure the data directory is mounted to a directory on your host with
--v flag. If you are following instructions from the README you will have used 
+`-v` flag. If you are following instructions from the [Getting Started guide](/GETTING_STARTED.md) you will have used
 the `-v $HOME/data:/data` flag in the `docker run` command. This will mount
-the `$HOME/data` directory to the `/data` directory in the container. 
-In this case set --data_dir to  `/data`. 
+the `$HOME/data` directory to the `/data` directory in the container.
+In this case set, `--data_dir` to  `/data`.
+
 ```bash
 DATA_DIR='/data'
 ```
-### Set data directory (on host)
-Alternatively, if you are running the data download script directly on your host, feel free
-to choose whatever directory you find suitable, further submission instructions 
-assume the data is stored in `~/data`.
+
+### Set Data Directory (on Host)
+
+Alternatively, if you are running the data download script directly on your host, feel free to choose whatever directory you find suitable, further submission instructions assume the data is stored in `~/data`.
+
 ```bash
 DATA_DIR='~/data'
 ```
+
 #### Start tmux session (Recommended)
-If running the dataset_setup.py on directly on host it is recommended to run 
-the dataset_setup.py script in a tmux session because some of the data downloads may 
-take several hours. To avoid your setup being interrupted start a tmux session:
+
+If running the `dataset_setup.py` on directly on host it is recommended to run
+the `dataset_setup.py` script in a `tmux` session because some of the data downloads may take several hours. To avoid your setup being interrupted start a `tmux` session:
+
 ```bash
 tmux new -s data_setup
 ```
 
+### Clean up
 
-## Datasets
+In order to avoid potential accidental deletion, this script does NOT
+delete any intermediate temporary files (such as zip archives) without a user
+confirmation. Deleting temp files is particularly important for Criteo 1TB, as
+there can be multiple copies of the dataset on disk during preprocessing if
+files are not cleaned up.
 
-### OGBG 
+By default, a user will be prompted before any files are deleted. If you do not want any temp files to be deleted, you can pass `--interactive_deletion=false` and then all files will be downloaded to the provided `--temp_dir`, and the user can manually delete these after downloading has finished.
+
+## Individual Dataset Instructions
+
+### OGBG
+
 From `algorithmic-efficiency` run:
+
 ```bash
 python3 datasets/dataset_setup.py \
---data_dir $DATA_DIR/ogbg \
+--data_dir $DATA_DIR \
 --ogbg
 ```
 
-### WMT 
+### WMT
+
 From `algorithmic-efficiency` run:
+
 ```bash
 python3 datasets/dataset_setup.py \
 --data_dir $DATA_DIR \
 --wmt
 ```
 
+### FastMRI
 
-## FastMRI
-Fill out form on https://fastmri.med.nyu.edu/. After filling out the form 
+Fill out form on <https://fastmri.med.nyu.edu/>. After filling out the form
 you should get an email containing the URLS for "knee_singlecoil_train",
 "knee_singlecoil_val" and "knee_singlecoil_test".  
 
@@ -81,18 +118,14 @@ python3 datasets/dataset_setup.py \
 --fastmri_knee_singlecoil_test_url '<knee_singlecoil_test_url>'
 ```
 
-## ImageNet
-Register on https://image-net.org/ and follow directions to obtain the 
+### ImageNet
+
+Register on <https://image-net.org/> and follow directions to obtain the
 URLS for the ILSVRC2012 train and validation images.
+The script will additionally automatically download the `matched-frequency` version of [ImageNet v2](https://www.tensorflow.org/datasets/catalog/imagenet_v2#imagenet_v2matched-frequency_default_config), which is used as the test set of the ImageNet workloads.
 
-Imagenet dataset processsing is resource intensive. To avoid potential
-ResourcExhausted errors increase the maximum number of open file descriptors:
-```bash
-ulimit -n 8192
-```
-
-The imagenet data pipeline differs between the pytorch and jax workloads. 
-Therefore, you will have to specify the framework (pytorch or jax) through theframework flag.
+The ImageNet data pipeline differs between the PyTorch and JAX workloads.
+Therefore, you will have to specify the framework (either `pytorch` or `jax`) through the framework flag.
 
 ```bash
 python3 datasets/dataset_setup.py \ 
@@ -102,15 +135,22 @@ python3 datasets/dataset_setup.py \
 --imagenet_train_url <imagenet_train_url> \
 --imagenet_val_url <imagenet_val_url> \
 --framework jax
-
 ```
 
-Note that some functions use subprocess.Popen(..., shell=True), which can be
-dangerous if the user injects code into the --data_dir or --temp_dir flags. We
-do some basic sanitization in main(), but submitters should not let untrusted
+Imagenet dataset processsing is resource intensive. To avoid potential
+ResourcExhausted errors increase the maximum number of open file descriptors:
+
+```bash
+ulimit -n 8192
+```
+
+Note that some functions use `subprocess.Popen(..., shell=True)`, which can be
+dangerous if the user injects code into the `--data_dir` or `--temp_dir` flags. We
+do some basic sanitization in `main()`, but submitters should not let untrusted
 users run this script on their systems.
 
-## Criteo1tb
+### Criteo1TB
+
 ```bash
 python3 datasets/dataset_setup.py \
 --data_dir $DATA_DIR \
@@ -118,19 +158,10 @@ python3 datasets/dataset_setup.py \
 --criteo1tb 
 ```
 
-### Clean up 
-In order to avoid potential accidental deletion, this script does NOT
-delete any intermediate temporary files (such as zip archives) without a user
-confirmation. Deleting temp files is particularly important for Criteo 1TB, as
-there can be multiple copies of the dataset on disk during preprocessing if
-files are not cleaned up. If you do not want any temp files to be deleted, you
-can pass --interactive_deletion=false and then all files will be downloaded to
-the provided --temp_dir, and the user can manually delete these after
-downloading has finished.
+### LibriSpeech
 
-
-## Librispeech
 To download, train a tokenizer and preprocess the librispeech dataset:
+
 ```bash
 python3 datasets/dataset_setup.py \
 --data_dir $DATA_DIR \
@@ -138,26 +169,26 @@ python3 datasets/dataset_setup.py \
 --librispeech
 ```
 
-### Notes on librispeech preprocessing
 #### Training SPM Tokenizer
+
  A simple sentence piece tokenizer is trained over librispeech training
  data. This tokenizer is then used in later preprocessing step to tokenize transcripts.
 This command generates `spm_model.vocab` file in `$DATA_DIR/librispeech`:
+
 ```bash
 python3 librispeech_tokenizer.py --train --data_dir=$DATA_DIR/librispeech
 ```
 
 The trained tokenizer can be loaded back to do sanity check by tokenizing + de-tokenizing a constant string:
+
 ```bash
 librispeech_tokenizer.py --data_dir=$DATA_DIR/librispeech
 ```
 
 #### Preprocessing Script
+
 The preprocessing script will generate `.npy` files for audio data, `features.csv` which has paths to saved audio `.npy`, and `trans.csv` which has paths to `features.csv` and transcription data.
 
 ```bash
 python3 librispeech_preprocess.py --data_dir=$DATA_DIR/librispeech --tokenizer_vocab_path=$DATA_DIR/librispeech/spm_model.vocab
 ```
-
-
-

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -351,6 +351,8 @@ python3 datasets/dataset_setup.py \
 --criteo1tb 
 ```
 
+Note, that this requries the [`pigz` library](https://zlib.net/pigz/) to be installed.
+
 <details>
 <summary>The final directory structure should look like this:</summary>
 
@@ -377,6 +379,8 @@ python3 datasets/dataset_setup.py \
 --temp_dir $DATA_DIR/tmp \
 --librispeech
 ```
+
+Note, that this requries the [`ffmpeg` toolbox](https://ffmpeg.org/) to be installed.
 
 <details>
 <summary>The final directory structure should look like this:</summary>

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -423,7 +423,7 @@ $DATA_DIR
 │  │   ├── [...]
 ```
 
-In total, it should contain 543,323 files (via `find -type f | wc -l`) for a total of 338 GB (via `du -sch librispeech/`).
+In total, it should contain 543,323 files (via `find -type f | wc -l`) for a total of 388 GB (via `du -sch librispeech/`).
 </details>
 
 #### Training SPM Tokenizer

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -388,36 +388,39 @@ Note, that this requries the [`ffmpeg` toolbox](https://ffmpeg.org/) to be insta
 ```bash
 $DATA_DIR
 ├──librispeech
+│  ├── dev-clean.csv
+│  ├── dev-other.csv
+│  ├── spm_model.vocab
+│  ├── test-clean.csv
+│  ├── train-clean-100.csv
+│  ├── train-clean-360.csv
+│  ├── train-clean-500.csv
 │  ├── dev-clean
 │  │   ├── 1272-128104-0000_audio.npy
 │  │   ├── 1272-128104-0000_targets.npy
+│  │   ├── 1272-128104-0001_audio.npy
+│  │   ├── 1272-128104-0001_targets.npy
 │  │   ├── [...]
-│  ├── dev-clean.csv
 │  ├── dev-other
 │  │   ├── 116-288045-0000_audio.npy
 │  │   ├── 116-288045-0000_targets.npy
 │  │   ├── [...]
-│  ├── dev-other.csv
-│  ├── spm_model.vocab
 │  ├── test-clean
 │  │   ├── 1089-134686-0000_audio.npy  
 │  │   ├── 1089-134686-0000_targets.npy
 │  │   ├── [...]
-│  ├── test-clean.csv
 │  ├── train-clean-100
 │  │   ├── 103-1240-0000_audio.npy
 │  │   ├── 103-1240-0000_targets.npy
 │  │   ├── [...]
-│  ├── train-clean-100.csv
 │  ├── train-clean-360
 │  │   ├── 100-121669-0000_audio.npy
 │  │   ├── 100-121669-0000_targets.npy
 │  │   ├── [...]
-│  ├── train-clean-360.csv
-│  │   ├── 985-126228-0050_audio.npy
-│  │   └── 985-126228-0050_targets.npy
+│  ├── train-other-500
+│  │   ├── 1006-135212-0000_audio.npy
+│  │   ├── 1006-135212-0000_targets.npy
 │  │   ├── [...]
-│  └── train-other-500.csv
 ```
 
 In total, it should contain 543,323 files (via `find -type f | wc -l`) for a total of 338 GB (via `du -sch librispeech/`).

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -93,6 +93,32 @@ python3 datasets/dataset_setup.py \
 --ogbg
 ```
 
+<details>
+<summary>The final directory structure should look like this:</summary>
+
+```bash
+$DATA_DIR
+├── ogbg
+│   └── ogbg_molpcba
+│       └── 0.1.3
+│           ├── dataset_info.json
+│           ├── features.json
+│           ├── metadata.json
+│           ├── ogbg_molpcba-test.tfrecord-00000-of-00001
+│           ├── ogbg_molpcba-train.tfrecord-00000-of-00008
+│           ├── ogbg_molpcba-train.tfrecord-00001-of-00008
+│           ├── ogbg_molpcba-train.tfrecord-00002-of-00008
+│           ├── ogbg_molpcba-train.tfrecord-00003-of-00008
+│           ├── ogbg_molpcba-train.tfrecord-00004-of-00008
+│           ├── ogbg_molpcba-train.tfrecord-00005-of-00008
+│           ├── ogbg_molpcba-train.tfrecord-00006-of-00008
+│           ├── ogbg_molpcba-train.tfrecord-00007-of-00008
+│           └── ogbg_molpcba-validation.tfrecord-00000-of-00001
+```
+
+In total, it should contain 13 files (via `find -type f | wc -l`) for a total of 777 MB (via `du -sch ogbg/`).
+</details>
+
 ### WMT
 
 From `algorithmic-efficiency` run:
@@ -102,6 +128,64 @@ python3 datasets/dataset_setup.py \
 --data_dir $DATA_DIR \
 --wmt
 ```
+
+<details>
+<summary>The final directory structure should look like this:</summary>
+
+```bash
+$DATA_DIR
+├── wmt
+    ├── wmt14_translate
+    │   └── de-en
+    │       └── 1.0.0
+    │           ├── dataset_info.json
+    │           ├── features.json
+    │           ├── wmt14_translate-test.tfrecord-00000-of-00001
+    │           ├── wmt14_translate-train.tfrecord-00000-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00001-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00002-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00003-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00004-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00005-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00006-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00007-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00008-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00009-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00010-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00011-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00012-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00013-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00014-of-00016
+    │           ├── wmt14_translate-train.tfrecord-00015-of-00016
+    │           └── wmt14_translate-validation.tfrecord-00000-of-00001
+    ├── wmt17_translate
+    │   └── de-en
+    │       └── 1.0.0
+    │           ├── dataset_info.json
+    │           ├── features.json
+    │           ├── wmt17_translate-test.tfrecord-00000-of-00001
+    │           ├── wmt17_translate-train.tfrecord-00000-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00001-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00002-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00003-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00004-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00005-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00006-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00007-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00008-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00009-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00010-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00011-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00012-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00013-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00014-of-00016
+    │           ├── wmt17_translate-train.tfrecord-00015-of-00016
+    │           └── wmt17_translate-validation.tfrecord-00000-of-00001
+    └── wmt_sentencepiece_model
+```
+
+In total, it should contain 43 files (via `find -type f | wc -l`) for a total of 3.3 GB (via `du -sch wmt/`).
+</details>
 
 ### FastMRI
 
@@ -117,6 +201,29 @@ python3 datasets/dataset_setup.py \
 --fastmri_knee_singlecoil_val_url '<knee_singlecoil_val_url>' \
 --fastmri_knee_singlecoil_test_url '<knee_singlecoil_test_url>'
 ```
+
+<details>
+<summary>The final directory structure should look like this:</summary>
+
+```bash
+$DATA_DIR
+├── fastmri
+│   ├── knee_singlecoil_test
+│   │   ├── file1000022.h5
+│   │   ├── [...]
+│   │   └── file1002571.h5
+│   ├── knee_singlecoil_train
+│   │   ├── file1000001.h5
+│   │   ├── [...]
+│   │   └── file1002569.h5
+│   └── knee_singlecoil_val
+│       ├── file1000000.h5
+│       ├── [...]
+│       └── file1002570.h5
+```
+
+In total, it should contain 1280 files (via `find -type f | wc -l`) for a total of 112 GB (via `du -sch fastmri/`).
+</details>
 
 ### ImageNet
 
@@ -149,6 +256,73 @@ dangerous if the user injects code into the `--data_dir` or `--temp_dir` flags. 
 do some basic sanitization in `main()`, but submitters should not let untrusted
 users run this script on their systems.
 
+<details>
+<summary>The final directory structure should look like this for ImageNet2012 (PyTorch):</summary>
+
+```bash
+$DATA_DIR
+├── imagenet
+│   ├── train
+│       ├── n01440764
+│           ├── n01440764_10026.JPEG
+│           ├── n01440764_10027.JPEG
+│           ├── n01440764_10029.JPEG
+│           ├── [...]
+│       ├── [...]
+│   └── val
+│       ├── n01440764
+│           ├── ILSVRC2012_val_00000293.JPEG
+│           ├── ILSVRC2012_val_00002138.JPEG
+│           ├── [...]
+│       ├── [...]
+```
+
+In total, it should contain 1,281,167 `train` files and 50,000 `val` (via `find -type f | wc -l`) for a total of 177 GB and 7.8 GB, respectively (via `du -sch train/` and `du -sch val/`).
+</details>
+
+**TODO**
+<details>
+<summary>The final directory structure should look like this for ImageNet2012 (JAX):</summary>
+
+```bash
+$DATA_DIR
+```
+
+In total, it should contain ?? files (via `find -type f | wc -l`) for a total of ?? GB (via `du -sch imagenet/`).
+</details>
+
+<details>
+<summary>The final directory structure should look like this for ImageNet v2:</summary>
+
+```bash
+$DATA_DIR
+├── imagenet_v2
+│   └── matched-frequency
+│       └── 3.0.0
+│           ├── dataset_info.json
+│           ├── features.json
+│           ├── imagenet_v2-test.tfrecord-00000-of-00016
+│           ├── imagenet_v2-test.tfrecord-00001-of-00016
+│           ├── imagenet_v2-test.tfrecord-00002-of-00016
+│           ├── imagenet_v2-test.tfrecord-00003-of-00016
+│           ├── imagenet_v2-test.tfrecord-00004-of-00016
+│           ├── imagenet_v2-test.tfrecord-00005-of-00016
+│           ├── imagenet_v2-test.tfrecord-00006-of-00016
+│           ├── imagenet_v2-test.tfrecord-00007-of-00016
+│           ├── imagenet_v2-test.tfrecord-00008-of-00016
+│           ├── imagenet_v2-test.tfrecord-00009-of-00016
+│           ├── imagenet_v2-test.tfrecord-00010-of-00016
+│           ├── imagenet_v2-test.tfrecord-00011-of-00016
+│           ├── imagenet_v2-test.tfrecord-00012-of-00016
+│           ├── imagenet_v2-test.tfrecord-00013-of-00016
+│           ├── imagenet_v2-test.tfrecord-00014-of-00016
+│           ├── imagenet_v2-test.tfrecord-00015-of-00016
+│           └── label.labels.txt
+```
+
+In total, it should contain 20 files (via `find -type f | wc -l`) for a total of 1.2 GB (via `du -sch imagenet_v2/`).
+</details>
+
 ### Criteo1TB
 
 ```bash
@@ -157,6 +331,17 @@ python3 datasets/dataset_setup.py \
 --temp_dir $DATA_DIR/tmp \
 --criteo1tb 
 ```
+
+**TODO**
+<details>
+<summary>The final directory structure should look like this:</summary>
+
+```bash
+$DATA_DIR
+```
+
+In total, it should contain ?? files (via `find -type f | wc -l`) for a total of ?? GB (via `du -sch criteo1tb/`).
+</details>
 
 ### LibriSpeech
 
@@ -168,6 +353,17 @@ python3 datasets/dataset_setup.py \
 --temp_dir $DATA_DIR/tmp \
 --librispeech
 ```
+
+**TODO**
+<details>
+<summary>The final directory structure should look like this:</summary>
+
+```bash
+$DATA_DIR
+```
+
+In total, it should contain ?? files (via `find -type f | wc -l`) for a total of ?? GB (via `du -sch librispeech/`).
+</details>
 
 #### Training SPM Tokenizer
 

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -280,19 +280,38 @@ $DATA_DIR
 In total, it should contain 1,281,167 `train` files and 50,000 `val` (via `find -type f | wc -l`) for a total of 177 GB and 7.8 GB, respectively (via `du -sch train/` and `du -sch val/`).
 </details>
 
-**TODO**
 <details>
 <summary>The final directory structure should look like this for ImageNet2012 (JAX):</summary>
 
 ```bash
 $DATA_DIR
+├──imagenet
+│  ├── jax
+│  │   ├── downloads
+│  │   │   ├── extracted
+│  │   │   └── manual_
+│  │   ├── imagenet2012
+│  │   │   └── 5.1.0
+│  │   │       ├── dataset_info.json
+│  │   │       ├── features.json
+│  │   │       ├── imagenet2012-train.tfrecord-00000-of-01024
+│  │   │       ├── imagenet2012-train.tfrecord-00001-of-01024
+│  │   │       ├── [...]
+│  │   └── imagenet_v2
+│  │       └── matched-frequency
+│  │           └── 3.0.0
+│  │               ├── dataset_info.json
+│  │               ├── features.json
+│  │               ├── imagenet_v2-test.tfrecord-00000-of-00016
+│  │               ├── imagenet_v2-test.tfrecord-00001-of-00016
+│  │               ├── [...]
 ```
 
-In total, it should contain ?? files (via `find -type f | wc -l`) for a total of ?? GB (via `du -sch imagenet/`).
+In total, it should contain 1,111 files (via `find -type f | wc -l`) for a total of 145 GB (via `du -sch imagenet/jax`).
 </details>
 
 <details>
-<summary>The final directory structure should look like this for ImageNet v2:</summary>
+<summary>The final directory structure should look like this for ImageNet v2 (separate):</summary>
 
 ```bash
 $DATA_DIR
@@ -332,15 +351,20 @@ python3 datasets/dataset_setup.py \
 --criteo1tb 
 ```
 
-**TODO**
 <details>
 <summary>The final directory structure should look like this:</summary>
 
 ```bash
 $DATA_DIR
+├── criteo1tb
+│  ├── day_0_000.csv
+│  ├── day_0_001.csv
+│  ├── day_0_002.csv
+│  ├── day_0_003.csv
+│  ├── [...]
 ```
 
-In total, it should contain ?? files (via `find -type f | wc -l`) for a total of ?? GB (via `du -sch criteo1tb/`).
+In total, it should contain 885 files (via `find -type f | wc -l`) for a total of 1.1 TB (via `du -sch criteo1tb/`).
 </details>
 
 ### LibriSpeech
@@ -354,15 +378,45 @@ python3 datasets/dataset_setup.py \
 --librispeech
 ```
 
-**TODO**
 <details>
 <summary>The final directory structure should look like this:</summary>
 
 ```bash
 $DATA_DIR
+├──librispeech
+│  ├── dev-clean
+│  │   ├── 1272-128104-0000_audio.npy
+│  │   ├── 1272-128104-0000_targets.npy
+│  │   ├── [...]
+│  ├── dev-clean.csv
+│  ├── dev-other
+│  │   ├── 116-288045-0000_audio.npy
+│  │   ├── 116-288045-0000_targets.npy
+│  │   ├── [...]
+│  ├── dev-other.csv
+│  ├── spm_model.vocab
+│  ├── test-clean
+│  │   ├── 1089-134686-0000_audio.npy  
+│  │   ├── 1089-134686-0000_targets.npy
+│  │   ├── [...]
+│  ├── test-clean.csv
+│  ├── train-clean-100
+│  │   ├── 103-1240-0000_audio.npy
+│  │   ├── 103-1240-0000_targets.npy
+│  │   ├── [...]
+│  ├── train-clean-100.csv
+│  ├── train-clean-360
+│  │   ├── 100-121669-0000_audio.npy
+│  │   ├── 100-121669-0000_targets.npy
+│  │   ├── [...]
+│  ├── train-clean-360.csv
+│  │   ├── 985-126228-0050_audio.npy
+│  │   └── 985-126228-0050_targets.npy
+│  │   ├── [...]
+│  └── train-other-500.csv
 ```
 
-In total, it should contain ?? files (via `find -type f | wc -l`) for a total of ?? GB (via `du -sch librispeech/`).
+In total, it should contain 543,323 files (via `find -type f | wc -l`) for a total of 338 GB (via `du -sch librispeech/`).
 </details>
 
 #### Training SPM Tokenizer

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -627,7 +627,7 @@ def download_librispeech(data_dir, tmp_dir):
         f'tar xzvf {tar_path} --directory {tmp_librispeech_dir}',
         shell=True).communicate()
 
-  tokenizer_vocab_path = os.path.join(data_dir, 'spm_model.vocab')
+  tokenizer_vocab_path = os.path.join(final_data_dir, 'spm_model.vocab')
 
   if not os.path.exists(tokenizer_vocab_path):
     librispeech_tokenizer.run(

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -26,17 +26,19 @@ and final data dir locations are on the same drive.
 
 Criteo 1TB download size: ~350GB
 Criteo 1TB final disk size: ~1TB
-FastMRI download size:
-FastMRI final disk size:
-LibriSpeech download size:
-LibriSpeech final disk size:
-OGBG download size:
-OGBG final disk size:
-WMT download size: (1.58 GiB + ) =
-WMT final disk size:
+FastMRI download size: ~90GB
+FastMRI final disk size: ~110GB
+ImageNet download size: ~150GB
+ImageNet final disk size: ~150GB
+LibriSpeech download size: ~60GB
+LibriSpeech final disk size: ~350GB
+OGBG download size: ~37MB
+OGBG final disk size: ~800MB
+WMT download size: ~3GB
+WMT final disk size: ~3GB
 _______________________
-Total download size:
-Total disk size:
+Total download size: ~650GB
+Total disk size: ~1.1TB
 
 Some datasets require signing a form before downloading:
 
@@ -49,8 +51,8 @@ ImageNet:
 Register on https://image-net.org/ and run this script with the links to the
 ILSVRC2012 train and validation images.
 
-Note for tfds ImageNet, you may have to increase the max number of files allowed
-open at once using `ulimit -n 8192`.
+Note for tfds ImageNet, you may have to increase the max number of files
+allowed open at once using `ulimit -n 8192`.
 
 Example command:
 

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -79,7 +79,6 @@ from datasets import librispeech_tokenizer
 
 import functools
 import os
-import resource
 import shutil
 import subprocess
 import tarfile

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -601,6 +601,8 @@ def download_librispeech(dataset_dir, tmp_dir):
 
   for split in ['dev', 'test']:
     for version in ['clean', 'other']:
+      if split == 'test' and version == 'other':
+        continue
       wget_cmd = (
           f'wget --directory-prefix={tmp_librispeech_dir} '
           f'http://www.openslr.org/resources/12/{split}-{version}.tar.gz')

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -334,6 +334,7 @@ def download_criteo1tb(data_dir,
 
 
 def download_cifar(data_dir, framework):
+  data_dir = os.path.join(data_dir, 'cifar10')
   if framework == 'jax':
     tfds.builder('cifar10:3.0.2', data_dir=data_dir).download_and_prepare()
   elif framework == 'pytorch':
@@ -398,18 +399,18 @@ def extract(source, dest, mode='r:xz'):
 
 
 def setup_fastmri(data_dir, src_data_dir):
+  data_dir = os.path.join(data_dir, 'fastmri')
 
   train_tar_file_path = os.path.join(src_data_dir, FASTMRI_TRAIN_TAR_FILENAME)
   val_tar_file_path = os.path.join(src_data_dir, FASTMRI_VAL_TAR_FILENAME)
   test_tar_file_path = os.path.join(src_data_dir, FASTMRI_TEST_TAR_FILENAME)
 
   # Make train, val and test subdirectories
-  fastmri_data_dir = os.path.join(data_dir, 'fastmri')
-  train_data_dir = os.path.join(fastmri_data_dir, 'train')
+  train_data_dir = os.path.join(data_dir, 'train')
   os.makedirs(train_data_dir, exist_ok=True)
-  val_data_dir = os.path.join(fastmri_data_dir, 'val')
+  val_data_dir = os.path.join(data_dir, 'val')
   os.makedirs(val_data_dir, exist_ok=True)
-  test_data_dir = os.path.join(fastmri_data_dir, 'test')
+  test_data_dir = os.path.join(data_dir, 'test')
   os.makedirs(test_data_dir, exist_ok=True)
 
   # Unzip tar file into subdirectories
@@ -425,6 +426,7 @@ def setup_fastmri(data_dir, src_data_dir):
 
 def download_imagenet(data_dir, imagenet_train_url, imagenet_val_url):
   """Downloads and returns the download dir."""
+  data_dir = os.path.join(data_dir, 'imagenet')
   imagenet_train_filepath = os.path.join(data_dir, IMAGENET_TRAIN_TAR_FILENAME)
   imagenet_val_filepath = os.path.join(data_dir, IMAGENET_VAL_TAR_FILENAME)
 
@@ -456,6 +458,7 @@ def download_imagenet(data_dir, imagenet_train_url, imagenet_val_url):
 
 
 def setup_imagenet(data_dir, framework=None):
+  data_dir = os.path.join(data_dir, 'imagenet')
   if framework == 'jax':
     setup_imagenet_jax(data_dir)
 
@@ -629,6 +632,7 @@ def download_librispeech(dataset_dir, tmp_dir):
 
 
 def download_mnist(data_dir):
+  data_dir = os.path.join(data_dir, 'MNIST')  # Capitalization to match PyTorch
   tfds.builder('mnist', data_dir=data_dir).download_and_prepare()
 
 
@@ -714,9 +718,8 @@ def main(_):
       raise ValueError(
           'Please specify either jax or pytorch framework through framework '
           'flag.')
-    imagenet_data_dir = os.path.join(data_dir, 'imagenet')
-    download_imagenet(imagenet_data_dir, imagenet_train_url, imagenet_val_url)
-    setup_imagenet(imagenet_data_dir, framework=FLAGS.framework)
+    download_imagenet(data_dir, imagenet_train_url, imagenet_val_url)
+    setup_imagenet(data_dir, framework=FLAGS.framework)
 
   if FLAGS.all or FLAGS.librispeech:
     logging.info('Downloading Librispeech...')

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -588,13 +588,13 @@ def download_imagenet_v2(data_dir):
       data_dir=data_dir).download_and_prepare()
 
 
-def download_librispeech(dataset_dir, tmp_dir):
+def download_librispeech(data_dir, tmp_dir):
   # After extraction the result is a folder named Librispeech containing audio
   # files in .flac format along with transcripts containing name of audio file
   # and corresponding transcription.
   tmp_librispeech_dir = os.path.join(tmp_dir, 'librispeech')
   extracted_data_dir = os.path.join(tmp_librispeech_dir, 'LibriSpeech')
-  final_data_dir = os.path.join(dataset_dir, 'librispeech')
+  final_data_dir = os.path.join(data_dir, 'librispeech')
 
   _maybe_mkdir(tmp_librispeech_dir)
   _maybe_mkdir(final_data_dir)
@@ -627,10 +627,13 @@ def download_librispeech(dataset_dir, tmp_dir):
         f'tar xzvf {tar_path} --directory {tmp_librispeech_dir}',
         shell=True).communicate()
 
-  tokenizer_vocab_path = os.path.join(extracted_data_dir, 'spm_model.vocab')
+  tokenizer_vocab_path = os.path.join(data_dir, 'spm_model.vocab')
 
   if not os.path.exists(tokenizer_vocab_path):
-    librispeech_tokenizer.run(train=True, data_dir=extracted_data_dir)
+    librispeech_tokenizer.run(
+        train=True,
+        input_dir=extracted_data_dir,
+        tokenizer_vocab_path=tokenizer_vocab_path)
 
   librispeech_preprocess.run(
       input_dir=extracted_data_dir,

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -399,30 +399,34 @@ def extract(source, dest, mode='r:xz'):
   tar.close()
 
 
-def setup_fastmri(data_dir, src_data_dir):
-  data_dir = os.path.join(data_dir, 'fastmri')
-
-  train_tar_file_path = os.path.join(src_data_dir, FASTMRI_TRAIN_TAR_FILENAME)
-  val_tar_file_path = os.path.join(src_data_dir, FASTMRI_VAL_TAR_FILENAME)
-  test_tar_file_path = os.path.join(src_data_dir, FASTMRI_TEST_TAR_FILENAME)
-
-  # Make train, val and test subdirectories
-  train_data_dir = os.path.join(data_dir, 'train')
-  os.makedirs(train_data_dir, exist_ok=True)
-  val_data_dir = os.path.join(data_dir, 'val')
-  os.makedirs(val_data_dir, exist_ok=True)
-  test_data_dir = os.path.join(data_dir, 'test')
-  os.makedirs(test_data_dir, exist_ok=True)
+def setup_fastmri(data_dir):
+  train_tar_file_path = os.path.join(data_dir, FASTMRI_TRAIN_TAR_FILENAME)
+  val_tar_file_path = os.path.join(data_dir, FASTMRI_VAL_TAR_FILENAME)
+  test_tar_file_path = os.path.join(data_dir, FASTMRI_TEST_TAR_FILENAME)
 
   # Unzip tar file into subdirectories
-  logging.info('Unzipping {} to {}'.format(train_tar_file_path, train_data_dir))
-  extract(train_tar_file_path, train_data_dir)
-  logging.info('Unzipping {} to {}'.format(val_tar_file_path, val_data_dir))
-  extract(val_tar_file_path, val_data_dir)
-  logging.info('Unzipping {} to {}'.format(test_tar_file_path, test_data_dir))
-  extract(test_tar_file_path, test_data_dir)
-  logging.info('Set up fastMRI dataset complete')
+  logging.info('Unzipping {} to {}'.format(train_tar_file_path, data_dir))
+  extract(train_tar_file_path, data_dir)
+  logging.info('Unzipping {} to {}'.format(val_tar_file_path, data_dir))
+  extract(val_tar_file_path, data_dir)
+  logging.info('Unzipping {} to {}'.format(test_tar_file_path, data_dir))
+  extract(test_tar_file_path, data_dir)
   logging.info('Extraction completed!')
+
+  # Rename folders to match what the workload expects
+  os.rename(
+      os.path.join(data_dir, "singlecoil_train"),
+      os.path.join(data_dir, "knee_singlecoil_train"),
+  )
+  os.rename(
+      os.path.join(data_dir, "singlecoil_val"),
+      os.path.join(data_dir, "knee_singlecoil_val"),
+  )
+  os.rename(
+      os.path.join(data_dir, "singlecoil_test"),
+      os.path.join(data_dir, "knee_singlecoil_test"),
+  )
+  logging.info("Set up fastMRI dataset complete")
 
 
 def download_imagenet(data_dir, imagenet_train_url, imagenet_val_url):

--- a/datasets/librispeech_preprocess.py
+++ b/datasets/librispeech_preprocess.py
@@ -31,8 +31,7 @@ librispeech_example_counts = {
     'train-clean-100': 28539,
     'train-clean-360': 104014,
     'train-other-500': 148688,
-    'test-clean': 2620,
-    'test-other': 2939,
+    'test-clean': 2620,  # 'test-other': 2939,
     'dev-clean': 2703,
     'dev-other': 2864,
 }
@@ -153,8 +152,7 @@ def run(input_dir, output_dir, tokenizer_vocab_path):
       'train-other-500',
       'dev-clean',
       'dev-other',
-      'test-clean',
-      'test-other',
+      'test-clean',  # 'test-other',
   ]
   for subset in subset_list:
     logging.info('Processing split = %s...', subset)

--- a/datasets/librispeech_tokenizer.py
+++ b/datasets/librispeech_tokenizer.py
@@ -108,17 +108,16 @@ def load_tokenizer(model_filepath):
   return sp_tokenizer
 
 
-def run(train, data_dir):
-  logging.info('Data dir: %s', data_dir)
-  vocab_path = os.path.join(data_dir, 'spm_model.vocab')
-  logging.info('vocab_path = ', vocab_path)
+def run(train, input_dir, tokenizer_vocab_path):
+  logging.info('Data dir: %s', input_dir)
+  logging.info('vocab_path = %s', tokenizer_vocab_path)
 
   if train:
     logging.info('Training...')
     splits = ['train-clean-100']
-    train_tokenizer(data_dir, splits, model_path=vocab_path)
+    train_tokenizer(input_dir, splits, model_path=tokenizer_vocab_path)
   else:
-    tokenizer = load_tokenizer(vocab_path)
+    tokenizer = load_tokenizer(tokenizer_vocab_path)
     test_input = 'OPEN SOURCE ROCKS'
     tokens = tokenizer.tokenize(test_input)
     detokenized = tokenizer.detokenize(tokens).numpy().decode('utf-8')

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,6 @@ full =
   %(ogbg)s
   %(librispeech_conformer)s
   %(wmt)s
-  pydub==0.25.1
 
 # All workloads plus development dependencies
 full_dev =
@@ -98,6 +97,7 @@ ogbg =
 librispeech_conformer =
   sentencepiece==0.1.99
   tensorflow-text==2.12.1
+  pydub==0.25.1
 
 wmt =
   sentencepiece==0.1.99


### PR DESCRIPTION
I updated the dataset setup and corresponding readme in the following ways:

- Update the package version to `0.1.0` (from `0.0.1`) to match the git tag.
- Restructured the dataset setup readme.
- Fixed the bash command for OGBG to use `data_dir` instead of `data_dir/ogbg`.
- Standardized how subfolders for datasets are implemented.
- Add to the readme how the directory structure and number and sizes of the files should look like as a check. @priyakasimbeg could you double-check that they are the same in your setup?
- Highlight the need for `ffmpeg` and `pigz` in the readme.
- Move `pydub` to a LibriSpeech dependency.
- Fix `fastMRI` directory structure (see below).
- Add missing download and disk sizes in the documentation.

With the last point, there are still two open todos

- [x] Missing directory structures and file sizes/numbers for Criteo1TB, ImageNet (JAX), and LibriSpeech. I am still downloading the former. @priyakasimbeg could you provide those for us? Especially the ImageNet (JAX) as I am not sure I will use it anytime soon.
- [x] If I am not mistaken, then the output of the fastMRI dataset setup does not match what we require for the workload. Specifically, the setup produces:
```bash
fastmri
├── test
    ├── singlecoil_test
        ├── file1000022.h5
        ├── [...]
├── train
    ├── singlecoil_train
        ├── file1000001.h5
        ├── [...]
├── val
    ├── singlecoil_val
        ├── file1000000.h5
        ├── [...]
```
While I believe, our workload expects:
```bash
fastmri
├── knee_singlecoil_test
    ├── file1000022.h5
    ├── [...]
├── knee_singlecoil_train
    ├── file1000001.h5
    ├── [...]
├── knee_singlecoil_val
    ├── file1000000.h5
    ├── [...]
```

It is simply a once-more nested version with slightly different folder names. @priyakasimbeg can you verify that this is what is happening?

There are two ways to fix this, either change the dataset setup function (to match what the workload expects) or fix the workload (to what the setup produces). I have a slight preference for the former, what about you @priyakasimbeg? In both cases, I could fix this with this PR if you want.