### PR TITLE
Add support for `.eval()`

### DIFF
--- a/submission_runner.py
+++ b/submission_runner.py
@@ -383,6 +383,8 @@ def train_once(
 
         try:
           eval_start_time = get_time()
+          if hasattr(optimizer_state['optimizer'], 'eval'):
+            optimizer_state['optimizer'].eval()
           latest_eval_result = workload.eval_model(global_eval_batch_size,
                                                    model_params,
                                                    model_state,


### PR DESCRIPTION
Fixes https://github.com/mlcommons/algorithmic-efficiency/issues/758 and https://github.com/mlcommons/algorithmic-efficiency/issues/719

These two lines of code are sufficient to enable many extrapolation algorithms, including the weight averaging variants such as stochastic weight averaging, exponential moving average, schedule-free (cc @adefazio).