### PR TITLE
Add missing `rng` for ImageNet-ViT and WMT

### DIFF
--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
@@ -21,8 +21,7 @@ from algorithmic_efficiency.workloads.imagenet_vit.workload import \
 # Make sure we inherit from the ViT base workload first.
 class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
 
-  def initialized(self,
-                  key: spec.RandomState,
+  def initialized(self, key: spec.RandomState,
                   model: nn.Module) -> spec.ModelInitState:
     input_shape = (1, 224, 224, 3)
     params_rng, dropout_rng = jax.random.split(key)

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_jax/workload.py
@@ -21,10 +21,14 @@ from algorithmic_efficiency.workloads.imagenet_vit.workload import \
 # Make sure we inherit from the ViT base workload first.
 class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
 
-  def initialized(self, key: spec.RandomState,
+  def initialized(self,
+                  key: spec.RandomState,
                   model: nn.Module) -> spec.ModelInitState:
     input_shape = (1, 224, 224, 3)
-    variables = jax.jit(model.init)({'params': key}, jnp.ones(input_shape))
+    params_rng, dropout_rng = jax.random.split(key)
+    variables = jax.jit(
+        model.init)({'params': params_rng, 'dropout': dropout_rng},
+                    jnp.ones(input_shape))
     model_state, params = variables.pop('params')
     return params, model_state
 

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -234,8 +234,9 @@ class WmtWorkload(BaseWmtWorkload):
     self._train_model = models.Transformer(model_config)
     eval_config = replace(model_config, deterministic=True)
     self._eval_model = models.Transformer(eval_config)
+    params_rng, dropout_rng = jax.random.split(rng)
     initial_variables = jax.jit(self._eval_model.init)(
-        rng,
+        {'params': params_rng, 'dropout': dropout_rng},
         jnp.ones(input_shape, jnp.float32),
         jnp.ones(target_shape, jnp.float32))
 

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -235,10 +235,10 @@ class WmtWorkload(BaseWmtWorkload):
     eval_config = replace(model_config, deterministic=True)
     self._eval_model = models.Transformer(eval_config)
     params_rng, dropout_rng = jax.random.split(rng)
-    initial_variables = jax.jit(self._eval_model.init)(
-        {'params': params_rng, 'dropout': dropout_rng},
-        jnp.ones(input_shape, jnp.float32),
-        jnp.ones(target_shape, jnp.float32))
+    initial_variables = jax.jit(
+        self._eval_model.init)({'params': params_rng, 'dropout': dropout_rng},
+                               jnp.ones(input_shape, jnp.float32),
+                               jnp.ones(target_shape, jnp.float32))
 
     initial_params = initial_variables['params']
     self._param_shapes = param_utils.jax_param_shapes(initial_params)


### PR DESCRIPTION
I went through all workloads and found two where we also don't initialize with a separate `rng` for dropout -- as in #672.