### PR TITLE
[WIP] JAX.JIT Switch and Sharding

### DIFF
--- a/algorithmic_efficiency/checkpoint_utils.py
+++ b/algorithmic_efficiency/checkpoint_utils.py
@@ -193,10 +193,7 @@ def save_checkpoint(framework: str,
     train_state, eval_results, global_step, preemption_count).
   """
   if framework == 'jax':
-    model_params = jax.device_get(jax_utils.unreplicate(model_params))
     opt_state, _ = optimizer_state
-    opt_state = jax.device_get(jax_utils.unreplicate(opt_state))
-    model_state = jax.device_get(jax_utils.unreplicate(model_state))
   else:
     if isinstance(
         model_params,

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -12,6 +12,7 @@ from torch.utils.data import DistributedSampler
 from torch.utils.data import Sampler
 
 from algorithmic_efficiency import spec
+from algorithmic_efficiency import sharding_utils
 
 
 def shard_and_maybe_pad_np(
@@ -60,7 +61,7 @@ def shard_and_maybe_pad_np(
     if remainder_size != 0 or pad_to_global_batch_size:
       x = pad(x, pad_size, padding_value=padding_value)
 
-    return x
+    return jax.device_put(x, sharding_utils.get_naive_sharding_spec()) # x
 
   return jax.tree_map(_prepare, batch)
 

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -60,10 +60,7 @@ def shard_and_maybe_pad_np(
     if remainder_size != 0 or pad_to_global_batch_size:
       x = pad(x, pad_size, padding_value=padding_value)
 
-    # Reshape (global_batch_size, ...) to
-    # (local_device_count, per_device_batch_size, ...).
-    # Assumes that `global_batch_size % local_device_count == 0`.
-    return x.reshape((local_device_count, -1, *x.shape[1:]))
+    return x
 
   return jax.tree_map(_prepare, batch)
 

--- a/algorithmic_efficiency/data_utils.py
+++ b/algorithmic_efficiency/data_utils.py
@@ -51,7 +51,7 @@ def shard_and_maybe_pad_np(
     weights = batch.get('weights')
     # The weights will also be padded.
     batch['weights'] = np.ones(mask_shape) if weights is None else weights
-
+  naive_sharding_spec = sharding_utils.get_naive_sharding_spec()
   def _prepare(x):
     # Use _numpy() for zero-copy conversion between TF and NumPy.
     if not isinstance(x, np.ndarray):
@@ -61,7 +61,7 @@ def shard_and_maybe_pad_np(
     if remainder_size != 0 or pad_to_global_batch_size:
       x = pad(x, pad_size, padding_value=padding_value)
 
-    return jax.device_put(x, sharding_utils.get_naive_sharding_spec()) # x
+    return jax.device_put(x, naive_sharding_spec)
 
   return jax.tree_map(_prepare, batch)
 

--- a/algorithmic_efficiency/sharding_utils.py
+++ b/algorithmic_efficiency/sharding_utils.py
@@ -1,7 +1,9 @@
 """Utilities for dealing with sharding in JAX."""
 
 import jax
-from jax.sharding import Mesh, NamedSharding, PartitionSpec
+from jax.sharding import Mesh
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec
 
 
 def get_mesh() -> jax.sharding.Mesh:

--- a/algorithmic_efficiency/sharding_utils.py
+++ b/algorithmic_efficiency/sharding_utils.py
@@ -5,58 +5,57 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 
 def get_mesh() -> jax.sharding.Mesh:
-    """Creates a mesh from all available GPUs. Here, we simply create a one-dimensional mesh."""
-    return jax.sharding.Mesh(jax.devices(), ("batch",))
+  """Creates a mesh from all available GPUs. Here, we simply create a one-dimensional mesh."""
+  return jax.sharding.Mesh(jax.devices(), ("batch",))
+
 
 def get_replicated_sharding(mesh=None):
-    """Returns a sharding spec that replicates data across all devices."""
-    if mesh is None:
-        mesh = get_mesh()
-    return NamedSharding(mesh, PartitionSpec())
+  """Returns a sharding spec that replicates data across all devices."""
+  if mesh is None:
+    mesh = get_mesh()
+  return NamedSharding(mesh, PartitionSpec())
+
 
 def get_naive_sharding_spec(mesh=None):
-    """Returns a sharding spec that shards data along the first axis."""
-    if mesh is None:
-        mesh = get_mesh()
-    return NamedSharding(mesh, PartitionSpec("batch"))
+  """Returns a sharding spec that shards data along the first axis."""
+  if mesh is None:
+    mesh = get_mesh()
+  return NamedSharding(mesh, PartitionSpec("batch"))
 
 
 def get_naive_sharding(x, mesh=None):
-    """Given a 1D mesh and a tensor, try to shard along the appropriate axis."""
-    if mesh is None:
-        mesh = get_mesh()
-    grid_size = mesh.shape["batch"]
-    if x.shape[0] % grid_size == 0:
-        return NamedSharding(mesh, PartitionSpec("batch"))
-    else:
-        return NamedSharding(mesh, PartitionSpec())
-
-
-def shard_params(params, mesh=None):
-    """Shards a parameter tree across all devices with naive sharding (see get_naive_sharding)."""
-    if mesh is None:
-        mesh = get_mesh()
-    return jax.tree_util.tree_map(
-        lambda x: jax.device_put(x, get_naive_sharding(x)), params
-    )
-
-
-def get_sharding_tree(params, mesh=None):
-    """Returns a sharding tree for a parameter tree."""
-    return jax.tree_util.tree_map(lambda x: get_naive_sharding(x, mesh), params)
-
-
-def get_empty_sharding(mesh=None):
-    """Returns a sharding spec that replicates data across all devices."""
-    if mesh is None:
-        mesh = get_mesh()
+  """Given a 1D mesh and a tensor, try to shard along the appropriate axis."""
+  if mesh is None:
+    mesh = get_mesh()
+  grid_size = mesh.shape["batch"]
+  if x.shape[0] % grid_size == 0:
+    return NamedSharding(mesh, PartitionSpec("batch"))
+  else:
     return NamedSharding(mesh, PartitionSpec())
 
 
+def shard_params(params, mesh=None):
+  """Shards a parameter tree across all devices with naive sharding (see get_naive_sharding)."""
+  if mesh is None:
+    mesh = get_mesh()
+  return jax.tree_util.tree_map(
+      lambda x: jax.device_put(x, get_naive_sharding(x)), params)
+
+
+def get_sharding_tree(params, mesh=None):
+  """Returns a sharding tree for a parameter tree."""
+  return jax.tree_util.tree_map(lambda x: get_naive_sharding(x, mesh), params)
+
+
+def get_empty_sharding(mesh=None):
+  """Returns a sharding spec that replicates data across all devices."""
+  if mesh is None:
+    mesh = get_mesh()
+  return NamedSharding(mesh, PartitionSpec())
+
+
 def disp_shard_info(x: jax.Array):
-    """Displays shard info of a jax array."""
-    for shard in x.addressable_shards:
-        print(
-            f"shard.device: {shard.device}, index: {shard.index}, replica_id:"
-            f" {shard.replica_id}.\n"
-        )
+  """Displays shard info of a jax array."""
+  for shard in x.addressable_shards:
+    print(f"shard.device: {shard.device}, index: {shard.index}, replica_id:"
+          f" {shard.replica_id}.\n")

--- a/algorithmic_efficiency/sharding_utils.py
+++ b/algorithmic_efficiency/sharding_utils.py
@@ -17,6 +17,11 @@ def get_replicated_sharding(mesh=None):
     mesh = get_mesh()
   return NamedSharding(mesh, PartitionSpec())
 
+def shard_replicated(x, mesh=None):
+  """Shards a tensor across all devices."""
+  if mesh is None:
+    mesh = get_mesh()
+  return jax.tree_map(lambda x: jax.device_put(x, get_replicated_sharding(mesh)), x)
 
 def get_naive_sharding_spec(mesh=None):
   """Returns a sharding spec that shards data along the first axis."""

--- a/algorithmic_efficiency/sharding_utils.py
+++ b/algorithmic_efficiency/sharding_utils.py
@@ -35,11 +35,10 @@ def get_naive_sharding(x, mesh=None):
   if mesh is None:
     mesh = get_mesh()
   grid_size = mesh.shape["batch"]
-  if x.shape[0] % grid_size == 0:
+  if len(x.shape) > 0 and x.shape[0] % grid_size == 0:
     return NamedSharding(mesh, PartitionSpec("batch"))
   else:
     return NamedSharding(mesh, PartitionSpec())
-
 
 def shard_params(params, mesh=None):
   """Shards a parameter tree across all devices with naive sharding (see get_naive_sharding)."""
@@ -48,6 +47,15 @@ def shard_params(params, mesh=None):
   return jax.tree_util.tree_map(
       lambda x: jax.device_put(x, get_naive_sharding(x)), params)
 
+def shard_naive(x, mesh=None):
+  return shard_params(x, mesh)
+
+
+
+def get_naive_sharding_tree(input_tree, mesh=None):
+  if mesh is None:
+    mesh = get_mesh()
+  return jax.tree_util.tree_map(lambda x: get_naive_sharding(x, mesh), input_tree)
 
 def get_sharding_tree(params, mesh=None):
   """Returns a sharding tree for a parameter tree."""

--- a/algorithmic_efficiency/sharding_utils.py
+++ b/algorithmic_efficiency/sharding_utils.py
@@ -1,0 +1,62 @@
+"""Utilities for dealing with sharding in JAX."""
+
+import jax
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+
+def get_mesh() -> jax.sharding.Mesh:
+    """Creates a mesh from all available GPUs. Here, we simply create a one-dimensional mesh."""
+    return jax.sharding.Mesh(jax.devices(), ("batch",))
+
+def get_replicated_sharding(mesh=None):
+    """Returns a sharding spec that replicates data across all devices."""
+    if mesh is None:
+        mesh = get_mesh()
+    return NamedSharding(mesh, PartitionSpec())
+
+def get_naive_sharding_spec(mesh=None):
+    """Returns a sharding spec that shards data along the first axis."""
+    if mesh is None:
+        mesh = get_mesh()
+    return NamedSharding(mesh, PartitionSpec("batch"))
+
+
+def get_naive_sharding(x, mesh=None):
+    """Given a 1D mesh and a tensor, try to shard along the appropriate axis."""
+    if mesh is None:
+        mesh = get_mesh()
+    grid_size = mesh.shape["batch"]
+    if x.shape[0] % grid_size == 0:
+        return NamedSharding(mesh, PartitionSpec("batch"))
+    else:
+        return NamedSharding(mesh, PartitionSpec())
+
+
+def shard_params(params, mesh=None):
+    """Shards a parameter tree across all devices with naive sharding (see get_naive_sharding)."""
+    if mesh is None:
+        mesh = get_mesh()
+    return jax.tree_util.tree_map(
+        lambda x: jax.device_put(x, get_naive_sharding(x)), params
+    )
+
+
+def get_sharding_tree(params, mesh=None):
+    """Returns a sharding tree for a parameter tree."""
+    return jax.tree_util.tree_map(lambda x: get_naive_sharding(x, mesh), params)
+
+
+def get_empty_sharding(mesh=None):
+    """Returns a sharding spec that replicates data across all devices."""
+    if mesh is None:
+        mesh = get_mesh()
+    return NamedSharding(mesh, PartitionSpec())
+
+
+def disp_shard_info(x: jax.Array):
+    """Displays shard info of a jax array."""
+    for shard in x.addressable_shards:
+        print(
+            f"shard.device: {shard.device}, index: {shard.index}, replica_id:"
+            f" {shard.replica_id}.\n"
+        )

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/input_pipeline.py
@@ -8,7 +8,6 @@ and adjusted to work for CIFAR10.
 import functools
 from typing import Dict, Iterator, Tuple
 
-from flax import jax_utils
 import jax
 import tensorflow as tf
 import tensorflow_datasets as tfds
@@ -171,5 +170,6 @@ def create_input_iter(
       functools.partial(
           shard_and_maybe_pad_np, global_batch_size=global_batch_size),
       ds)
-  it = jax_utils.prefetch_to_device(it, 2)
+  # FIXME(rka97): Figure out how to do prefetching+sharding.
+  # it = jax_utils.prefetch_to_device(it, 2)
   return it

--- a/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
+++ b/algorithmic_efficiency/workloads/cifar/cifar_jax/workload.py
@@ -3,7 +3,6 @@
 import functools
 from typing import Any, Dict, Iterator, Optional, Tuple
 
-from flax import jax_utils
 from flax import linen as nn
 import jax
 from jax import lax
@@ -12,6 +11,7 @@ import optax
 import tensorflow_datasets as tfds
 
 from algorithmic_efficiency import param_utils
+from algorithmic_efficiency import sharding_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.cifar.cifar_jax import models
 from algorithmic_efficiency.workloads.cifar.cifar_jax.input_pipeline import \
@@ -28,15 +28,16 @@ class CifarWorkload(BaseCifarWorkload):
       data_dir: str,
       batch_size: int,
       cache: Optional[bool] = None,
-      repeat_final_dataset: Optional[bool] = None
+      repeat_final_dataset: Optional[bool] = None,
   ) -> Iterator[Dict[str, spec.Tensor]]:
-    ds_builder = tfds.builder('cifar10:3.0.2', data_dir=data_dir)
-    train = split == 'train'
+    data_dir = data_dir + "/cifar10"
+    ds_builder = tfds.builder("cifar10:3.0.2", data_dir=data_dir)
+    train = split == "train"
     assert self.num_train_examples + self.num_validation_examples == 50000
-    if split in ['train', 'eval_train']:
-      split = f'train[:{self.num_train_examples}]'
-    elif split == 'validation':
-      split = f'train[{self.num_train_examples}:]'
+    if split in ["train", "eval_train"]:
+      split = f"train[:{self.num_train_examples}]"
+    elif split == "validation":
+      split = f"train[{self.num_train_examples}:]"
     ds = create_input_iter(
         split,
         ds_builder,
@@ -48,7 +49,8 @@ class CifarWorkload(BaseCifarWorkload):
         self.padding_size,
         train=train,
         cache=not train if cache is None else cache,
-        repeat_final_dataset=repeat_final_dataset)
+        repeat_final_dataset=repeat_final_dataset,
+    )
     return ds
 
   def _build_input_queue(
@@ -59,7 +61,8 @@ class CifarWorkload(BaseCifarWorkload):
       global_batch_size: int,
       cache: Optional[bool] = None,
       repeat_final_dataset: Optional[bool] = None,
-      num_batches: Optional[int] = None) -> Iterator[Dict[str, spec.Tensor]]:
+      num_batches: Optional[int] = None,
+  ) -> Iterator[Dict[str, spec.Tensor]]:
     del num_batches
     return self._build_cifar_dataset(data_rng,
                                      split,
@@ -74,34 +77,35 @@ class CifarWorkload(BaseCifarWorkload):
     # An axis_name is passed to pmap which can then be used by pmean.
     # In this case each device has its own version of the batch statistics
     # and we average them.
-    avg_fn = jax.pmap(lambda x: lax.pmean(x, 'x'), 'x')
+    avg_fn = jax.pmap(lambda x: lax.pmean(x, "x"), "x")
     new_model_state = model_state.copy(
-        {'batch_stats': avg_fn(model_state['batch_stats'])})
+        {"batch_stats": avg_fn(model_state["batch_stats"])})
     return new_model_state
 
   def init_model_fn(
       self,
       rng: spec.RandomState,
       dropout_rate: Optional[float] = None,
-      aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
+      aux_dropout_rate: Optional[float] = None,
+  ) -> spec.ModelInitState:
     """Dropout is unused."""
     del dropout_rate
     del aux_dropout_rate
-    model_cls = getattr(models, 'ResNet18')
+    model_cls = getattr(models, "ResNet18")
     model = model_cls(num_classes=self._num_classes, dtype=jnp.float32)
     self._model = model
     input_shape = (1, 32, 32, 3)
-    variables = jax.jit(model.init)({'params': rng},
+    variables = jax.jit(model.init)({"params": rng},
                                     jnp.ones(input_shape, model.dtype))
-    model_state, params = variables.pop('params')
+    model_state, params = variables.pop("params")
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
-    model_state = jax_utils.replicate(model_state)
-    params = jax_utils.replicate(params)
+    # model_state = jax_utils.replicate(model_state)
+    # params = jax_utils.replicate(params)
     return params, model_state
 
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
-    return param_key == 'Dense_0'
+    return param_key == "Dense_0"
 
   def model_fn(
       self,
@@ -110,23 +114,26 @@ class CifarWorkload(BaseCifarWorkload):
       model_state: spec.ModelAuxiliaryState,
       mode: spec.ForwardPassMode,
       rng: spec.RandomState,
-      update_batch_norm: bool) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
+      update_batch_norm: bool,
+  ) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del mode
     del rng
-    variables = {'params': params, **model_state}
+    variables = {"params": params, **model_state}
     if update_batch_norm:
       logits, new_model_state = self._model.apply(
           variables,
-          augmented_and_preprocessed_input_batch['inputs'],
+          augmented_and_preprocessed_input_batch["inputs"],
           update_batch_norm=update_batch_norm,
-          mutable=['batch_stats'])
+          mutable=["batch_stats"],
+      )
       return logits, new_model_state
     else:
       logits = self._model.apply(
           variables,
-          augmented_and_preprocessed_input_batch['inputs'],
+          augmented_and_preprocessed_input_batch["inputs"],
           update_batch_norm=update_batch_norm,
-          mutable=False)
+          mutable=False,
+      )
       return logits, model_state
 
   # Does NOT apply regularization, which is left to the submitter to do in
@@ -136,13 +143,15 @@ class CifarWorkload(BaseCifarWorkload):
       label_batch: spec.Tensor,  # Dense or one-hot labels.
       logits_batch: spec.Tensor,
       mask_batch: Optional[spec.Tensor] = None,
-      label_smoothing: float = 0.0) -> Dict[str, spec.Tensor]:  # differentiable
+      label_smoothing: float = 0.0,
+  ) -> Dict[str, spec.Tensor]:  # differentiable
     """Evaluate the (masked) loss function at (label_batch, logits_batch).
 
