### PR TITLE
Increase number of evals for Criteo1tb

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -97,7 +97,7 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
 
   @property
   def eval_period_time_sec(self) -> int:
-    return 2 * 600  # 20 mins.
+    return 2 * 60  # 2 mins.
 
   def _build_input_queue(
       self,


### PR DESCRIPTION
We may have unintentionally reduced this in [PR/484](https://github.com/mlcommons/algorithmic-efficiency/pull/484/files#diff-c7dabb11032798ac4e737e03e3e871fe6bfa6160bbc6bc80996ba2e98de5d21c)