### PR TITLE
Fix self-tuning submissions hyperparameter specification

### DIFF
--- a/prize_qualification_baselines/self_tuning/jax_nadamw_full_budget.py
+++ b/prize_qualification_baselines/self_tuning/jax_nadamw_full_budget.py
@@ -1,5 +1,6 @@
 """Submission file for an NAdamW optimizer with warmup+cosine LR in Jax."""
 
+import collections
 import functools
 
 # isort: off
@@ -34,6 +35,9 @@ HPARAMS = {
     "weight_decay": 0.08121616522670176,
     "warmup_factor": 0.02
 }
+HPARAMS = collections.namedtuple(
+    'Hyperparameters', 
+    HPARAMS.keys())(**HPARAMS)
 
 
 # Forked from

--- a/prize_qualification_baselines/self_tuning/jax_nadamw_target_setting.py
+++ b/prize_qualification_baselines/self_tuning/jax_nadamw_target_setting.py
@@ -1,5 +1,6 @@
 """Submission file for an NAdamW optimizer with warmup+cosine LR in Jax."""
 
+import collections
 import functools
 
 # isort: off
@@ -34,6 +35,9 @@ HPARAMS = {
     "weight_decay": 0.08121616522670176,
     "warmup_factor": 0.02
 }
+HPARAMS = collections.namedtuple(
+    'Hyperparameters', 
+    HPARAMS.keys())(**HPARAMS)
 
 
 # Forked from

--- a/prize_qualification_baselines/self_tuning/pytorch_nadamw_full_budget.py
+++ b/prize_qualification_baselines/self_tuning/pytorch_nadamw_full_budget.py
@@ -1,5 +1,6 @@
 """Submission file for an NAdamW optimizer with warmup+cosine LR in PyTorch."""
 
+import collections
 import math
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
@@ -24,6 +25,9 @@ HPARAMS = {
     "weight_decay": 0.08121616522670176,
     "warmup_factor": 0.02
 }
+HPARAMS = collections.namedtuple(
+    'Hyperparameters', 
+    HPARAMS.keys())(**HPARAMS)
 
 
 # Modified from github.com/pytorch/pytorch/blob/v1.12.1/torch/optim/adamw.py.

--- a/prize_qualification_baselines/self_tuning/pytorch_nadamw_target_setting.py
+++ b/prize_qualification_baselines/self_tuning/pytorch_nadamw_target_setting.py
@@ -1,5 +1,6 @@
 """Submission file for an NAdamW optimizer with warmup+cosine LR in PyTorch."""
 
+import collections
 import math
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
@@ -24,6 +25,9 @@ HPARAMS = {
     "weight_decay": 0.08121616522670176,
     "warmup_factor": 0.02
 }
+HPARAMS = collections.namedtuple(
+    'Hyperparameters', 
+    HPARAMS.keys())(**HPARAMS)
 
 
 # Modified from github.com/pytorch/pytorch/blob/v1.12.1/torch/optim/adamw.py.


### PR DESCRIPTION
Self-tuning submissions in `prize_qualification_baselines/self_tuning/` define `HPARAMS` as a dictionary:
```python
HPARAMS = {
    "dropout_rate": 0.1,
    "learning_rate": 0.0017,
    ...
}
```
But later try to access its entries via attribute access:

https://github.com/mlcommons/algorithmic-efficiency/blob/5cc62ea286403add41b0e7929bf638681b850718/prize_qualification_baselines/self_tuning/pytorch_nadamw_full_budget.py#L211-L217

This pull request just converts `HPARAMS` to a named tuple to allow for attribute access.