-    Return {'summed': scalar summed loss, 'n_valid_examples': scalar number of
-    valid examples in batch, 'per_example': 1-d array of per-example losses}
-    (not synced across devices).
-    """
+        Return {'summed': scalar summed loss,
+        'n_valid_examples': scalar number of
+        valid examples in batch, 'per_example': 1-d array of per-example losses}
+        (not synced across devices).
+        """
     one_hot_targets = jax.nn.one_hot(label_batch, self._num_classes)
     smoothed_targets = optax.smooth_labels(one_hot_targets, label_smoothing)
     per_example_losses = -jnp.sum(
@@ -155,51 +164,69 @@ class CifarWorkload(BaseCifarWorkload):
       n_valid_examples = len(per_example_losses)
     summed_loss = per_example_losses.sum()
     return {
-        'summed': summed_loss,
-        'n_valid_examples': n_valid_examples,
-        'per_example': per_example_losses,
+        "summed": summed_loss,
+        "n_valid_examples": n_valid_examples,
+        "per_example": per_example_losses,
     }
 
   def _compute_metrics(self,
                        logits: spec.Tensor,
                        labels: spec.Tensor,
                        weights: spec.Tensor) -> Dict[str, spec.Tensor]:
-    summed_loss = self.loss_fn(labels, logits, weights)['summed']
+    summed_loss = self.loss_fn(labels, logits, weights)["summed"]
     # Number of correct predictions.
     accuracy = jnp.sum((jnp.argmax(logits, -1) == labels) * weights)
-    metrics = {
-        'loss': summed_loss,
-        'accuracy': accuracy,
-    }
-    metrics = lax.psum(metrics, axis_name='batch')
-    return metrics
+    return jnp.array(summed_loss), jnp.array(accuracy)
 
-  @functools.partial(
-      jax.pmap,
-      axis_name='batch',
-      in_axes=(None, 0, 0, 0, None),
-      static_broadcasted_argnums=(0,))
   def _eval_model(
       self,
       params: spec.ParameterContainer,
       batch: Dict[str, spec.Tensor],
       model_state: spec.ModelAuxiliaryState,
-      rng: spec.RandomState) -> Dict[spec.Tensor, spec.ModelAuxiliaryState]:
+      rng: spec.RandomState,
+  ) -> Dict[spec.Tensor, spec.ModelAuxiliaryState]:
     """Return the mean accuracy and loss as a dict."""
