### PR TITLE
Fsdp pytorch draft PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 .vscode/
 env/
 venv/
+.venv/
 workdir/
 makefile
 *.out
@@ -24,3 +25,6 @@ scoring/plots/
 
 !scoring/test_data/experiment_dir/study_0/mnist_jax/trial_0/eval_measurements.csv
 !scoring/test_data/experiment_dir/study_0/mnist_jax/trial_1/eval_measurements.csv
+
+tags
+*~

--- a/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/criteo1tb/criteo1tb_pytorch/workload.py
@@ -1,11 +1,18 @@
 """Criteo1TB workload implemented in PyTorch."""
 
 import contextlib
+import functools
 from typing import Dict, Iterator, Optional, Tuple
 
 import torch
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.wrap import (
+        size_based_auto_wrap_policy,
+        enable_wrap,
+        wrap,
+        )
 
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
@@ -93,7 +100,15 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
-        model = DDP(model, device_ids=[RANK], output_device=RANK)
+        auto_wrap_policy = functools.partial(
+                size_based_auto_wrap_policy, min_num_params=2 ** 10
+                )
+        model = FSDP(
+                model,
+                use_orig_params=True,
+                auto_wrap_policy=auto_wrap_policy,
+                device_id=RANK
+                )
       else:
         model = torch.nn.DataParallel(model)
     return model, None
@@ -117,6 +132,7 @@ class Criteo1TbDlrmSmallWorkload(BaseCriteo1TbDlrmSmallWorkload):
     inputs = augmented_and_preprocessed_input_batch['inputs']
 
     if mode == spec.ForwardPassMode.EVAL:
+      model.zero_grad()
       model.eval()
 
     if mode == spec.ForwardPassMode.TRAIN:

--- a/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/imagenet_vit/imagenet_pytorch/workload.py
@@ -1,10 +1,17 @@
 """ImageNet ViT workload implemented in PyTorch."""
 
 import contextlib
+import functools
 from typing import Dict, Optional, Tuple
 
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.wrap import (
+        size_based_auto_wrap_policy,
+        enable_wrap,
+        wrap,
+        )
 
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import pytorch_utils
@@ -43,7 +50,15 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     model.to(DEVICE)
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
-        model = DDP(model, device_ids=[RANK], output_device=RANK)
+        auto_wrap_policy = functools.partial(
+                size_based_auto_wrap_policy, min_num_params=2 ** 10
+                )
+        model = FSDP(
+                model,
+                use_orig_params=True,
+                auto_wrap_policy=auto_wrap_policy,
+                device_id=RANK
+                )
       else:
         model = torch.nn.DataParallel(model)
     return model, None
@@ -66,6 +81,9 @@ class ImagenetVitWorkload(BaseImagenetVitWorkload, ImagenetResNetWorkload):
     model = params
 
     if mode == spec.ForwardPassMode.EVAL:
+      # need to zero grad for FSDP or else error is thrown
+      # during evaluation
+      model.zero_grad()
       model.eval()
 
     if mode == spec.ForwardPassMode.TRAIN:

--- a/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/librispeech_deepspeech/librispeech_pytorch/workload.py
@@ -1,7 +1,14 @@
 from typing import Optional
+import functools
 
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.wrap import (
+        size_based_auto_wrap_policy,
+        enable_wrap,
+        wrap,
+        )
 
 from algorithmic_efficiency import param_utils
 from algorithmic_efficiency import spec
@@ -58,7 +65,15 @@ class LibriSpeechDeepSpeechWorkload(LibriSpeechConformerWorkload):
     self.requires_sync_before_eval = False
     if N_GPUS > 1:
       if USE_PYTORCH_DDP:
-        model = DDP(model, device_ids=[RANK], output_device=RANK)
+        auto_wrap_policy = functools.partial(
+                size_based_auto_wrap_policy, min_num_params=2 ** 10
+                )
+        model = FSDP(
+                model,
+                use_orig_params=True,
+                auto_wrap_policy=auto_wrap_policy,
+                device_id=RANK
+                )
       else:
         model = torch.nn.DataParallel(model)
     return model, None

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
@@ -167,12 +167,11 @@ class OgbgWorkload(BaseOgbgWorkload):
                 size_based_auto_wrap_policy, min_num_params=2 ** 10
                 )
         model = FSDP(
-                self._model,
+                model,
                 use_orig_params=True,
                 auto_wrap_policy=auto_wrap_policy,
                 device_id=RANK
                 )
-
       else:
         model = torch.nn.DataParallel(model)
     return model, None

--- a/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
+++ b/algorithmic_efficiency/workloads/ogbg/ogbg_pytorch/workload.py
@@ -1,5 +1,6 @@
 """OGBG workload implemented in PyTorch."""
 import contextlib
+import functools
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import jax

--- a/datasets/dataset_setup.py
+++ b/datasets/dataset_setup.py
@@ -74,8 +74,8 @@ from torchvision.datasets import CIFAR10
 from algorithmic_efficiency.workloads.wmt import tokenizer
 from algorithmic_efficiency.workloads.wmt.input_pipeline import \
     normalize_feature_names
-from datasets import librispeech_preprocess
-from datasets import librispeech_tokenizer
+# from datasets import librispeech_preprocess
+# from datasets import librispeech_tokenizer
 
 import functools
 import os


### PR DESCRIPTION
A draft PR for potential changes for the pytorch workloads to upgrade to FSDP (fully sharded data parallel) from DDP (distributed data parallel).

Summary for changes to: cifar, mnist, criteo1tb, imagenet vit, imagenet resnet, librispeech deepspeech, librispeech conformer, ogbg, wmt, fastmri
- import required packages (e.g., fsdp)
- construct model using FSDP constructor instead of DDP constructor
- very naive sharding for now
- Crucially: must zero grad before eval 

Summary for changes to momentum (as simple test optimizer):
- first compute weighted loss on each device
- then loss.backward (the gradient of the losses will now be all reduced by a pytorch communication hook)
- then display the correct loss