### PR TITLE
Add `pytorch_num_workers` flag for workloads with PyTorch data loaders

### DIFF
--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -231,7 +231,7 @@ def cycle(iterable: Iterable,
 class PrefetchedWrapper:
 
   def __init__(self,
-               dataloader: torch.utils.data.DataLoader,
+               dataloader: DataLoader,
                device: torch.device,
                start_epoch: int = 0) -> None:
     self.dataloader = dataloader

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -101,7 +101,7 @@ class Workload(metaclass=abc.ABCMeta):
     self._eval_iters: Dict[str, Iterator] = {}
     self.metrics_logger = None
     # Is set in submission_runner.py for workloads with PyTorch data loaders.
-    self._num_workers = None
+    self._eval_num_workers = None
 
   @property
   @abc.abstractmethod

--- a/algorithmic_efficiency/spec.py
+++ b/algorithmic_efficiency/spec.py
@@ -100,6 +100,8 @@ class Workload(metaclass=abc.ABCMeta):
     self._param_types: Optional[ParameterTypeTree] = None
     self._eval_iters: Dict[str, Iterator] = {}
     self.metrics_logger = None
+    # Is set in submission_runner.py for workloads with PyTorch data loaders.
+    self._num_workers = None
 
   @property
   @abc.abstractmethod

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -28,7 +28,8 @@ class CifarWorkload(BaseCifarWorkload):
   @property
   def num_workers(self) -> int:
     if self._num_workers is None:
-      raise ValueError('num_workers property must be set before workload is used.')
+      raise ValueError(
+          'num_workers property must be set before workload is used.')
     return self._num_workers
 
   @num_workers.setter

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -25,6 +25,16 @@ USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_utils.pytorch_setup()
 
 class CifarWorkload(BaseCifarWorkload):
 
+  @property
+  def num_workers(self) -> int:
+      if self._num_workers is None:
+          raise ValueError('num_workers property must be set before workload is used.')
+      return self._num_workers
+
+  @num_workers.setter
+  def num_workers(self, num_workers: int):
+      self._num_workers = num_workers
+
   def _build_dataset(
       self,
       data_rng: spec.RandomState,
@@ -88,7 +98,7 @@ class CifarWorkload(BaseCifarWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=4,
+        num_workers=self.num_workers,
         pin_memory=True,
         drop_last=is_train)
     dataloader = data_utils.PrefetchedWrapper(dataloader, DEVICE)

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -26,15 +26,15 @@ USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_utils.pytorch_setup()
 class CifarWorkload(BaseCifarWorkload):
 
   @property
-  def num_workers(self) -> int:
-    if self._num_workers is None:
+  def eval_num_workers(self) -> int:
+    if self._eval_num_workers is None:
       raise ValueError(
           'num_workers property must be set before workload is used.')
-    return self._num_workers
+    return self._eval_num_workers
 
-  @num_workers.setter
-  def num_workers(self, num_workers: int):
-    self._num_workers = num_workers
+  @eval_num_workers.setter
+  def eval_num_workers(self, eval_num_workers: int):
+    self._eval_num_workers = eval_num_workers
 
   def _build_dataset(
       self,
@@ -99,7 +99,7 @@ class CifarWorkload(BaseCifarWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=self.num_workers,
+        num_workers=4 if is_train else self.eval_num_workers,
         pin_memory=True,
         drop_last=is_train)
     dataloader = data_utils.PrefetchedWrapper(dataloader, DEVICE)

--- a/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_pytorch/workload.py
@@ -27,13 +27,13 @@ class CifarWorkload(BaseCifarWorkload):
 
   @property
   def num_workers(self) -> int:
-      if self._num_workers is None:
-          raise ValueError('num_workers property must be set before workload is used.')
-      return self._num_workers
+    if self._num_workers is None:
+      raise ValueError('num_workers property must be set before workload is used.')
+    return self._num_workers
 
   @num_workers.setter
   def num_workers(self, num_workers: int):
-      self._num_workers = num_workers
+    self._num_workers = num_workers
 
   def _build_dataset(
       self,

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -51,6 +51,16 @@ def imagenet_v2_to_torch(
 
 class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
+  @property
+  def num_workers(self) -> int:
+      if self._num_workers is None:
+          raise ValueError('num_workers property must be set before workload is used.')
+      return self._num_workers
+
+  @num_workers.setter
+  def num_workers(self, num_workers: int):
+      self._num_workers = num_workers
+
   def _build_dataset(
       self,
       data_rng: spec.RandomState,
@@ -126,7 +136,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=4 if is_train else 0,
+        num_workers=self.num_workers,
         pin_memory=True,
         drop_last=is_train,
         persistent_workers=is_train)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -54,7 +54,8 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
   @property
   def num_workers(self) -> int:
     if self._num_workers is None:
-      raise ValueError('num_workers property must be set before workload is used.')
+      raise ValueError(
+          'num_workers property must be set before workload is used.')
     return self._num_workers
 
   @num_workers.setter

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -52,15 +52,15 @@ def imagenet_v2_to_torch(
 class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
   @property
-  def num_workers(self) -> int:
-    if self._num_workers is None:
+  def eval_num_workers(self) -> int:
+    if self._eval_num_workers is None:
       raise ValueError(
           'num_workers property must be set before workload is used.')
-    return self._num_workers
+    return self._eval_num_workers
 
-  @num_workers.setter
-  def num_workers(self, num_workers: int):
-    self._num_workers = num_workers
+  @eval_num_workers.setter
+  def eval_num_workers(self, eval_num_workers: int):
+    self._eval_num_workers = eval_num_workers
 
   def _build_dataset(
       self,
@@ -137,7 +137,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=self.num_workers,
+        num_workers=4 if is_train else self.eval_num_workers,
         pin_memory=True,
         drop_last=is_train,
         persistent_workers=is_train)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/workload.py
@@ -53,13 +53,13 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
 
   @property
   def num_workers(self) -> int:
-      if self._num_workers is None:
-          raise ValueError('num_workers property must be set before workload is used.')
-      return self._num_workers
+    if self._num_workers is None:
+      raise ValueError('num_workers property must be set before workload is used.')
+    return self._num_workers
 
   @num_workers.setter
   def num_workers(self, num_workers: int):
-      self._num_workers = num_workers
+    self._num_workers = num_workers
 
   def _build_dataset(
       self,

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -32,6 +32,16 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     self.use_specaug = use_specaug
 
   @property
+  def num_workers(self) -> int:
+      if self._num_workers is None:
+          raise ValueError('num_workers property must be set before workload is used.')
+      return self._num_workers
+
+  @num_workers.setter
+  def num_workers(self, num_workers: int):
+      self._num_workers = num_workers
+
+  @property
   def use_post_layer_norm(self) -> bool:
     return True
 
@@ -147,7 +157,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
             batch_size=global_batch_size,
             shuffle=train,
             sampler=None,
-            num_workers=4,
+            num_workers=self.num_workers,
             prefetch_factor=10,
             pin_memory=False,
             drop_last=train,

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -33,13 +33,13 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
   @property
   def num_workers(self) -> int:
-      if self._num_workers is None:
-          raise ValueError('num_workers property must be set before workload is used.')
-      return self._num_workers
+    if self._num_workers is None:
+      raise ValueError('num_workers property must be set before workload is used.')
+    return self._num_workers
 
   @num_workers.setter
   def num_workers(self, num_workers: int):
-      self._num_workers = num_workers
+    self._num_workers = num_workers
 
   @property
   def use_post_layer_norm(self) -> bool:

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -34,7 +34,8 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
   @property
   def num_workers(self) -> int:
     if self._num_workers is None:
-      raise ValueError('num_workers property must be set before workload is used.')
+      raise ValueError(
+          'num_workers property must be set before workload is used.')
     return self._num_workers
 
   @num_workers.setter

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -32,15 +32,15 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     self.use_specaug = use_specaug
 
   @property
-  def num_workers(self) -> int:
-    if self._num_workers is None:
+  def eval_num_workers(self) -> int:
+    if self._eval_num_workers is None:
       raise ValueError(
           'num_workers property must be set before workload is used.')
-    return self._num_workers
+    return self._eval_num_workers
 
-  @num_workers.setter
-  def num_workers(self, num_workers: int):
-    self._num_workers = num_workers
+  @eval_num_workers.setter
+  def eval_num_workers(self, eval_num_workers: int):
+    self._eval_num_workers = eval_num_workers
 
   @property
   def use_post_layer_norm(self) -> bool:
@@ -158,7 +158,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
             batch_size=global_batch_size,
             shuffle=train,
             sampler=None,
-            num_workers=self.num_workers,
+            num_workers=4 if train else self.eval_num_workers,
             prefetch_factor=10,
             pin_memory=False,
             drop_last=train,

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -37,15 +37,15 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     self.use_specaug = use_specaug
 
   @property
-  def num_workers(self) -> int:
-    if self._num_workers is None:
+  def eval_num_workers(self) -> int:
+    if self._eval_num_workers is None:
       raise ValueError(
           'num_workers property must be set before workload is used.')
-    return self._num_workers
+    return self._eval_num_workers
 
-  @num_workers.setter
-  def num_workers(self, num_workers: int):
-    self._num_workers = num_workers
+  @eval_num_workers.setter
+  def eval_num_workers(self, eval_num_workers: int):
+    self._eval_num_workers = eval_num_workers
 
   @property
   def use_post_layer_norm(self) -> bool:
@@ -184,7 +184,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=self.num_workers,
+        num_workers=4 if is_train else self.eval_num_workers,
         pin_memory=True,
         drop_last=is_train)
 

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -37,6 +37,16 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     self.use_specaug = use_specaug
 
   @property
+  def num_workers(self) -> int:
+      if self._num_workers is None:
+          raise ValueError('num_workers property must be set before workload is used.')
+      return self._num_workers
+
+  @num_workers.setter
+  def num_workers(self, num_workers: int):
+      self._num_workers = num_workers
+
+  @property
   def use_post_layer_norm(self) -> bool:
     return True
 
@@ -173,7 +183,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
         batch_size=ds_iter_batch_size,
         shuffle=not USE_PYTORCH_DDP and is_train,
         sampler=sampler,
-        num_workers=4,
+        num_workers=self.num_workers,
         pin_memory=True,
         drop_last=is_train)
 

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -38,13 +38,13 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
   @property
   def num_workers(self) -> int:
-      if self._num_workers is None:
-          raise ValueError('num_workers property must be set before workload is used.')
-      return self._num_workers
+    if self._num_workers is None:
+      raise ValueError('num_workers property must be set before workload is used.')
+    return self._num_workers
 
   @num_workers.setter
   def num_workers(self, num_workers: int):
-      self._num_workers = num_workers
+    self._num_workers = num_workers
 
   @property
   def use_post_layer_norm(self) -> bool:

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_pytorch/workload.py
@@ -39,7 +39,8 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
   @property
   def num_workers(self) -> int:
     if self._num_workers is None:
-      raise ValueError('num_workers property must be set before workload is used.')
+      raise ValueError(
+          'num_workers property must be set before workload is used.')
     return self._num_workers
 
   @num_workers.setter

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -152,7 +152,7 @@ flags.DEFINE_integer(
 flags.DEFINE_boolean('set_pytorch_max_split_size',
                      False,
                      'If true, set pytorch max_split_size_mb to 256')
-flags.DEFINE_integer('pytorch_num_workers',
+flags.DEFINE_integer('pytorch_eval_num_workers',
                      4,
                      'Number of workers for PyTorch data loaders.')
 FLAGS = flags.FLAGS
@@ -207,9 +207,9 @@ def train_once(
 
   # Workload setup.
   logging.info('Initializing dataset.')
-  if hasattr(workload, 'num_workers'):
+  if hasattr(workload, 'eval_num_workers'):
     # Set the number of workers for PyTorch data loaders.
-    workload.num_workers = FLAGS.pytorch_num_workers
+    workload.eval_num_workers = FLAGS.pytorch_eval_num_workers
   with profiler.profile('Initializing dataset'):
     input_queue = workload._build_input_queue(
         data_rng,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -143,7 +143,7 @@ flags.DEFINE_integer(
 flags.DEFINE_integer(
     'hparam_end_index',
     None,
-    'End index to slice set of hyperparameters in tuning spearch space.')
+    'End index to slice set of hyperparameters in tuning search space.')
 flags.DEFINE_integer(
     'rng_seed',
     None,
@@ -152,6 +152,9 @@ flags.DEFINE_integer(
 flags.DEFINE_boolean('set_pytorch_max_split_size',
                      False,
                      'If true, set pytorch max_split_size_mb to 256')
+flags.DEFINE_integer('pytorch_num_workers',
+                     4,
+                     'Number of workers for PyTorch data loaders.')
 FLAGS = flags.FLAGS
 USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 
@@ -204,6 +207,9 @@ def train_once(
 
   # Workload setup.
   logging.info('Initializing dataset.')
+  if hasattr(workload, 'num_workers'):
+    # Set the number of workers for PyTorch data loaders.
+    workload.num_workers = FLAGS.pytorch_num_workers
   with profiler.profile('Initializing dataset'):
     input_queue = workload._build_input_queue(
         data_rng,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -154,7 +154,7 @@ flags.DEFINE_boolean('set_pytorch_max_split_size',
                      'If true, set pytorch max_split_size_mb to 256')
 flags.DEFINE_integer('pytorch_eval_num_workers',
                      4,
-                     'Number of workers for PyTorch data loaders.')
+                     'Number of workers for PyTorch evaluation data loaders.')
 FLAGS = flags.FLAGS
 USE_PYTORCH_DDP, RANK, DEVICE, N_GPUS = pytorch_setup()
 


### PR DESCRIPTION
Address #638.

I have added a new flag to set `num_workers` for workloads with PyTorch data loaders. It defaults to 4 (same as before, with the exception of ImageNet evaluation). I think this flag makes sense because there is no general rule to set `num_workers` and users might want to tune it to improve performance on their hardware. Actually, the optimal number is probably different for each workload, but I think allowing for a per-workload setting adds too much complexity -- we can revisit this if users request it.