-    logits, _ = self.model_fn(
-        params,
-        batch,
-        model_state,
-        spec.ForwardPassMode.EVAL,
-        rng,
-        update_batch_norm=False)
-    weights = batch.get('weights')
-    if weights is None:
-      weights = jnp.ones(len(logits))
-    return self._compute_metrics(logits, batch['targets'], weights)
+
+    @functools.partial(
+        jax.jit,
+        in_shardings=(
+            sharding_utils.get_replicated_sharding(),  # params
+            sharding_utils.get_naive_sharding_spec(),  # batch
+            sharding_utils.get_replicated_sharding(),  # model_state
+            sharding_utils.get_naive_sharding_spec(),  # rng
+        ),
+    )
+    def _per_device_eval_model(
+        params: spec.ParameterContainer,
+        batch: Dict[str, spec.Tensor],
+        model_state: spec.ModelAuxiliaryState,
+        rng: spec.RandomState,
+    ) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
+      logits, _ = self.model_fn(
+          params,
+          batch,
+          model_state,
+          spec.ForwardPassMode.EVAL,
+          rng,
+          update_batch_norm=False,
+      )
+      weights = batch.get("weights")
+      if weights is None:
+        weights = jnp.ones(len(logits))
+      return self._compute_metrics(logits, batch["targets"], weights)
+
+    losses, accuracies = _per_device_eval_model(params, batch, model_state, rng)
+    metrics = {
+        "loss":
+            jnp.mean(losses, axis=0) if losses.ndim > 0 else losses,
+        "accuracy":
+            (jnp.mean(accuracies, axis=0) if accuracies.ndim > 0 else accuracies
+            ),
+    }
+    return metrics
 
   def _normalize_eval_metrics(
       self, num_examples: int, total_metrics: Dict[str,
                                                    Any]) -> Dict[str, float]:
     """Normalize eval metrics."""
-    return jax.tree_map(lambda x: float(x[0] / num_examples), total_metrics)
+    return jax.tree_map(lambda x: x / num_examples, total_metrics)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/input_pipeline.py
@@ -400,6 +400,6 @@ def create_input_iter(split: str,
       ds)
 
   # Note(Dan S): On a Nvidia 2080 Ti GPU, this increased GPU utilization by 10%.
-  it = jax_utils.prefetch_to_device(it, 2)
+  # it = jax_utils.prefetch_to_device(it, 2)
 
   return iter(it)

--- a/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_resnet/imagenet_jax/workload.py
@@ -17,6 +17,7 @@ import jax.numpy as jnp
 import optax
 import tensorflow_datasets as tfds
 
+from algorithmic_efficiency import sharding_utils
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import random_utils as prng
 from algorithmic_efficiency import spec
@@ -72,16 +73,20 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         use_randaug=use_randaug)
     return ds
 
+  @functools.partial(
+      jax.jit,
+      in_shardings=(
+          sharding_utils.get_replicated_sharding(),  # model_state
+      ),
+      out_shardings=sharding_utils.get_replicated_sharding(),
+      static_argnums=(0,))
   def sync_batch_stats(
       self, model_state: spec.ModelAuxiliaryState) -> spec.ModelAuxiliaryState:
