### PR TITLE
Use separate `rng` for dropout in FastMRI `model_init`

### DIFF
--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -34,8 +34,9 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         use_layer_norm=self.use_layer_norm,
         dropout_rate=dropout_rate)
     params_rng, dropout_rng = jax.random.split(rng)
-    variables = jax.jit(self._model.init)(
-        {'params': params_rng, 'dropout': dropout_rng}, fake_batch)
+    variables = jax.jit(
+        self._model.init)({'params': params_rng, 'dropout': dropout_rng},
+                          fake_batch)
     params = variables['params']
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)

--- a/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
+++ b/algorithmic_efficiency/workloads/fastmri/fastmri_jax/workload.py
@@ -33,8 +33,9 @@ class FastMRIWorkload(BaseFastMRIWorkload):
         use_tanh=self.use_tanh,
         use_layer_norm=self.use_layer_norm,
         dropout_rate=dropout_rate)
-
-    variables = jax.jit(self._model.init)({'params': rng}, fake_batch)
+    params_rng, dropout_rng = jax.random.split(rng)
+    variables = jax.jit(self._model.init)(
+        {'params': params_rng, 'dropout': dropout_rng}, fake_batch)
     params = variables['params']
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)


### PR DESCRIPTION
Fixes #664. Not sure why this worked before and stopped working now?