### PR TITLE
fix contrast() transform

### DIFF
--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/randaugment.py
@@ -128,19 +128,7 @@ def color(image, factor):
 
 def contrast(image, factor):
   """Equivalent of PIL Contrast."""
-  degenerate = tf.image.rgb_to_grayscale(image)
-  # Cast before calling tf.histogram.
-  degenerate = tf.cast(degenerate, tf.int32)
-
-  # Compute the grayscale histogram, then compute the mean pixel value,
-  # and create a constant image size of that value.  Use that as the
-  # blending degenerate target of the original image.
-  hist = tf.histogram_fixed_width(degenerate, [0, 255], nbins=256)
-  mean = tf.reduce_sum(tf.cast(hist, tf.float32)) / 256.0
-  degenerate = tf.ones_like(degenerate, dtype=tf.float32) * mean
-  degenerate = tf.clip_by_value(degenerate, 0.0, 255.0)
-  degenerate = tf.image.grayscale_to_rgb(tf.cast(degenerate, tf.uint8))
-  return blend(degenerate, image, factor)
+  return tf.image.adjust_contrast(image, factor)
 
 
 def brightness(image, factor):


### PR DESCRIPTION
See https://github.com/google-research/big_vision/issues/109, fix suggested by @yeqingli in https://github.com/tensorflow/models/pull/11219#pullrequestreview-2355525720.

In short, the original implementation of the contrast() transform which is copied 4-5+ times is broken:
What is meant to be the mean RGB value ends up being (h*w) / 256, which is always 196 for 224x224 crop.
This bug is often left unfixed, but here we are comparing the JAX vs. PyTorch implementations and the latter has the correct contrast transform:
https://github.com/mlcommons/algorithmic-efficiency/blob/86d2a0d23c9a3192f878406edc72547fcf0568ec/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_pytorch/randaugment.py#L107-L108

So the JAX counterpart should be correct as well.