-    """Sync the batch statistics across replicas."""
-    # An axis_name is passed to pmap which can then be used by pmean.
-    # In this case each device has its own version of the batch statistics and
-    # we average them.
-    avg_fn = jax.pmap(lambda x: lax.pmean(x, 'x'), 'x')
-    new_model_state = model_state.copy(
-        {'batch_stats': avg_fn(model_state['batch_stats'])})
-    return new_model_state
+    """Sync batch statistics across replicas."""
+    new_batch_stats = jax.tree_map(lambda x: jnp.mean(x, axis=0),
+                                   model_state['batch_stats'])
+    return model_state.copy({'batch_stats': new_batch_stats})
+
 
   def init_model_fn(
       self,
@@ -114,18 +119,30 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
     model_state, params = variables.pop('params')
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
-    model_state = jax_utils.replicate(model_state)
-    params = jax_utils.replicate(params)
+    mesh = sharding_utils.get_mesh()
+    params = jax.tree_map(
+        lambda x: jax.device_put(x, sharding_utils.get_replicated_sharding(mesh)
+                                ),
+        params)
+    model_state = jax.tree_map(
+        lambda x: jax.device_put(x, sharding_utils.get_replicated_sharding(mesh)
+                                ),
+        model_state)
     return params, model_state
 
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     return param_key == 'Dense_0'
 
   @functools.partial(
-      jax.pmap,
-      axis_name='batch',
-      in_axes=(None, 0, 0, 0, 0),
-      static_broadcasted_argnums=(0,))
+      jax.jit,
+      in_shardings=(
+          sharding_utils.get_replicated_sharding(),  # params
+          sharding_utils.get_naive_sharding_spec(),  # batch
+          sharding_utils.get_replicated_sharding(),  # model_state
+          sharding_utils.get_replicated_sharding(),  # rng
+      ),
+      static_argnums=(0,),
+      out_shardings=sharding_utils.get_naive_sharding_spec())
   def _eval_model(self,
                   params: spec.ParameterContainer,
                   batch: Dict[str, spec.Tensor],
@@ -215,7 +232,7 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
         'loss': summed_loss,
         'accuracy': accuracy,
     }
-    metrics = lax.psum(metrics, axis_name='batch')
+    # metrics = lax.psum(metrics, axis_name='batch')
     return metrics
 
   def _eval_model_on_split(self,
@@ -249,11 +266,12 @@ class ImagenetResNetWorkload(BaseImagenetResNetWorkload):
       eval_rng = prng.fold_in(eval_rng, bi)
       step_eval_rngs = prng.split(eval_rng, jax.local_device_count())
       batch = next(self._eval_iters[split])
-      # We already average these metrics across devices inside _compute_metrics.
       synced_metrics = self._eval_model(params,
                                         batch,
                                         model_state,
                                         step_eval_rngs)
+      # Sum up the synced metrics
+      synced_metrics = jax.tree_map(lambda x: jnp.sum(x, axis=0), synced_metrics)
       for metric_name, metric_value in synced_metrics.items():
         if metric_name not in eval_metrics:
           eval_metrics[metric_name] = 0.0

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/models.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/models.py
@@ -153,8 +153,8 @@ class Conv2dSubsampling(nn.Module):
     self.kernel = self.param('kernel',
                              nn.initializers.xavier_uniform(),
                              self.filter_shape)
-    self.bias = self.param(
-        'bias', lambda rng, s: jnp.zeros(s, jnp.float32), self.output_channels)
+    self.bias = self.param('bias', lambda rng, s: jnp.zeros(s, jnp.float32),
+                           self.output_channels)
 
   @nn.compact
   def __call__(self, inputs, paddings):
@@ -442,12 +442,10 @@ class BatchNorm(nn.Module):
     dtype = self.config.dtype
 
     self.ra_mean = self.variable('batch_stats',
-                                 'mean',
-                                 lambda s: jnp.zeros(s, dtype),
+                                 'mean', lambda s: jnp.zeros(s, dtype),
                                  dim)
     self.ra_var = self.variable('batch_stats',
-                                'var',
-                                lambda s: jnp.ones(s, dtype),
+                                'var', lambda s: jnp.ones(s, dtype),
                                 dim)
 
     self.gamma = self.param('scale', nn.initializers.zeros, dim, dtype)

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/spectrum_augmenter.py
@@ -81,8 +81,8 @@ class SpecAug(nn.Module):
           jnp.expand_dims(jnp.arange(multiplicity, dtype=jnp.int32), 0),
           [batch_size, 1])
       multiplicity_tensor = masks_per_frame * choose_range
-      multiplicity_weights = (multiplicity_weights <
-                              multiplicity_tensor).astype(jnp.int32)
+      multiplicity_weights = (multiplicity_weights
+                              < multiplicity_tensor).astype(jnp.int32)
       pre_mask = jnp.einsum('bmt,bm->bt', pre_mask, multiplicity_weights)
     else:
       pre_mask = jnp.einsum('bmt->bt', pre_mask)

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -6,16 +6,16 @@ from flax import jax_utils
 import flax.linen as nn
 import jax
 from jax import lax
-from jax.sharding import NamedSharding, PartitionSpec as P
-
-from algorithmic_efficiency import sharding_utils
 import jax.numpy as jnp
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 import numpy as np
 import optax
 import torch
 
 from algorithmic_efficiency import data_utils
 from algorithmic_efficiency import param_utils
+from algorithmic_efficiency import sharding_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.librispeech_conformer import metrics
 from algorithmic_efficiency.workloads.librispeech_conformer import workload
@@ -23,6 +23,7 @@ from algorithmic_efficiency.workloads.librispeech_conformer.input_pipeline impor
     LibriSpeechDataset
 from algorithmic_efficiency.workloads.librispeech_conformer.librispeech_jax import \
     models
+
 
 class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
@@ -95,16 +96,18 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
-    
+
     # Add sharding
     mesh = sharding_utils.get_mesh()
     params = jax.tree_map(
-        lambda x: jax.device_put(x, sharding_utils.get_replicated_sharding(mesh)),
+        lambda x: jax.device_put(x, sharding_utils.get_replicated_sharding(mesh)
+                                ),
         params)
     model_state = jax.tree_map(
-        lambda x: jax.device_put(x, sharding_utils.get_replicated_sharding(mesh)),
+        lambda x: jax.device_put(x, sharding_utils.get_replicated_sharding(mesh)
+                                ),
         model_state)
-    
+
     return params, model_state
 
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
@@ -340,36 +343,41 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     targets, target_paddings = batch['targets']
     # Convert metrics bundle to dictionary
     metrics_dict = {
-        'loss_per_example': loss['per_example'],
-        'decoded': decoded,
-        'decoded_paddings': decoded_paddings,
-        'targets': targets,
-        'target_paddings': target_paddings,
-        'n_valid_examples': jnp.zeros((len(jax.devices()), 1)) + loss['n_valid_examples']
+        'loss_per_example':
+            loss['per_example'],
+        'decoded':
+            decoded,
+        'decoded_paddings':
+            decoded_paddings,
+        'targets':
+            targets,
+        'target_paddings':
+            target_paddings,
+        'n_valid_examples':
+            jnp.zeros((len(jax.devices()), 1)) + loss['n_valid_examples']
     }
     return metrics_dict
 
-  def eval_step(
-      self,
-      params: spec.ParameterContainer,
-      batch: Dict[str, spec.Tensor],
-      model_state: spec.ModelAuxiliaryState,
-      rng: spec.RandomState):
+  def eval_step(self,
+                params: spec.ParameterContainer,
+                batch: Dict[str, spec.Tensor],
+                model_state: spec.ModelAuxiliaryState,
+                rng: spec.RandomState):
     """Evaluates the model and returns a metrics bundle."""
     metrics_dict = self._eval_step(params, batch, model_state, rng)
