### PR TITLE
Changes to random utils

### DIFF
--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -86,8 +86,8 @@ def PRNGKey(seed: SeedType) -> SeedType:  # pylint: disable=invalid-name
   return _PRNGKey(seed)
 
 
-def randint(seed:SeedType) -> int:
+def randint(seed: SeedType) -> int:
   if FLAGS.framework == 'jax':
     _check_jax_install()
-    return jax_rng.randint(seed, )
+    return jax_rng.randint(seed,)
   return _randint(seed)

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -89,5 +89,5 @@ def PRNGKey(seed: SeedType) -> SeedType:  # pylint: disable=invalid-name
 def randint(seed: SeedType) -> int:
   if FLAGS.framework == 'jax':
     _check_jax_install()
-    return jax_rng.randint(seed,)
+    return jax_rng.randint(seed, (0), 0, MAX_INT32)
   return _randint(seed)

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -69,9 +69,7 @@ def _check_jax_install() -> None:
 
 
 def _bits(seed: SeedType) -> int:
-  rng = np.random.RandomState(_signed_to_unsigned(seed))
-  b = rng.bytes(4)
-  return int.from_bytes(b, byteorder='little')
+  return seed
 
 
 def fold_in(seed: SeedType, data: int) -> SeedType:

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -21,9 +21,11 @@ FLAGS = flags.FLAGS
 MAX_INT32 = 2**31
 MIN_INT32 = -MAX_INT32
 
-# SALT constants 
-_SALT1 = np.random.RandomState(seed=5).randint(MIN_INT32, MAX_INT32, dtype=np.int32)
-_SALT2 = np.random.RandomState(seed=6).randint(MIN_INT32, MAX_INT32, dtype=np.int32)
+# SALT constants
+_SALT1 = np.random.RandomState(seed=5).randint(
+    MIN_INT32, MAX_INT32, dtype=np.int32)
+_SALT2 = np.random.RandomState(seed=6).randint(
+    MIN_INT32, MAX_INT32, dtype=np.int32)
 
 SeedType = Union[int, list, np.ndarray]
 
@@ -37,10 +39,13 @@ def _signed_to_unsigned(seed: SeedType) -> SeedType:
     return np.array([s + 2**32 if s < 0 else s for s in seed.tolist()])
 
 
-def _fold_in(seed, data, verbose = True):
-  a = np.random.RandomState(seed=_signed_to_unsigned(seed ^ _SALT1)).randint(MIN_INT32, MAX_INT32, dtype=np.int32)
-  b = np.random.RandomState(seed=_signed_to_unsigned(data ^ _SALT2)).randint(MIN_INT32, MAX_INT32, dtype=np.int32)
-  c = np.random.RandomState(seed=_signed_to_unsigned(a ^ b)).randint(MIN_INT32, MAX_INT32, dtype=np.int32)
+def _fold_in(seed, data, verbose=True):
+  a = np.random.RandomState(seed=_signed_to_unsigned(seed ^ _SALT1)).randint(
+      MIN_INT32, MAX_INT32, dtype=np.int32)
+  b = np.random.RandomState(seed=_signed_to_unsigned(data ^ _SALT2)).randint(
+      MIN_INT32, MAX_INT32, dtype=np.int32)
+  c = np.random.RandomState(seed=_signed_to_unsigned(a ^ b)).randint(
+      MIN_INT32, MAX_INT32, dtype=np.int32)
   return c
 
 

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -1,6 +1,6 @@
 """Proxy functions in front of the Jax RNG API or a compatible Numpy RNG API."""
 
-from typing import Any, List, Union
+from typing import Union
 
 from absl import flags
 from absl import logging
@@ -36,7 +36,7 @@ def _signed_to_unsigned(seed: SeedType) -> SeedType:
 def _fold_in(seed: SeedType, data: int) -> SeedType:
   rng_1 = np.random.RandomState(seed=_signed_to_unsigned(seed))
   new_seed_1 = rng_1.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
