### PR TITLE
Update Criteo1TB eval bsz for pytorch and jax

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -379,7 +379,7 @@ python scoring/run_workloads.py \
 
 Note that to run the above script you will need at least the `jax_cpu` and `pytorch_cpu` installations of the `algorithmic-efficiency` package.
 
-During submission development, it might be useful to do faster, approximate scoring (e.g. without `5` different studies or when some trials are missing) so the scoring scripts allow someflexibility.
+During submission development, it might be useful to do faster, approximate scoring (e.g. without `5` different studies or when some trials are missing) so the scoring scripts allow some flexibility.
 To simulate official scoring, pass the `--strict=True` flag in `score_submission.py`. To get the raw scores and performance profiles of group of submissions or single submission:
 
 ```bash

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_jax/workload.py
@@ -19,7 +19,7 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
 
   @property
   def eval_batch_size(self) -> int:
-    return 524_288
+    return 131_072
 
   def _per_example_sigmoid_binary_cross_entropy(
       self, logits: spec.Tensor, targets: spec.Tensor) -> spec.Tensor:

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
@@ -21,7 +21,7 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
 
   @property
   def eval_batch_size(self) -> int:
-    return 32_768
+    return 8_192
 
   def _per_example_sigmoid_binary_cross_entropy(
       self, logits: spec.Tensor, targets: spec.Tensor) -> spec.Tensor:

--- a/submissions/template/submission.py
+++ b/submissions/template/submission.py
@@ -44,7 +44,8 @@ def update_params(workload: spec.Workload,
 
 def get_batch_size(workload_name):
   """
-    Gets batch size for workload.
+    Gets batch size for workload. 
+    Note that these batch sizes only apply during training and not during evals.
     Args: 
       workload_name (str): Valid workload_name values are: "wmt", "ogbg", 
         "criteo1tb", "fastmri", "imagenet_resnet", "imagenet_vit", 


### PR DESCRIPTION
Addresses https://github.com/mlcommons/algorithmic-efficiency/issues/641

Update Criteo1TB eval bsz for PyTorch and JAX to reduce likelihood of OOMs during eval.
Note this change won't affect submission times measured for scoring since the submission time excludes evals.