-    
+
     # Convert dictionary back to metrics bundle
     metrics = self.metrics_bundle.single_from_model_output(
         loss_dict={
-          'summed': metrics_dict['loss_per_example'].sum(),
-          'per_example': metrics_dict['loss_per_example'],
-          'n_valid_examples': metrics_dict['n_valid_examples'].sum()
+            'summed': metrics_dict['loss_per_example'].sum(),
+            'per_example': metrics_dict['loss_per_example'],
+            'n_valid_examples': metrics_dict['n_valid_examples'].sum()
         },
         decoded=metrics_dict['decoded'],
         decoded_paddings=metrics_dict['decoded_paddings'],
         targets=metrics_dict['targets'],
         target_paddings=metrics_dict['target_paddings'])
-    
+
     return metrics
 
   def _eval_model_on_split(self,
@@ -395,10 +403,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     metrics_report = None
     for _ in range(num_batches):
       eval_batch = next(self._eval_iters[split])
-      computed_metrics = self.eval_step(params,
-                                      eval_batch,
-                                      model_state,
-                                      rng)
+      computed_metrics = self.eval_step(params, eval_batch, model_state, rng)
 
       if metrics_report is None:
         metrics_report = computed_metrics
@@ -416,15 +421,13 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
           sharding_utils.get_replicated_sharding(),  # model_state
       ),
       out_shardings=sharding_utils.get_replicated_sharding(),
-      static_argnums=(0,)
-  )
+      static_argnums=(0,))
   def sync_batch_stats(
       self, model_state: spec.ModelAuxiliaryState) -> spec.ModelAuxiliaryState:
     """Sync batch statistics across replicas."""
     # Replace pmean with direct mean across devices
-    new_batch_stats = jax.tree_map(
-        lambda x: jnp.mean(x, axis=0), 
-        model_state['batch_stats'])
+    new_batch_stats = jax.tree_map(lambda x: jnp.mean(x, axis=0),
+                                   model_state['batch_stats'])
     return model_state.copy({'batch_stats': new_batch_stats})
 
 

--- a/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -6,6 +6,9 @@ from flax import jax_utils
 import flax.linen as nn
 import jax
 from jax import lax
+from jax.sharding import NamedSharding, PartitionSpec as P
+
+from algorithmic_efficiency import sharding_utils
 import jax.numpy as jnp
 import numpy as np
 import optax
@@ -20,7 +23,6 @@ from algorithmic_efficiency.workloads.librispeech_conformer.input_pipeline impor
     LibriSpeechDataset
 from algorithmic_efficiency.workloads.librispeech_conformer.librispeech_jax import \
     models
-
 
 class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
@@ -93,8 +95,16 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
     self._param_shapes = param_utils.jax_param_shapes(params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
-    model_state = jax_utils.replicate(model_state)
-    params = jax_utils.replicate(params)
+    
+    # Add sharding
+    mesh = sharding_utils.get_mesh()
+    params = jax.tree_map(
+        lambda x: jax.device_put(x, sharding_utils.get_replicated_sharding(mesh)),
+        params)
+    model_state = jax.tree_map(
+        lambda x: jax.device_put(x, sharding_utils.get_replicated_sharding(mesh)),
+        model_state)
+    
     return params, model_state
 
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
@@ -176,6 +186,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
           'targets': (targets.numpy(), target_paddings.numpy()),
       }
 
+      # Use data_utils.shard_and_maybe_pad_np to handle sharding
       padded_batch = data_utils.shard_and_maybe_pad_np(
           numpy_batch, padding_value=1.0)
       yield padded_batch
