### PR TITLE
Update metrics.py - fix for ogbg pytorch

### DIFF
--- a/algoperf/workloads/ogbg/metrics.py
+++ b/algoperf/workloads/ogbg/metrics.py
@@ -49,8 +49,10 @@ class MeanAveragePrecision(
         dist.all_gather(all_tensors, tensor)
         all_values[idx] = torch.cat(all_tensors).cpu().numpy()
       labels, logits, mask = all_values
+      
       def sigmoid_np(x):
         return 1 / (1 + np.exp(-x))
+        
       sigmoid = sigmoid_np
 
     mask = mask.astype(bool)

--- a/algoperf/workloads/ogbg/metrics.py
+++ b/algoperf/workloads/ogbg/metrics.py
@@ -40,7 +40,7 @@ class MeanAveragePrecision(
 
     if USE_PYTORCH_DDP:
       # Sync labels, logits, and masks across devices.
-      all_values = [labels, logits, mask]
+      all_values = [np.array(labels), np.array(logits), np.array(mask)]
       for idx, array in enumerate(all_values):
         tensor = torch.as_tensor(array, device=DEVICE)
         # Assumes that the tensors on all devices have the same shape.
@@ -51,7 +51,7 @@ class MeanAveragePrecision(
 
     mask = mask.astype(bool)
 
-    probs = jax.nn.sigmoid(logits)
+    probs = 1 / (1 + np.exp(-logits))
     num_tasks = labels.shape[1]
     average_precisions = np.full(num_tasks, np.nan)
 

--- a/algoperf/workloads/ogbg/metrics.py
+++ b/algoperf/workloads/ogbg/metrics.py
@@ -31,9 +31,6 @@ class MeanAveragePrecision(
     metrics.CollectingMetric.from_outputs(('logits', 'labels', 'mask'))):
   """Computes the mean average precision (mAP) over different tasks."""
 
-  def sigmoid_np(x):
-    return 1 / (1 + np.exp(-x))
-
   def compute(self):
     # Matches the official OGB evaluation scheme for mean average precision.
     values = super().compute()
@@ -52,6 +49,8 @@ class MeanAveragePrecision(
         dist.all_gather(all_tensors, tensor)
         all_values[idx] = torch.cat(all_tensors).cpu().numpy()
       labels, logits, mask = all_values
+      def sigmoid_np(x):
+        return 1 / (1 + np.exp(-x))
       sigmoid = sigmoid_np
 
     mask = mask.astype(bool)

--- a/algoperf/workloads/ogbg/metrics.py
+++ b/algoperf/workloads/ogbg/metrics.py
@@ -31,6 +31,9 @@ class MeanAveragePrecision(
     metrics.CollectingMetric.from_outputs(('logits', 'labels', 'mask'))):
   """Computes the mean average precision (mAP) over different tasks."""
 
+  def sigmoid_np(x):
+    return 1 / (1 + np.exp(-x))
+
   def compute(self):
     # Matches the official OGB evaluation scheme for mean average precision.
     values = super().compute()
@@ -49,7 +52,7 @@ class MeanAveragePrecision(
         dist.all_gather(all_tensors, tensor)
         all_values[idx] = torch.cat(all_tensors).cpu().numpy()
       labels, logits, mask = all_values
-      sigmoid = lambda x: 1 / (1 + np.exp(-x))
+      sigmoid = sigmoid_np
 
     mask = mask.astype(bool)
 

--- a/algoperf/workloads/ogbg/metrics.py
+++ b/algoperf/workloads/ogbg/metrics.py
@@ -49,10 +49,10 @@ class MeanAveragePrecision(
         dist.all_gather(all_tensors, tensor)
         all_values[idx] = torch.cat(all_tensors).cpu().numpy()
       labels, logits, mask = all_values
-      
+
       def sigmoid_np(x):
         return 1 / (1 + np.exp(-x))
-        
+
       sigmoid = sigmoid_np
 
     mask = mask.astype(bool)


### PR DESCRIPTION
It seems that the problem affecting the pytorch ogbg workloads (but only if they run for some length of time) has to do with jax/xla cpu compilation of the metrics computation. By converting the jax arrays to numpy, hopefully this can be avoided. The next step is to test on schedule free and shampoo, which I hope to do very soon.