### PR TITLE
Update submission deadline (moved by a week)

### DIFF
--- a/CALL_FOR_SUBMISSIONS.md
+++ b/CALL_FOR_SUBMISSIONS.md
@@ -16,7 +16,7 @@ Submissions can compete under two hyperparameter tuning rulesets (with separate 
 - Call for submissions: November 28th, 2023
 - **Registration deadline to express non-binding intent to submit: February 28th, 2024**.\
 Please fill out the (mandatory but non-binding) [**registration form**](https://forms.gle/K7ty8MaYdi2AxJ4N8).
-- **Submission deadline: March 28th, 2024**
+- **Submission deadline: April 04th, 2024** *(moved by a week from the initial March 28th, 2024)*
 - **Deadline for self-reporting preliminary results: May 28th, 2024**
 - [tentative] Announcement of all results: July 15th, 2024
 

--- a/COMPETITION_RULES.md
+++ b/COMPETITION_RULES.md
@@ -42,7 +42,7 @@ The Competition is open to English-speaking individuals and teams (made of indiv
 The Competition begins at 12:01am (ET) on November 28, 2023 and ends at 11:59pm (ET) on May 28, 2024, all according to Sponsor's time clock, which decisions are final (the "Competition Period"). There are several deadlines contained within the Competition Period:
 
 - **Intention to Submit.** You must register your Intention to Submit no later than 11:59pm ET on February 28, 2024.
-- **Submission Period.** You must complete your Submission and enter it after the Intention to Submit deadline, but no later than 11:59pm ET on March 28, 2024.
+- **Submission Period.** You must complete your Submission and enter it after the Intention to Submit deadline, but no later than 11:59pm ET on April 04, 2024.
 - **Deadline for self-reporting results.** 11:59pm ET on May 28, 2024.
 
 ## Agreement to Official Rules

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 > [!IMPORTANT]
 > Upcoming Deadline:
-> Submission deadline: **March 28th, 2024**.\
+> Submission deadline: **April 04th, 2024** (*moved by a week*) \
 > For other key dates please see [Call for Submissions](/CALL_FOR_SUBMISSIONS.md).
 
 ## Table of Contents <!-- omit from toc -->
@@ -97,7 +97,7 @@ python3 submission_runner.py \
 
 ## Call for Submissions
 
-The [Call for Submissions](/CALL_FOR_SUBMISSIONS.md) announces the first iteration of the AlgoPerf: Training Algorithms competition based on the benchmark by the same name. This document also contains the schedule and key dates for the competition. 
+The [Call for Submissions](/CALL_FOR_SUBMISSIONS.md) announces the first iteration of the AlgoPerf: Training Algorithms competition based on the benchmark by the same name. This document also contains the schedule and key dates for the competition.
 
 ### Competition Rules
 


### PR DESCRIPTION
As discussed, we decided to move the submission deadline by a week (from March 28 to April 04). All other deadlines are unaffected.

@priyakasimbeg I suggest to merge to main directly to have it visible as soon as possible.