-  rng_2 = np.random.RandomState(seed=(_signed_to_unsigned(data) & 0xffffffff))
+  rng_2 = np.random.RandomState(seed=_signed_to_unsigned(data) & 0xffffffff)
   new_seed_2 = rng_2.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
   return new_seed_1 + new_seed_2
 

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -86,8 +86,8 @@ def PRNGKey(seed: SeedType) -> SeedType:  # pylint: disable=invalid-name
   return _PRNGKey(seed)
 
 
-def randint(seed: SeedType) -> int:
+def bits(seed: SeedType) -> int:
   if FLAGS.framework == 'jax':
     _check_jax_install()
-    return jax_rng.randint(seed, (), 0, MAX_INT32)
+    return jax_rng.bits(seed)
   return _randint(seed)

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -89,5 +89,5 @@ def PRNGKey(seed: SeedType) -> SeedType:  # pylint: disable=invalid-name
 def randint(seed: SeedType) -> int:
   if FLAGS.framework == 'jax':
     _check_jax_install()
-    return jax_rng.randint(seed, (0), 0, MAX_INT32)
+    return jax_rng.randint(seed, (), 0, MAX_INT32)
   return _randint(seed)

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -36,6 +36,7 @@ def _signed_to_unsigned(seed: SeedType) -> SeedType:
 def _fold_in(seed: SeedType, data: int) -> SeedType:
   rng_1 = np.random.RandomState(seed=_signed_to_unsigned(seed))
   new_seed_1 = rng_1.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
+  # Truncate data to 32-bits, since numpy does not support 64-bit ints.
   rng_2 = np.random.RandomState(seed=_signed_to_unsigned(data) & 0xffffffff)
   new_seed_2 = rng_2.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
   return new_seed_1 + new_seed_2

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -33,10 +33,12 @@ def _signed_to_unsigned(seed: SeedType) -> SeedType:
     return np.array([s + 2**32 if s < 0 else s for s in seed.tolist()])
 
 
-def _fold_in(seed: SeedType, data: Any) -> List[Union[SeedType, Any]]:
-  rng = np.random.RandomState(seed=_signed_to_unsigned(seed))
-  new_seed = rng.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
-  return [new_seed, data]
+def _fold_in(seed: SeedType, data: int) -> SeedType:
+  rng_1 = np.random.RandomState(seed=_signed_to_unsigned(seed))
+  new_seed_1 = rng_1.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
+  rng_2 = np.random.RandomState(seed=_signed_to_unsigned(data))
+  new_seed_2 = rng_2.randint(MIN_INT32, MAX_INT32, dtype=np.int32)
+  return new_seed_1 + new_seed_2
 
 
 def _split(seed: SeedType, num: int = 2) -> SeedType:
@@ -58,7 +60,7 @@ def _check_jax_install() -> None:
         '--framework=pytorch to use the Numpy version instead.')
 
 
-def fold_in(seed: SeedType, data: Any) -> List[Union[SeedType, Any]]:
+def fold_in(seed: SeedType, data: int) -> SeedType:
   if FLAGS.framework == 'jax':
     _check_jax_install()
     return jax_rng.fold_in(seed, data)

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -60,9 +60,10 @@ def _check_jax_install() -> None:
         '--framework=pytorch to use the Numpy version instead.')
 
 
-def _randint(seed: SeedType) -> int:
+def _bits(seed: SeedType) -> int:
   rng = np.random.RandomState(_signed_to_unsigned(seed))
-  return rng.randint(MAX_INT32)
+  b = rng.bytes(4)
+  return int.from_bytes(b, byteorder='little')
 
 
 def fold_in(seed: SeedType, data: int) -> SeedType:
@@ -90,4 +91,4 @@ def bits(seed: SeedType) -> int:
   if FLAGS.framework == 'jax':
     _check_jax_install()
     return jax_rng.bits(seed)
-  return _randint(seed)
+  return _bits(seed)

--- a/algorithmic_efficiency/random_utils.py
+++ b/algorithmic_efficiency/random_utils.py
@@ -39,7 +39,7 @@ def _signed_to_unsigned(seed: SeedType) -> SeedType:
     return np.array([s + 2**32 if s < 0 else s for s in seed.tolist()])
 
 