@@ -300,11 +311,16 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     return hyp, hyp_paddings
 
   @functools.partial(
-      jax.pmap,
-      axis_name='batch',
-      in_axes=(None, 0, 0, 0, None),
-      static_broadcasted_argnums=(0,))
-  def eval_step_pmapped(
+      jax.jit,
+      in_shardings=(
+          sharding_utils.get_replicated_sharding(),  # params
+          sharding_utils.get_naive_sharding_spec(),  # batch
+          sharding_utils.get_replicated_sharding(),  # model_state  
+          sharding_utils.get_replicated_sharding(),  # rng
+      ),
+      out_shardings=sharding_utils.get_naive_sharding_spec(),
+      static_argnums=(0,))
+  def _eval_step(
       self,
       params: spec.ParameterContainer,
       batch: Dict[str, spec.Tensor],
@@ -322,13 +338,39 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     loss = self.loss_fn(batch['targets'], (logits, logit_paddings))
 
     targets, target_paddings = batch['targets']
-    return self.metrics_bundle.gather_from_model_output(
-        loss_dict=loss,
-        decoded=decoded,
-        decoded_paddings=decoded_paddings,
-        targets=targets,
-        target_paddings=target_paddings,
-        axis_name='batch')
+    # Convert metrics bundle to dictionary
+    metrics_dict = {
+        'loss_per_example': loss['per_example'],
+        'decoded': decoded,
+        'decoded_paddings': decoded_paddings,
+        'targets': targets,
+        'target_paddings': target_paddings,
+        'n_valid_examples': jnp.zeros((len(jax.devices()), 1)) + loss['n_valid_examples']
+    }
+    return metrics_dict
+
+  def eval_step(
+      self,
+      params: spec.ParameterContainer,
+      batch: Dict[str, spec.Tensor],
+      model_state: spec.ModelAuxiliaryState,
+      rng: spec.RandomState):
+    """Evaluates the model and returns a metrics bundle."""
+    metrics_dict = self._eval_step(params, batch, model_state, rng)
+    
+    # Convert dictionary back to metrics bundle
+    metrics = self.metrics_bundle.single_from_model_output(
+        loss_dict={
+          'summed': metrics_dict['loss_per_example'].sum(),
+          'per_example': metrics_dict['loss_per_example'],
+          'n_valid_examples': metrics_dict['n_valid_examples'].sum()
+        },
+        decoded=metrics_dict['decoded'],
+        decoded_paddings=metrics_dict['decoded_paddings'],
+        targets=metrics_dict['targets'],
+        target_paddings=metrics_dict['target_paddings'])
+    
+    return metrics
 
   def _eval_model_on_split(self,
                            split: str,
@@ -353,10 +395,10 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
     metrics_report = None
     for _ in range(num_batches):
       eval_batch = next(self._eval_iters[split])
-      computed_metrics = self.eval_step_pmapped(params,
-                                                eval_batch,
-                                                model_state,
-                                                rng).unreplicate()
+      computed_metrics = self.eval_step(params,
+                                      eval_batch,
+                                      model_state,
+                                      rng)
 
       if metrics_report is None:
         metrics_report = computed_metrics
@@ -368,15 +410,22 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
 
     return computed_metrics
 
+  @functools.partial(
+      jax.jit,
+      in_shardings=(
+          sharding_utils.get_replicated_sharding(),  # model_state
+      ),
+      out_shardings=sharding_utils.get_replicated_sharding(),
+      static_argnums=(0,)
+  )
   def sync_batch_stats(
       self, model_state: spec.ModelAuxiliaryState) -> spec.ModelAuxiliaryState:
-    # An axis_name is passed to pmap which can then be used by pmean.
-    # In this case each device has its own version of the batch statistics and
-    # we average them.
-    avg_fn = jax.pmap(lambda x: lax.pmean(x, 'x'), 'x')
-    new_model_state = model_state.copy(
-        {'batch_stats': avg_fn(model_state['batch_stats'])})
-    return new_model_state
+    """Sync batch statistics across replicas."""
+    # Replace pmean with direct mean across devices
+    new_batch_stats = jax.tree_map(
+        lambda x: jnp.mean(x, axis=0), 
+        model_state['batch_stats'])
+    return model_state.copy({'batch_stats': new_batch_stats})
 
 
 class LibriSpeechConformerAttentionTemperatureWorkload(

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_jax/models.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_jax/models.py
@@ -139,8 +139,8 @@ class Conv2dSubsampling(nn.Module):
     self.kernel = self.param('kernel',
                              nn.initializers.xavier_uniform(),
                              self.filter_shape)
-    self.bias = self.param(
-        'bias', lambda rng, s: jnp.zeros(s, jnp.float32), self.output_channels)
+    self.bias = self.param('bias', lambda rng, s: jnp.zeros(s, jnp.float32),
+                           self.output_channels)
 
   @nn.compact
   def __call__(self, inputs, paddings, train):
@@ -273,12 +273,10 @@ class BatchNorm(nn.Module):
     dtype = self.dtype
 
     self.ra_mean = self.variable('batch_stats',
-                                 'mean',
-                                 lambda s: jnp.zeros(s, dtype),
+                                 'mean', lambda s: jnp.zeros(s, dtype),
                                  dim)
     self.ra_var = self.variable('batch_stats',
-                                'var',
-                                lambda s: jnp.ones(s, dtype),
+                                'var', lambda s: jnp.ones(s, dtype),
                                 dim)
 
     self.gamma = self.param('scale', nn.initializers.zeros, dim, dtype)

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -10,7 +10,8 @@ from jax import lax
 import jax.numpy as jnp
 import optax
 
-from algorithmic_efficiency import param_utils, sharding_utils
+from algorithmic_efficiency import param_utils
+from algorithmic_efficiency import sharding_utils
 from algorithmic_efficiency import spec
 from algorithmic_efficiency.workloads.mnist.workload import BaseMnistWorkload
 

--- a/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/mnist_jax/workload.py
@@ -102,11 +102,12 @@ class MnistWorkload(BaseMnistWorkload):
 
   @functools.partial(
       jax.jit,
-      in_shardings=(sharding_utils.get_replicated_sharding(),  # params
-                    sharding_utils.get_naive_sharding_spec(),  # batch
-                    sharding_utils.get_replicated_sharding(),  # model_state
-                    sharding_utils.get_naive_sharding_spec(),  # rng
-                    ),
+      in_shardings=(
+          sharding_utils.get_replicated_sharding(),  # params
+          sharding_utils.get_naive_sharding_spec(),  # batch
+          sharding_utils.get_replicated_sharding(),  # model_state
+          sharding_utils.get_naive_sharding_spec(),  # rng
+      ),
       static_argnums=(0,))
   def _eval_model(
       self,
@@ -134,5 +135,8 @@ class MnistWorkload(BaseMnistWorkload):
       self, num_examples: int, total_metrics: Dict[str,
                                                    Any]) -> Dict[str, float]:
     """Normalize eval metrics."""
-    total_metrics = {'accuracy': total_metrics['accuracy'].item() / num_examples, 'loss': total_metrics['loss'].item() / num_examples}
+    total_metrics = {
+        'accuracy': total_metrics['accuracy'].item() / num_examples,
+        'loss': total_metrics['loss'].item() / num_examples
+    }
     return total_metrics

--- a/algorithmic_efficiency/workloads/mnist/workload.py
+++ b/algorithmic_efficiency/workloads/mnist/workload.py
@@ -46,8 +46,7 @@ def _build_mnist_dataset(
   ds = ds.map(
       lambda x: {
           'inputs': _normalize(x['image'], train_mean, train_stddev),
-          'targets': x['label'],
-      })
+          'targets': x['label'],})
   is_train = split == 'train'
 
   if cache:
@@ -214,8 +213,6 @@ class BaseMnistWorkload(spec.Workload):
                                        batch,
                                        model_state,
                                        per_device_model_rngs)
-      total_metrics = {
-          k: v + batch_metrics[k] for k, v in total_metrics.items()
-      }
+      total_metrics = {k: v + batch_metrics[k] for k, v in total_metrics.items()}
 
     return self._normalize_eval_metrics(num_examples, total_metrics)

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/test_models.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/test_models.py
@@ -1,0 +1,182 @@
+"""Tests for WMT model sharding functionality."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from algorithmic_efficiency.workloads.wmt.wmt_jax import models
+from algorithmic_efficiency.workloads.wmt.wmt_jax.workload import WmtWorkload
+from algorithmic_efficiency.workloads.wmt import tokenizer
+
+from algorithmic_efficiency.sharding_utils import get_mesh, get_naive_sharding, get_replicated_sharding
+from algorithmic_efficiency import sharding_utils
+
+
+def test_eval_step_sharding():
+    # Initialize model and workload
+    batch_size = 8
+    seq_len = 32
+    vocab_size = 1000
+    
+    # Create random input data
+    rng = jax.random.PRNGKey(0)
+    rng, init_rng = jax.random.split(rng)
+    
+    inputs = jax.random.randint(
+        rng, (batch_size, seq_len), 0, vocab_size, dtype=jnp.int32)
+    targets = jax.random.randint(
+        rng, (batch_size, seq_len), 0, vocab_size, dtype=jnp.int32)
+    
+    # Initialize workload with sentencepiece tokenizer
+    workload = WmtWorkload()
+    workload._tokenizer = tokenizer.load_tokenizer('/home/ak4605/data/wmt/wmt_sentencepiece_model')
+    params, _ = workload.init_model_fn(init_rng)
+
+    # Initialize cache
+    cache = workload.initialize_cache(inputs, 256)
+
+    # Create input batch
+    batch = {
+        'inputs': inputs,
+        'weights': jnp.ones_like(targets, dtype=jnp.float32),
+        'targets': targets,
+    }
+
+    # Test eval step sharding
+    mesh = get_mesh()
+    with mesh:
+        # Shard the batch
+        sharded_batch = jax.tree_map(
+            lambda x: jax.device_put(x, get_naive_sharding(x)), batch)
+        
+        # Replicate params
+        sharded_params = jax.tree_map(
+            lambda x: jax.device_put(x, get_replicated_sharding()), params)
+        
+        # Run eval step
+        metrics = workload.eval_step(sharded_params, sharded_batch)
+
+        print(metrics)
+        
+        # Verify metrics are replicated
+        assert metrics['loss'].sharding.is_fully_replicated
+        assert metrics['accuracy'].sharding.is_fully_replicated
+        assert metrics['denominator'].sharding.is_fully_replicated
+
+
+def test_predict_step_sharding():
+    # Initialize model and workload  
+    batch_size = 8
+    workload = WmtWorkload()
+    seq_len = 16
+    vocab_size = 1000
+    beam_size = 4
+    max_decode_len = 32
+    
+    # Create random input data
+    rng = jax.random.PRNGKey(1)
+    rng, init_rng = jax.random.split(rng)
+    
+    inputs = jax.random.randint(
+        rng, (batch_size, seq_len), 0, vocab_size, dtype=jnp.int32)
+    
+    # Initialize workload
+    workload = WmtWorkload()
+    params, _ = workload.init_model_fn(init_rng)
+    
+    # Initialize cache
+    cache = workload.initialize_cache(inputs, max_decode_len)
+
+    mesh = get_mesh()
+    with mesh:
+        # Shard inputs
+        sharded_inputs = jax.device_put(inputs, get_naive_sharding(inputs))
+        
+        # Replicate params and cache
+        sharded_params = jax.tree_map(
+            lambda x: jax.device_put(x, get_replicated_sharding()), params)
+        sharded_cache = jax.tree_map(
+            lambda x: jax.device_put(x, get_naive_sharding(x)), cache)
+        
+        # Create jitted predict step
+        jitted_predict_step = jax.jit(
+            workload.predict_step,
+            in_shardings=(
+                sharding_utils.get_naive_sharding_spec(), # inputs
+                sharding_utils.get_replicated_sharding(), # params
+                sharding_utils.get_naive_sharding_tree(cache), # cache
+            ),
+            static_argnums=(3, 4, 5) # eos_id, max_decode_len, beam_size
+        )
+        
+        # Run predict step
+        predictions = jitted_predict_step(
+            sharded_inputs,
+            sharded_params, 
+            sharded_cache,
+            2,
+            max_decode_len,
+            beam_size)
+        
+        # Verify predictions are sharded on batch dimension
+        assert not predictions.sharding.is_fully_replicated
+        assert predictions.shape[0] == batch_size
+
+
+def test_translate_and_calculate_bleu():
+    # Initialize model and workload
+    batch_size = 8
+    seq_len = 16
+    vocab_size = 1000
+    max_decode_len = 32
+    num_batches = 2
+    
+    # Create random input data
+    rng = jax.random.PRNGKey(2)
+    rng, init_rng = jax.random.split(rng)
+    
+    # Create fake dataset iterator
+    def fake_ds_iter():
+        for _ in range(num_batches):
+            yield {
+                'inputs': jax.random.randint(
+                    rng, (batch_size, seq_len), 0, vocab_size, dtype=jnp.int32),
+                'targets': jax.random.randint(
+                    rng, (batch_size, seq_len), 0, vocab_size, dtype=jnp.int32),
+                'weights': jnp.ones((batch_size, seq_len), dtype=jnp.float32)
+            }
+    
+    # Initialize workload
+    workload = WmtWorkload()
+    params, _ = workload.init_model_fn(init_rng)
+    workload._tokenizer = tokenizer.load_tokenizer('/home/ak4605/data/wmt/wmt_sentencepiece_model')
+    # Test translate_and_calculate_bleu sharding
+    mesh = get_mesh()
+    with mesh:
+        # Replicate params
+        sharded_params = jax.tree_map(
+            lambda x: jax.device_put(x, get_replicated_sharding()), params)
+        
+        # Run translation
+        bleu_score = workload.translate_and_calculate_bleu(
+            sharded_params,
+            fake_ds_iter(),
+            num_batches,
+            max_decode_len)
+        
+        # Verify we get a valid BLEU score
+        assert isinstance(bleu_score, float)
+        assert 0 <= bleu_score <= 100
+
+def run_tests():
+    test_predict_step_sharding()
+    print("Predict step sharding test passed!")
+    test_eval_step_sharding() 
+    print("Eval step sharding test passed!")
+    test_translate_and_calculate_bleu()
+    print("Translate and calculate BLEU test passed!")
+    print("All tests passed!")
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
+++ b/algorithmic_efficiency/workloads/wmt/wmt_jax/workload.py
@@ -15,6 +15,7 @@ import optax
 
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
+from algorithmic_efficiency import sharding_utils
 from algorithmic_efficiency.workloads.wmt import bleu
 from algorithmic_efficiency.workloads.wmt.wmt_jax import decode
 from algorithmic_efficiency.workloads.wmt.wmt_jax import models
@@ -69,10 +70,16 @@ class WmtWorkload(BaseWmtWorkload):
     }
 
   @functools.partial(
-      jax.pmap, axis_name='batch', static_broadcasted_argnums=(0,))
-  def eval_step_pmapped(
-      self, params: spec.ParameterContainer,
-      batch: Dict[str, spec.Tensor]) -> Dict[str, spec.Tensor]:
+      jax.jit, 
+      in_shardings=(
+        sharding_utils.get_replicated_sharding(), # params
+        sharding_utils.get_naive_sharding_spec(), # batch
+      ), 
+      static_argnums=(0,), # self
+  )
+  def eval_step(self,
+                params: spec.ParameterContainer,
+                batch: Dict[str, spec.Tensor]) -> Dict[str, spec.Tensor]:
     """Calculate evaluation metrics on a batch."""
     inputs = batch['inputs']
     targets = batch['targets']
@@ -90,14 +97,13 @@ class WmtWorkload(BaseWmtWorkload):
         'denominator': weight_sum,
     }
 
-  def eval_step(self,
-                params: spec.ParameterContainer,
-                batch: Dict[str, spec.Tensor]) -> Dict[str, spec.Tensor]:
-    replicated_eval_metrics = self.eval_step_pmapped(params, batch)
-    return jax.tree_map(lambda x: jnp.sum(x, axis=0), replicated_eval_metrics)
-
   @functools.partial(
-      jax.pmap, axis_name='batch', static_broadcasted_argnums=(0,))
+      jax.jit, 
+      in_shardings=(
+        sharding_utils.get_naive_sharding_spec(), # inputs
+      ),
+      static_argnums=(0,2,)
+  )
   def initialize_cache(self,
                        inputs: spec.Tensor,
                        max_decode_len: int = 256) -> Dict[str, spec.Tensor]:
@@ -108,11 +114,10 @@ class WmtWorkload(BaseWmtWorkload):
         jax.random.PRNGKey(0),
         jnp.ones(inputs.shape, jnp.float32),
         jnp.ones(target_shape, jnp.float32))
+    print(initial_variables['cache'])
+    print(jax.tree_map(lambda x: x.shape, initial_variables['cache']))
     return initial_variables['cache']
 
-  # eos_id, max_decode_len are constant.
-  @functools.partial(
-      jax.pmap, axis_name='batch', static_broadcasted_argnums=(0, 4, 5))
   def predict_step(self,
                    inputs: spec.Tensor,
                    params: spec.ParameterContainer,
@@ -180,20 +185,34 @@ class WmtWorkload(BaseWmtWorkload):
     """Translates the `predict_ds` and calculates the BLEU score."""
     logging.info('Translating evaluation dataset.')
     references, predictions = [], []
+    jitted_predit_step = None
     for _ in range(num_batches):
       pred_batch = next(ds_iter)
       cache = self.initialize_cache(pred_batch['inputs'])
-      predicted = self.predict_step(pred_batch['inputs'],
+      if jitted_predit_step is None:
+        jitted_predict_step = jax.jit(
+            self.predict_step, 
+            in_shardings=(
+                sharding_utils.get_naive_sharding_spec(), # inputs
+                sharding_utils.get_replicated_sharding(), # params
+                sharding_utils.get_naive_sharding_tree(cache), # cache
+            ),
+            static_argnums=(3, # eos_id
+                            4, # max_decode_len,
+                            5, # beam_size
+                            ))
+      predicted = jitted_predict_step(pred_batch['inputs'],
                                     params,
                                     cache,
                                     decode.EOS_ID,
                                     max_predict_length)
-      predicted = _to_host(predicted)
-      targets = _to_host(pred_batch['targets'])
+      # predicted = _to_host(predicted)
+      # targets = _to_host(pred_batch['targets'])
+      targets = pred_batch['targets']
       # Find actual batch size, ignoring the potential padding.
       weights = pred_batch.get('weights')
       if weights is not None:
-        weights = _to_host(weights)
+        # weights = _to_host(weights)
         actual_batch_size = int(weights.sum(0)[0].item())
       else:
         actual_batch_size = len(predicted)
@@ -213,7 +232,7 @@ class WmtWorkload(BaseWmtWorkload):
       aux_dropout_rate: Optional[float] = None) -> spec.ModelInitState:
     """aux_dropout_rate is used as attention_dropout_rate."""
 
-    init_fake_batch_size = 2
+    init_fake_batch_size = 8
     input_shape = (init_fake_batch_size, 256)
     target_shape = (init_fake_batch_size, 256)
 
@@ -235,15 +254,20 @@ class WmtWorkload(BaseWmtWorkload):
     eval_config = replace(model_config, deterministic=True)
     self._eval_model = models.Transformer(eval_config)
     params_rng, dropout_rng = jax.random.split(rng)
+    inputs = jnp.ones(input_shape, jnp.float32)
+    targets = jnp.ones(target_shape, jnp.float32)
+    sharded_inputs = sharding_utils.shard_naive(inputs)
+    sharded_targets = sharding_utils.shard_naive(targets)
+
     initial_variables = jax.jit(
         self._eval_model.init)({'params': params_rng, 'dropout': dropout_rng},
-                               jnp.ones(input_shape, jnp.float32),
-                               jnp.ones(target_shape, jnp.float32))
+                              sharded_inputs, sharded_targets)
 
     initial_params = initial_variables['params']
     self._param_shapes = param_utils.jax_param_shapes(initial_params)
     self._param_types = param_utils.jax_param_types(self._param_shapes)
-    return jax_utils.replicate(initial_params), None
+    params = sharding_utils.shard_replicated(initial_params)
+    return initial_params, None
 
   def is_output_params(self, param_key: spec.ParameterKey) -> bool:
     return param_key == 'shared_embedding'

--- a/reference_algorithms/paper_baselines/adamw/jax/submission.py
+++ b/reference_algorithms/paper_baselines/adamw/jax/submission.py
@@ -162,18 +162,17 @@ def update_params(workload: spec.Workload,
       static_argnums=(0, 1),
       donate_argnums=(2, 3, 4),
       in_shardings=arg_shardings,
-      out_shardings=out_shardings
-  )
+      out_shardings=out_shardings)
 
   outputs = jitted_train_step(workload,
-                           opt_update_fn,
-                           model_state,
-                           optimizer_state,
-                           current_param_container,
-                           batch,
-                           per_device_rngs,
-                           grad_clip,
-                           label_smoothing)
+                              opt_update_fn,
+                              model_state,
+                              optimizer_state,
+                              current_param_container,
+                              batch,
+                              per_device_rngs,
+                              grad_clip,
+                              label_smoothing)
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 
   # Log loss, grad_norm.

--- a/reference_algorithms/paper_baselines/nesterov/jax/submission.py
+++ b/reference_algorithms/paper_baselines/nesterov/jax/submission.py
@@ -95,14 +95,14 @@ def sgd(learning_rate, weight_decay, momentum=None, nesterov=False):
 #     static_broadcasted_argnums=(0, 1),
 #     donate_argnums=(2, 3, 4))
 def train_step(workload,
-                       opt_update_fn,
-                       model_state,
-                       optimizer_state,
-                       current_param_container,
-                       batch,
-                       rng,
-                       grad_clip,
-                       label_smoothing):
+               opt_update_fn,
+               model_state,
+               optimizer_state,
+               current_param_container,
+               batch,
+               rng,
+               grad_clip,
+               label_smoothing):
 
   def _loss_fn(params):
     """Loss function used for training."""
@@ -178,20 +178,20 @@ def update_params(workload: spec.Workload,
   arg_shardings = (
       # workload is static
       # opt_update_fn is static
-      replicated,     # model_state
-      replicated,     # optimizer_state
-      replicated,     # current_param_container
-      sharded,     # batch
-      sharded,     # per_device_rngs
+      replicated,  # model_state
+      replicated,  # optimizer_state
+      replicated,  # current_param_container
+      sharded,  # batch
+      sharded,  # per_device_rngs
       replicated,  # grad_clip
-      replicated   # label_smoothing
+      replicated  # label_smoothing
   )
   out_shardings = (
-      replicated,               # new_optimizer_state
-      replicated,               # updated_params
-      replicated,               # new_model_state
-      replicated,               # loss
-      replicated                # grad_norm
+      replicated,  # new_optimizer_state
+      replicated,  # updated_params
+      replicated,  # new_model_state
+      replicated,  # loss
+      replicated  # grad_norm
   )
   # Jit with shardings
   jitted_train_step = jax.jit(
@@ -199,17 +199,16 @@ def update_params(workload: spec.Workload,
       static_argnums=(0, 1),
       donate_argnums=(2, 3, 4),
       in_shardings=arg_shardings,
-      out_shardings=out_shardings
-  )
+      out_shardings=out_shardings)
   outputs = jitted_train_step(workload,
-                               opt_update_fn,
-                               model_state,
-                               optimizer_state,
-                               current_param_container,
-                               batch,
-                               per_device_rngs,
-                               grad_clip,
-                               label_smoothing)
+                              opt_update_fn,
+                              model_state,
+                              optimizer_state,
+                              current_param_container,
+                              batch,
+                              per_device_rngs,
+                              grad_clip,
+                              label_smoothing)
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 
   # Log loss, grad_norm.
@@ -246,6 +245,8 @@ def get_batch_size(workload_name):
     return 128
   elif workload_name == 'mnist':
     return 16
+  elif workload_name == 'cifar':
+    return 128
   else:
     raise ValueError(f'Unsupported workload name: {workload_name}.')
 

--- a/reference_algorithms/paper_baselines/nesterov/jax/submission.py
+++ b/reference_algorithms/paper_baselines/nesterov/jax/submission.py
@@ -159,7 +159,6 @@ def update_params(workload: spec.Workload,
   del eval_results
 
   optimizer_state, opt_update_fn = optimizer_state
-  per_device_rngs = jax.random.split(rng, jax.local_device_count())
   if hasattr(hyperparameters, 'label_smoothing'):
     label_smoothing = hyperparameters.label_smoothing
   else:
@@ -182,7 +181,7 @@ def update_params(workload: spec.Workload,
       replicated,  # optimizer_state
       replicated,  # current_param_container
       sharded,  # batch
-      sharded,  # per_device_rngs
+      replicated,  # rngs
       replicated,  # grad_clip
       replicated  # label_smoothing
   )
@@ -206,7 +205,7 @@ def update_params(workload: spec.Workload,
                               optimizer_state,
                               current_param_container,
                               batch,
-                              per_device_rngs,
+                              rng,
                               grad_clip,
                               label_smoothing)
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs

--- a/reference_algorithms/paper_baselines/nesterov/jax/submission.py
+++ b/reference_algorithms/paper_baselines/nesterov/jax/submission.py
@@ -6,11 +6,13 @@ from typing import Callable, Dict, Iterator, List, Tuple
 from flax import jax_utils
 import jax
 from jax import lax
-from jax.sharding import NamedSharding, PartitionSpec as P
 import jax.numpy as jnp
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 import optax
 
-from algorithmic_efficiency import spec, sharding_utils
+from algorithmic_efficiency import sharding_utils
+from algorithmic_efficiency import spec
 
 _GRAD_CLIP_EPS = 1e-6
 
@@ -199,7 +201,7 @@ def update_params(workload: spec.Workload,
       donate_argnums=(2, 3, 4),
       in_shardings=arg_shardings,
       out_shardings=out_shardings)
-  outputs = jitted_train_step(workload,
+  new_optimizer_state, new_params, new_model_state, loss, grad_norm = jitted_train_step(workload,
                               opt_update_fn,
                               model_state,
                               optimizer_state,
@@ -208,7 +210,6 @@ def update_params(workload: spec.Workload,
                               rng,
                               grad_clip,
                               label_smoothing)
-  new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 
   # Log loss, grad_norm.
   if global_step % 100 == 0 and workload.metrics_logger is not None:

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -377,8 +377,8 @@ def train_once(
     train_state['is_time_remaining'] = (
         train_state['accumulated_submission_time'] < max_allowed_runtime_sec)
     # Check if submission is eligible for an untimed eval.
-    if ((train_step_end_time - train_state['last_eval_time']) >=
-        workload.eval_period_time_sec or train_state['training_complete']):
+    if ((train_step_end_time - train_state['last_eval_time'])
+        >= workload.eval_period_time_sec or train_state['training_complete']):
       with profiler.profile('Evaluation'):
         del batch
         _reset_cuda_mem()

--- a/submission_runner.py
+++ b/submission_runner.py
@@ -28,6 +28,9 @@ from absl import app
 from absl import flags
 from absl import logging
 import jax
+
+jax.config.update('jax_default_prng_impl', 'threefry2x32')
+jax.config.update('jax_threefry_partitionable', True)
 import torch
 import torch.distributed as dist
 


### PR DESCRIPTION
## Purpose

The goal of this PR is to allow model parameter and optimizer state sharding, and also to migrate the JAX code from using jax.pmap to using jax.jit. 

## TODOs:
- [ ] Migrate reference optimizers to use jax.jit
  - [X] Nesterov
  - [X] AdamW
  - [ ] Others
- [ ] Migrate workloads to use jax.jit
  - [X]  (Test workload) MNIST
  - [X]  (Test workload) CIFAR
  - [ ] WMT
  - [ ] Criteo1TB
  - [ ] FastMRI
  - [ ] Librispeech
  - [ ] OGBG
  - [ ] ImageNet
 
## Changelog
- Added some sharding utilities to handle data distributed
- Replaced pmap code for CIFAR/MNIST with jit
- Modified AdamW and Nesterov accordingly
- Updated checkpoint and data_utils to support the new approach (mostly removing explicit jax_utils.replicate calls).

## Issues
- Prefetching functionality in CIFAR is temporarily disabled (marked with FIXME), not sure how to best support it here.
- I haven't edited any of the PyTorch code, we will need to make sure they still do comparably..