### PR TITLE
fix pytorch_default_init()

### DIFF
--- a/algorithmic_efficiency/init_utils.py
+++ b/algorithmic_efficiency/init_utils.py
@@ -13,6 +13,6 @@ def pytorch_default_init(module: nn.Module) -> None:
   # Perform lecun_normal initialization.
   fan_in, _ = nn.init._calculate_fan_in_and_fan_out(module.weight)
   std = math.sqrt(1. / fan_in) / .87962566103423978
-  nn.init.trunc_normal_(module.weight, std=std)
+  nn.init.trunc_normal_(module.weight, std=std, a=-2 * std, b=2 * std)
   if module.bias is not None:
     nn.init.constant_(module.bias, 0.)


### PR DESCRIPTION
[torch.nn.init.trunc_normal_() defaults to truncation at (a, b)](https://pytorch.org/docs/stable/nn.init.html#torch.nn.init.trunc_normal_), not (a * std, b * std). So to conform to JAX's `variance_scaling(..., distribution="truncated_normal", ...)` we need to multiply by `std` ourselves. We can see this by initializing a test model. Here is the repo's JAX ViT-S/16:

```python
>>> import jax.numpy
>>> import jax.random
>>> from algorithmic_efficiency.workloads.imagenet_vit.imagenet_jax.models import ViT
>>> from algorithmic_efficiency.workloads.imagenet_vit.workload import decode_variant
>>> vit = ViT(**decode_variant('S/16'))
>>> x = jax.numpy.zeros((1, 224, 224, 3), jax.numpy.float32)
>>> params = vit.init(jax.random.key(0), x)
>>> for w in [params['params']['conv_patch_extract']['kernel'], params['params']['pre_logits']['kernel']]:
...   print(w.min(), w.max())
...
-0.08204417 0.08203908
-0.11602508 0.116011634
```

Here is the repo's PyTorch ViT-S/16 before the fix:

```python
>>> from algorithmic_efficiency.workloads.imagenet_vit.imagenet_pytorch.models import ViT
>>> from algorithmic_efficiency.workloads.imagenet_vit.workload import decode_variant
>>> vit = ViT(**decode_variant('S/16'))
>>> for w in [vit.conv_patch_extract.weight, vit.pre_logits.weight]:
...   print(w.min(), w.max())
...
tensor(-0.2119, grad_fn=<MinBackward1>) tensor(0.1907, grad_fn=<MaxBackward1>)
tensor(-0.2749, grad_fn=<MinBackward1>) tensor(0.2512, grad_fn=<MaxBackward1>)
```

Here is the repo's PyTorch ViT-S/16 after the fix:

```python
>>> from algorithmic_efficiency.workloads.imagenet_vit.imagenet_pytorch.models import ViT
>>> from algorithmic_efficiency.workloads.imagenet_vit.workload import decode_variant
>>> vit = ViT(**decode_variant('S/16'))
>>> for w in [vit.conv_patch_extract.weight, vit.pre_logits.weight]:
...   print(w.min(), w.max())
... 
tensor(-0.0820, grad_fn=<MinBackward1>) tensor(0.0820, grad_fn=<MaxBackward1>)
tensor(-0.1160, grad_fn=<MinBackward1>) tensor(0.1160, grad_fn=<MaxBackward1>)
```
[Affected current workloads](https://github.com/search?q=repo%3Amlcommons%2Falgorithmic-efficiency%20pytorch_default_init&type=code) include `imagenet_vit`, `imagenet_resnet`, `fastmri`, and `ogbg`, along with (retired? test?) workloads `cifar` and `mnist`.

I hope this bug doesn't drastically upend the results so far but I don't know 😬