-def _fold_in(seed, data, verbose=True):
+def _fold_in(seed: SeedType, data: int) -> SeedType:
   a = np.random.RandomState(seed=_signed_to_unsigned(seed ^ _SALT1)).randint(
       MIN_INT32, MAX_INT32, dtype=np.int32)
   b = np.random.RandomState(seed=_signed_to_unsigned(data ^ _SALT2)).randint(

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -65,7 +65,7 @@ class CifarWorkload(BaseCifarWorkload):
     }
     if split == 'eval_train':
       train_indices = indices_split['train']
-      random.Random(data_rng[0]).shuffle(train_indices)
+      random.Random(data_rng).shuffle(train_indices)
       indices_split['eval_train'] = train_indices[:self.num_eval_train_examples]
     if split in indices_split:
       dataset = torch.utils.data.Subset(dataset, indices_split[split])
@@ -111,7 +111,7 @@ class CifarWorkload(BaseCifarWorkload):
         self._model.reset_parameters()
       return self._model, None
 
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
     self._model = resnet18(num_classes=self._num_classes)
     self._param_shapes = param_utils.pytorch_param_shapes(self._model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
@@ -72,7 +72,7 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
       aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
     """Only dropout is used."""
     del aux_dropout_rate
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
     # Disable cudnn benchmark to avoid OOM errors.
     torch.backends.cudnn.benchmark = False
     if self.use_resnet:

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_pytorch/workload.py
@@ -113,7 +113,7 @@ class FastMRIWorkload(BaseFastMRIWorkload):
       dropout_rate: Optional[float] = None,
       aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
     del aux_dropout_rate
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
     model = UNet(
         num_pool_layers=self.num_pool_layers,
         num_channels=self.num_channels,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -103,7 +103,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
     if split == 'eval_train':
       indices = list(range(self.num_train_examples))
-      random.Random(data_rng[0]).shuffle(indices)
+      random.Random(data_rng).shuffle(indices)
       dataset = torch.utils.data.Subset(dataset,
                                         indices[:self.num_eval_train_examples])
 
@@ -147,7 +147,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     """Dropout is unused."""
     del dropout_rate
     del aux_dropout_rate
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
 
     if self.use_silu and self.use_gelu:
       raise RuntimeError('Cannot use both GELU and SiLU activations.')

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
@@ -30,7 +30,7 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
       dropout_rate: Optional[float] = None,
       aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
     del aux_dropout_rate
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
     model = models.ViT(
         dropout_rate=dropout_rate,
         num_classes=self._num_classes,

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -58,7 +58,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     Here we use dropout_rate as residual_dropout_rate, and aux_dropout_rate as
     input_dropout_rate.
     """
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
     # Configure torch backends to avoid OOM errors.
     torch.backends.cudnn.benchmark = False
     torch.backends.cuda.enable_flash_sdp(False)

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/workload.py
@@ -32,7 +32,7 @@ class LibriSpeechDeepSpeechWorkload(LibriSpeechConformerWorkload):
     Here we use dropout_rate as feed_forward_dropout_rate, and aux_dropout_rate
     as input_dropout_rate.
     """
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
     model = DeepspeechEncoderDecoder(
         DeepspeechConfig(
             feed_forward_dropout_rate=dropout_rate,

--- a/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_pytorch/workload.py
@@ -133,7 +133,7 @@ class MnistWorkload(BaseMnistWorkload):
         self._model.reset_parameters()
       return self._model, None
 
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
     self._model = _Model()
     self._param_shapes = param_utils.pytorch_param_shapes(self._model)
     self._param_types = param_utils.pytorch_param_types(self._param_shapes)

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -55,7 +55,7 @@ def _build_mnist_dataset(
 
   if shuffle:
     ds = ds.repeat()
-    ds = ds.shuffle(16 * global_batch_size, seed=data_rng)
+    ds = ds.shuffle(16 * global_batch_size, seed=prng.randint(data_rng))
   ds = ds.batch(global_batch_size, drop_remainder=is_train)
 
   if repeat_final_dataset:

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -55,7 +55,7 @@ def _build_mnist_dataset(
 
   if shuffle:
     ds = ds.repeat()
-    ds = ds.shuffle(16 * global_batch_size, seed=data_rng[0])
+    ds = ds.shuffle(16 * global_batch_size, seed=data_rng)
   ds = ds.batch(global_batch_size, drop_remainder=is_train)
 
   if repeat_final_dataset:

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -55,7 +55,7 @@ def _build_mnist_dataset(
 
   if shuffle:
     ds = ds.repeat()
-    ds = ds.shuffle(16 * global_batch_size, seed=prng.randint(data_rng))
+    ds = ds.shuffle(16 * global_batch_size, seed=prng.bits(data_rng))
   ds = ds.batch(global_batch_size, drop_remainder=is_train)
 
   if repeat_final_dataset:

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
@@ -143,7 +143,7 @@ class OgbgWorkload(BaseOgbgWorkload):
       aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
     """aux_dropout_rate is unused."""
     del aux_dropout_rate
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
     model = GNN(
         num_outputs=self._num_outputs,
         dropout_rate=dropout_rate,

--- a/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_pytorch/workload.py
@@ -171,7 +171,7 @@ class WmtWorkload(BaseWmtWorkload):
       dropout_rate: Optional[float] = None,
       aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
     """aux_dropout_rate is used as attention_dropout_rate."""
-    torch.random.manual_seed(rng[0])
+    torch.random.manual_seed(rng)
 
     if self.activation == 'relu':
       activation = F.relu

--- a/scoring/run_workloads.py
+++ b/scoring/run_workloads.py
@@ -148,7 +148,7 @@ def main(_):
     # For each runnable workload check if there are any containers running and if not launch next container command
     for workload in workloads:
       run_key = prng.fold_in(rng_subkey, hash(workload))
-      run_seed = prng.randint(run_key)  # arbitrary
+      run_seed = prng.bits(run_key)
       base_workload_name = get_base_workload_name(workload)
       wait_until_container_not_running()
       os.system(

--- a/scoring/run_workloads.py
+++ b/scoring/run_workloads.py
@@ -148,7 +148,7 @@ def main(_):
     # For each runnable workload check if there are any containers running and if not launch next container command
     for workload in workloads:
       run_key = prng.fold_in(rng_subkey, hash(workload))
-      run_seed = run_key[0]  # arbitrary
+      run_seed = prng.randint(run_key)  # arbitrary
       base_workload_name = get_base_workload_name(workload)
       wait_until_container_not_running()
       os.system(

--- a/tests/test_param_shapes.py
+++ b/tests/test_param_shapes.py
@@ -113,7 +113,7 @@ def get_workload(workload):
   else:
     raise ValueError(f'Workload {workload} is not available.')
   _ = jax_workload.init_model_fn(jax.random.PRNGKey(0))
-  _ = pytorch_workload.init_model_fn([0])
+  _ = pytorch_workload.init_model_fn(0)
   return jax_workload, pytorch_workload
 
 

--- a/tests/test_param_types.py
+++ b/tests/test_param_types.py
@@ -221,7 +221,7 @@ def get_workload(workload_name):
   else:
     raise ValueError(f'Workload {workload_name} is not available.')
   _ = jax_workload.init_model_fn(jax.random.PRNGKey(0))
-  _ = pytorch_workload.init_model_fn([0])
+  _ = pytorch_workload.init_model_fn(0)
   return jax_workload, pytorch_workload
 
 


### PR DESCRIPTION
- Update function signatures for _split and _fold_in to accurately reflect SeedType inputs and outputs.
- Change _fold_in to use data for sampling new seed instead of returning data.
- Force PyTorch function SeedType outputs to be 1-dim as opposed to 2-dim which is typical for Jax PRNGKeys
- Update run_workloads.py to use newly added randint for getting workload seeds.