### PR TITLE
Fix `prepare_for_eval` usage in self-tuning track

### DIFF
--- a/submission_runner.py
+++ b/submission_runner.py
@@ -668,7 +668,7 @@ def score_submission_on_workload(workload: spec.Workload,
       score, _ = train_once(
           workload, workload_name, global_batch_size, global_eval_batch_size,
           data_dir, imagenet_v2_data_dir,
-          init_optimizer_state, update_params, data_selection,
+          init_optimizer_state, update_params, data_selection, prepare_for_eval,
           None, rng_seed, rng, profiler, max_global_steps, log_dir,
           save_checkpoints=save_checkpoints)
   return score


### PR DESCRIPTION
I noticed that `prepare_for_eval` was not passed as an argument to `train_once` in the self tuning track, sorry for the oversight.

It's a 1-line fix.
