### PR TITLE
Fix test eval bug for self-tuning ruleset

### DIFF
--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -5,7 +5,6 @@ import os
 from typing import Dict, Iterator, Optional, Tuple
 
 from absl import flags
-from absl import logging
 import torch.distributed as dist
 
 from algorithmic_efficiency import spec
@@ -142,7 +141,6 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
     num_batches = int(math.ceil(num_examples / global_batch_size))
     if split not in self._eval_iters:
       # These iterators will repeat indefinitely.
-      logging.info(f"BUILDING split with {data_dir} ")
       self._eval_iters[split] = self._build_input_queue(
           data_rng=rng,
           split=split,

--- a/algorithmic_efficiency/workloads/criteo1tb/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/workload.py
@@ -5,6 +5,7 @@ import os
 from typing import Dict, Iterator, Optional, Tuple
 
 from absl import flags
+from absl import logging
 import torch.distributed as dist
 
 from algorithmic_efficiency import spec
@@ -141,6 +142,7 @@ class BaseCriteo1TbDlrmSmallWorkload(spec.Workload):
     num_batches = int(math.ceil(num_examples / global_batch_size))
     if split not in self._eval_iters:
       # These iterators will repeat indefinitely.
+      logging.info(f"BUILDING split with {data_dir} ")
       self._eval_iters[split] = self._build_input_queue(
           data_rng=rng,
           split=split,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -83,7 +83,7 @@ flags.DEFINE_integer('num_tuning_trials',
                      'The number of external hyperparameter trials to run.')
 flags.DEFINE_string('data_dir', '~/data', 'Dataset location.')
 flags.DEFINE_string('imagenet_v2_data_dir',
-                    '~/data',
+                    None,
                     'Dataset location for ImageNet-v2.')
 flags.DEFINE_string('librispeech_tokenizer_vocab_path',
                     '',
@@ -575,8 +575,6 @@ def score_submission_on_workload(workload: spec.Workload,
         tuning_search_space[hi] = hyperparameters
 
       with profiler.profile('Train'):
-        if 'imagenet' not in workload_name:
-          imagenet_v2_data_dir = None
         timing, metrics = train_once(workload, workload_name,
                                      global_batch_size,
                                      global_eval_batch_size,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -622,7 +622,6 @@ def score_submission_on_workload(workload: spec.Workload,
 
 
 def main(_):
-  logging.info(f'Data directory is set to {FLAGS.data_dir}')
   if FLAGS.profile:
     profiler = Profiler()
   else:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -624,7 +624,7 @@ def score_submission_on_workload(workload: spec.Workload,
 
 
 def main(_):
-  logging.info(f'Datas directory is set to {FLAGS.data_dir}')
+  logging.info(f'Data directory is set to {FLAGS.data_dir}')
   if FLAGS.profile:
     profiler = Profiler()
   else:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -624,6 +624,7 @@ def score_submission_on_workload(workload: spec.Workload,
 
 
 def main(_):
+  logging.info(f'Datas directory is set to {FLAGS.data_dir}')
   if FLAGS.profile:
     profiler = Profiler()
   else:


### PR DESCRIPTION
The submission_runner module has an obscure check  in train_once to set `imagenet_v2_data_dir` to None for non-imagenet workloads. It only performs the check for the external_tuning ruleset for some reason. 
As a result the with the self-tuning ruleset other workloads are being passed the default str for imagenet_v2_data_dir as the test_dir and breaking in the test eval.

To fix, this just set the default value for `imagenet_v2_data_dir` in the flag definition to None. 