### PR TITLE
Don't save final checkpoint when `save_checkpoints=False`

### DIFF
--- a/submission_runner.py
+++ b/submission_runner.py
@@ -111,8 +111,8 @@ flags.DEFINE_string('experiment_name', None, 'Name of the experiment.')
 flags.DEFINE_boolean(
     'save_checkpoints',
     True,
-    'Whether or not to save checkpoints of the model at every eval and after training.',
-)
+    'Whether or not to save checkpoints of the model and optimizer '
+    'at every eval and after training.')
 flags.DEFINE_boolean(
     'save_intermediate_checkpoints',
     True,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -111,7 +111,8 @@ flags.DEFINE_string('experiment_name', None, 'Name of the experiment.')
 flags.DEFINE_boolean(
     'save_checkpoints',
     True,
-    'Whether or not to save checkpoints of the model at every eval and after training.')
+    'Whether or not to save checkpoints of the model at every eval and after training.',
+)
 flags.DEFINE_boolean(
     'save_intermediate_checkpoints',
     True,

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -370,8 +370,8 @@ def train_once(
     train_state['is_time_remaining'] = (
         train_state['accumulated_submission_time'] < max_allowed_runtime_sec)
     # Check if submission is eligible for an untimed eval.
-    if ((train_step_end_time - train_state['last_eval_time'])
-        >= workload.eval_period_time_sec or train_state['training_complete']):
+    if ((train_step_end_time - train_state['last_eval_time']) >=
+        workload.eval_period_time_sec or train_state['training_complete']):
       with profiler.profile('Evaluation'):
         del batch
         _reset_cuda_mem()


### PR DESCRIPTION
Fixes #705.

I noticed that we already have a `save_intermediate_checkpoints` flag. When setting this to `False` and `save_checkpoints=True`, we can recreate the previous behaviour of only storing one final checkpoint.

Not sure where exactly in the docs to mention the lack of checkpointing during scoring? It shouldn't matter to the submitter as it is not timed, besides in edge cases like having an optimizer that does something like [this](https://github.com/facebookresearch/optimizers/blob/main/distributed_shampoo/distributed_shampoo.py#L901-L909), which would lead to an error in the submission if `save_checkpoints=True`.