### PR TITLE
Data setup improvements

### DIFF
--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -679,6 +679,7 @@ def main(_):
   if any(s in tmp_dir for s in bad_chars):
     raise ValueError(f'Invalid temp_dir: {tmp_dir}.')
   data_dir = os.path.abspath(os.path.expanduser(data_dir))
+  tmp_dir = os.path.abspath(os.path.expanduser(data_dir))
   logging.info('Downloading data to %s...', data_dir)
 
   if FLAGS.all or FLAGS.criteo1tb:

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -692,7 +692,7 @@ def main(_):
   if any(s in tmp_dir for s in bad_chars):
     raise ValueError(f'Invalid temp_dir: {tmp_dir}.')
   data_dir = os.path.abspath(os.path.expanduser(data_dir))
-  tmp_dir = os.path.abspath(os.path.expanduser(data_dir))
+  tmp_dir = os.path.abspath(os.path.expanduser(tmp_dir))
   logging.info('Downloading data to %s...', data_dir)
 
   if FLAGS.all or FLAGS.criteo1tb:

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -302,8 +302,8 @@ def download_criteo1tb(data_dir,
     if overwrite == 'n':
       logging.info(f'Skipping download URL {url} to {file_path}')
       download = False
-  
-  if download: 
+
+  if download:
     with open(all_days_zip_filepath, 'wb') as f:
       for chunk in download_request.iter_content(chunk_size=1024):
         f.write(chunk)

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -291,9 +291,22 @@ def download_criteo1tb(data_dir,
       stream=True)
 
   all_days_zip_filepath = os.path.join(tmp_criteo_dir, 'all_days.zip')
-  with open(all_days_zip_filepath, 'wb') as f:
-    for chunk in download_request.iter_content(chunk_size=1024):
-      f.write(chunk)
+  download = True
+  if os.path.exists(all_days_zip_filepath):
+    while True:
+      overwrite = input('File already exists {}.\n Overwrite? (Y/n)'.format(
+          all_days_zip_filepath)).lower()
+      if overwrite in ['y', 'n']:
+        break
+      logging.info('Invalid response. Try again.')
+    if overwrite == 'n':
+      logging.info(f'Skipping download URL {url} to {file_path}')
+      download = False
+  
+  if download: 
+    with open(all_days_zip_filepath, 'wb') as f:
+      for chunk in download_request.iter_content(chunk_size=1024):
+        f.write(chunk)
 
   unzip_cmd = f'unzip {all_days_zip_filepath} -d {tmp_criteo_dir}'
   logging.info(f'Running Criteo 1TB unzip command:\n{unzip_cmd}')

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -300,7 +300,7 @@ def download_criteo1tb(data_dir,
         break
       logging.info('Invalid response. Try again.')
     if overwrite == 'n':
-      logging.info(f'Skipping download URL {url} to {file_path}')
+      logging.info(f'Skipping download to {all_days_zip_filepath}')
       download = False
 
   if download:


### PR DESCRIPTION
Expand path for tmp_dir flags in case users pass in ~.
Add prompt for overwriting Criteo1tB all_days.zip (~350GB) file. 

Addresses requests in https://github.com/mlcommons/algorithmic-efficiency/issues/674.