### PR TITLE
Dropout Fix - Final Polishing: updated submissions, tests, docs.

### DIFF
--- a/algoperf/spec.py
+++ b/algoperf/spec.py
@@ -235,16 +235,9 @@ class Workload(metaclass=abc.ABCMeta):
   def is_output_params(self, param_key: ParameterKey) -> bool:
     """Whether a key in ParameterContainer is the output layer parameters."""
 
-  # InitModelFn = Callable[
-  #     Tuple[RandomState, Optional[float], Optional[float]],
-  #     ParameterContainer]
+  # InitModelFn = Callable[Optional[float]], ParameterContainer]
   @abc.abstractmethod
-  def init_model_fn(
-    self,
-    rng: RandomState,
-    dropout_rate: Optional[float] = None,
-    aux_dropout_rate: Optional[float] = None,
-  ) -> ModelInitState:
+  def init_model_fn(self, rng: RandomState) -> ModelInitState:
     """Return (initial_params, initial_model_state)."""
 
   # ModelFn = Callable[

--- a/algoperf/workloads/cifar/cifar_jax/workload.py
+++ b/algoperf/workloads/cifar/cifar_jax/workload.py
@@ -105,9 +105,11 @@ class CifarWorkload(BaseCifarWorkload):
     rng: spec.RandomState,
     update_batch_norm: bool,
     use_running_average_bn: Optional[bool] = None,
+    dropout_rate: float = 0.0,
   ) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del mode
     del rng
+    del dropout_rate
     variables = {'params': params, **model_state}
     if update_batch_norm:
       logits, new_model_state = self._model.apply(

--- a/algoperf/workloads/cifar/cifar_pytorch/workload.py
+++ b/algoperf/workloads/cifar/cifar_pytorch/workload.py
@@ -118,16 +118,8 @@ class CifarWorkload(BaseCifarWorkload):
     dataloader = data_utils.cycle(dataloader, custom_sampler=USE_PYTORCH_DDP)
     return dataloader
 
-  def init_model_fn(
-    self,
-    rng: spec.RandomState,
-    dropout_rate: Optional[float] = None,
-    aux_dropout_rate: Optional[float] = None,
-  ) -> spec.ModelInitState:
+  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     """Dropout is unused."""
-    del dropout_rate
-    del aux_dropout_rate
-
     if hasattr(self, '_model'):
       if isinstance(self._model, (DDP, torch.nn.DataParallel)):
         self._model.module.reset_parameters()
@@ -158,9 +150,11 @@ class CifarWorkload(BaseCifarWorkload):
     mode: spec.ForwardPassMode,
     rng: spec.RandomState,
     update_batch_norm: bool,
+    dropout_rate: float = 0.0,
   ) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del rng
+    del dropout_rate
     model = params
     if mode == spec.ForwardPassMode.EVAL:
       if update_batch_norm:

--- a/algoperf/workloads/fastmri/fastmri_jax/workload.py
+++ b/algoperf/workloads/fastmri/fastmri_jax/workload.py
@@ -19,7 +19,6 @@ class FastMRIWorkload(BaseFastMRIWorkload):
     self,
     rng: spec.RandomState,
   ) -> spec.ModelInitState:
-    """aux_dropout_rate is unused."""
     fake_batch = jnp.zeros((13, 320, 320))
     self._model = UNet(
       num_pool_layers=self.num_pool_layers,

--- a/algoperf/workloads/imagenet_vit/imagenet_jax/models.py
+++ b/algoperf/workloads/imagenet_vit/imagenet_jax/models.py
@@ -186,7 +186,7 @@ class ViT(nn.Module):
   mlp_dim: Optional[int] = None  # Defaults to 4x input dim.
   num_heads: int = 12
   rep_size: Union[int, bool] = True
-  dropout_rate: [float] = DROPOUT_RATE
+  dropout_rate: float = DROPOUT_RATE
   reinit: Optional[Sequence[str]] = None
   head_zeroinit: bool = True
   use_glu: bool = False

--- a/algoperf/workloads/mnist/mnist_jax/workload.py
+++ b/algoperf/workloads/mnist/mnist_jax/workload.py
@@ -48,10 +48,12 @@ class MnistWorkload(BaseMnistWorkload):
     mode: spec.ForwardPassMode,
     rng: spec.RandomState,
     update_batch_norm: bool,
+    dropout_rate: float = 0.0,
   ) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del rng
     del update_batch_norm
+    del dropout_rate
     train = mode == spec.ForwardPassMode.TRAIN
     logits_batch = self._model.apply(
       {'params': params},

--- a/algoperf/workloads/mnist/mnist_pytorch/workload.py
+++ b/algoperf/workloads/mnist/mnist_pytorch/workload.py
@@ -138,16 +138,7 @@ class MnistWorkload(BaseMnistWorkload):
       }
       yield batch
 
-  def init_model_fn(
-    self,
-    rng: spec.RandomState,
-    dropout_rate: Optional[float] = None,
-    aux_dropout_rate: Optional[float] = None,
-  ) -> spec.ModelInitState:
-    """Dropout is unused."""
-    del dropout_rate
-    del aux_dropout_rate
-
+  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
     if hasattr(self, '_model'):
       if isinstance(self._model, (DDP, torch.nn.DataParallel)):
         self._model.module.reset_parameters()
@@ -178,10 +169,12 @@ class MnistWorkload(BaseMnistWorkload):
     mode: spec.ForwardPassMode,
     rng: spec.RandomState,
     update_batch_norm: bool,
+    dropout_rate: float = 0.0,
   ) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del rng
     del update_batch_norm
+    del dropout_rate
     model = params
     if mode == spec.ForwardPassMode.EVAL:
       model.eval()

--- a/algoperf/workloads/wmt/wmt_jax/workload.py
+++ b/algoperf/workloads/wmt/wmt_jax/workload.py
@@ -240,7 +240,6 @@ class WmtWorkload(BaseWmtWorkload):
     return bleu_score
 
   def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
-
     init_fake_batch_size = 8
     input_shape = (init_fake_batch_size, 256)
     target_shape = (init_fake_batch_size, 256)

--- a/algoperf/workloads/wmt/wmt_jax/workload.py
+++ b/algoperf/workloads/wmt/wmt_jax/workload.py
@@ -239,13 +239,7 @@ class WmtWorkload(BaseWmtWorkload):
     bleu_score = bleu.corpus_bleu(predictions, [references]).score
     return bleu_score
 
-  def init_model_fn(
-    self,
-    rng: spec.RandomState,
-    dropout_rate: Optional[float] = None,
-    aux_dropout_rate: Optional[float] = None,
-  ) -> spec.ModelInitState:
-    """aux_dropout_rate is used as attention_dropout_rate."""
+  def init_model_fn(self, rng: spec.RandomState) -> spec.ModelInitState:
 
     init_fake_batch_size = 8
     input_shape = (init_fake_batch_size, 256)
@@ -295,7 +289,7 @@ class WmtWorkload(BaseWmtWorkload):
     mode: spec.ForwardPassMode,
     rng: spec.RandomState,
     update_batch_norm: bool,
-    dropout_rate: [float] = models.DROPOUT_RATE,
+    dropout_rate: float = models.DROPOUT_RATE,
   ) -> Tuple[spec.Tensor, spec.ModelAuxiliaryState]:
     del model_state
     del update_batch_norm

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -104,12 +104,7 @@ def _build_input_queue(
 ###### Model initialization
 
 ```python
-def init_model_fn(
-    self,
-    rng: RandomState,
-    dropout_rate: Optional[float] = None,
-    aux_dropout_rate: Optional[float] = None
-) -> initial model parameters
+def init_model_fn(self, rng: RandomState) -> initial model parameters
 ```
 
 - Unlike in the *Model Track*, this function that initializes the parameters of the model, is fixed. While it can be called by the submission (e.g. to restart the model after a failed training effort) it cannot be changed.
@@ -125,7 +120,8 @@ def model_fn(
     mode: ForwardPassMode,  # mode \in {train, eval}
     rng: RandomState,
     hyperparameters: Hyperparameters,
-    update_batch_norm: bool
+    update_batch_norm: bool,
+    dropout_rate: float
 ) -> (logits_output_batch, new_model_state): Tuple[Tensor, ModelAuxiliaryState]
 ```
 
@@ -134,6 +130,7 @@ def model_fn(
 - `logits_output_batch` is before the output activation
 - `new_model_state` is for batch norm or similar side effects and will only be updated if `update_batch_norm` is set
 - `hyperparameters` will contain only dropout rates, which will be used in the models that support it. These can be tuned or will default to documented model-specific values. Note that adding additional dropout would be considered changing the model, which is not allowed, but the tuning of dropout in existing dropout layers can be considered a regularizer, so we allow it. There should be at most two dropout rates in a model (if there are more than two we will reuse the same values).
+- `dropout_rate` is used in the model forward pass. If not provided, the workload’s default value is used (see below for the list of defaults).
 
 ###### Loss function
 

--- a/reference_algorithms/paper_baselines/adafactor/jax/submission.py
+++ b/reference_algorithms/paper_baselines/adafactor/jax/submission.py
@@ -169,7 +169,7 @@ def update_params(
     per_device_rngs,
     grad_clip,
     label_smoothing,
-    dropout_rate
+    dropout_rate,
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/paper_baselines/adafactor/jax/submission.py
+++ b/reference_algorithms/paper_baselines/adafactor/jax/submission.py
@@ -78,6 +78,7 @@ def pmapped_train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -94,6 +95,7 @@ def pmapped_train_step(
       logits_batch=logits,
       mask_batch=batch.get('weights'),
       label_smoothing=label_smoothing,
+      dropout_rate=dropout_rate,
     )
     summed_loss = loss_dict['summed']
     n_valid_examples = loss_dict['n_valid_examples']
@@ -156,6 +158,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
   outputs = pmapped_train_step(
     workload,
     opt_update_fn,
@@ -166,6 +169,7 @@ def update_params(
     per_device_rngs,
     grad_clip,
     label_smoothing,
+    dropout_rate
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/paper_baselines/adafactor/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/adafactor/pytorch/submission.py
@@ -227,6 +227,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/adafactor/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/adafactor/pytorch/submission.py
@@ -227,7 +227,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/adamw/jax/submission.py
+++ b/reference_algorithms/paper_baselines/adamw/jax/submission.py
@@ -69,6 +69,7 @@ def train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -79,6 +80,7 @@ def train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -144,6 +146,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
 
   # Set up mesh and sharding
   mesh = jax.sharding.Mesh(jax.devices(), ('batch'))
@@ -164,6 +167,7 @@ def update_params(
       replicated,  # rng
       replicated,  # grad_clip
       replicated,  # label_smoothing
+      replicated,  # dropout_rate
     ),
     out_shardings=(
       replicated,  # new_optimizer_state
@@ -185,6 +189,7 @@ def update_params(
       rng,
       grad_clip,
       label_smoothing,
+      dropout_rate
     )
   )
 

--- a/reference_algorithms/paper_baselines/adamw/jax/submission.py
+++ b/reference_algorithms/paper_baselines/adamw/jax/submission.py
@@ -189,7 +189,7 @@ def update_params(
       rng,
       grad_clip,
       label_smoothing,
-      dropout_rate
+      dropout_rate,
     )
   )
 

--- a/reference_algorithms/paper_baselines/adamw/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/adamw/pytorch/submission.py
@@ -84,7 +84,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/adamw/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/adamw/pytorch/submission.py
@@ -84,6 +84,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/lamb/jax/submission.py
+++ b/reference_algorithms/paper_baselines/lamb/jax/submission.py
@@ -176,7 +176,7 @@ def update_params(
     per_device_rngs,
     grad_clip,
     label_smoothing,
-    dropout_rate
+    dropout_rate,
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/paper_baselines/lamb/jax/submission.py
+++ b/reference_algorithms/paper_baselines/lamb/jax/submission.py
@@ -84,6 +84,7 @@ def pmapped_train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -94,6 +95,7 @@ def pmapped_train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -163,6 +165,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
   outputs = pmapped_train_step(
     workload,
     opt_update_fn,
@@ -173,6 +176,7 @@ def update_params(
     per_device_rngs,
     grad_clip,
     label_smoothing,
+    dropout_rate
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/paper_baselines/lamb/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/lamb/pytorch/submission.py
@@ -225,7 +225,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/lamb/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/lamb/pytorch/submission.py
@@ -225,6 +225,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/momentum/jax/submission.py
+++ b/reference_algorithms/paper_baselines/momentum/jax/submission.py
@@ -227,7 +227,7 @@ def update_params(
     rng,
     grad_clip,
     label_smoothing,
-      dropout_rate
+    dropout_rate,
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/paper_baselines/momentum/jax/submission.py
+++ b/reference_algorithms/paper_baselines/momentum/jax/submission.py
@@ -103,6 +103,7 @@ def train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -113,6 +114,7 @@ def train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -177,6 +179,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
 
   # Create shardings for each argument
   replicated = jax_sharding_utils.get_replicate_sharding()  # No partitioning
@@ -195,6 +198,7 @@ def update_params(
     replicated,  # rng
     replicated,  # grad_clip
     replicated,  # label_smoothing
+    replicated,  # dropout_rate
   )
   out_shardings = (
     replicated,  # new_optimizer_state
@@ -223,6 +227,7 @@ def update_params(
     rng,
     grad_clip,
     label_smoothing,
+      dropout_rate
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/paper_baselines/momentum/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/momentum/pytorch/submission.py
@@ -104,6 +104,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/momentum/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/momentum/pytorch/submission.py
@@ -104,7 +104,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/nadamw/jax/submission.py
+++ b/reference_algorithms/paper_baselines/nadamw/jax/submission.py
@@ -215,6 +215,7 @@ def train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -225,6 +226,7 @@ def train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -289,6 +291,8 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
+
   # Create shardings for each argument
   replicated = jax_sharding_utils.get_replicate_sharding()  # No partitioning
   sharded = (
@@ -306,6 +310,7 @@ def update_params(
     replicated,  # rng
     replicated,  # grad_clip
     replicated,  # label_smoothing
+    replicated,  # dropout_rate
   )
   out_shardings = (
     replicated,  # new_optimizer_state
@@ -335,6 +340,7 @@ def update_params(
       rng,
       grad_clip,
       label_smoothing,
+      dropout_rate
     )
   )
 

--- a/reference_algorithms/paper_baselines/nadamw/jax/submission.py
+++ b/reference_algorithms/paper_baselines/nadamw/jax/submission.py
@@ -340,7 +340,7 @@ def update_params(
       rng,
       grad_clip,
       label_smoothing,
-      dropout_rate
+      dropout_rate,
     )
   )
 

--- a/reference_algorithms/paper_baselines/nadamw/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/nadamw/pytorch/submission.py
@@ -264,6 +264,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/nadamw/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/nadamw/pytorch/submission.py
@@ -264,7 +264,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/nesterov/jax/submission.py
+++ b/reference_algorithms/paper_baselines/nesterov/jax/submission.py
@@ -105,6 +105,7 @@ def train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -115,6 +116,7 @@ def train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -179,6 +181,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
 
   # Create shardings for each argument
   mesh = jax.sharding.Mesh(jax.devices(), ('batch'))
@@ -196,6 +199,7 @@ def update_params(
     replicated,  # rngs
     replicated,  # grad_clip
     replicated,  # label_smoothing
+    replicated,  # dropout_rate
   )
   out_shardings = (
     replicated,  # new_optimizer_state
@@ -223,6 +227,7 @@ def update_params(
       rng,
       grad_clip,
       label_smoothing,
+      dropout_rate,
     )
   )
 

--- a/reference_algorithms/paper_baselines/nesterov/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/nesterov/pytorch/submission.py
@@ -104,6 +104,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/nesterov/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/nesterov/pytorch/submission.py
@@ -104,7 +104,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/paper_baselines/sam/jax/submission.py
+++ b/reference_algorithms/paper_baselines/sam/jax/submission.py
@@ -175,6 +175,7 @@ def pmapped_train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params, update_batch_norm=True):
     """Loss function used for training."""
@@ -185,6 +186,7 @@ def pmapped_train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=update_batch_norm,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -251,6 +253,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
   outputs = pmapped_train_step(
     workload,
     opt_update_fn,
@@ -261,6 +264,7 @@ def update_params(
     per_device_rngs,
     grad_clip,
     label_smoothing,
+    dropout_rate,
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/paper_baselines/sam/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/sam/pytorch/submission.py
@@ -173,6 +173,7 @@ def update_params(
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
       update_batch_norm=update_batch_norm,
+      dropout_rate=hyperparameters.dropout_rate
     )
     label_smoothing = (
       hyperparameters.label_smoothing

--- a/reference_algorithms/paper_baselines/sam/pytorch/submission.py
+++ b/reference_algorithms/paper_baselines/sam/pytorch/submission.py
@@ -173,7 +173,7 @@ def update_params(
       mode=spec.ForwardPassMode.TRAIN,
       rng=rng,
       update_batch_norm=update_batch_norm,
-      dropout_rate=hyperparameters.dropout_rate
+      dropout_rate=hyperparameters.dropout_rate,
     )
     label_smoothing = (
       hyperparameters.label_smoothing

--- a/reference_algorithms/paper_baselines/shampoo/jax/submission.py
+++ b/reference_algorithms/paper_baselines/shampoo/jax/submission.py
@@ -81,6 +81,7 @@ def pmapped_train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -91,6 +92,7 @@ def pmapped_train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -159,6 +161,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
   outputs = pmapped_train_step(
     workload,
     opt_update_fn,
@@ -169,6 +172,7 @@ def update_params(
     per_device_rngs,
     grad_clip,
     label_smoothing,
+    dropout_rate,
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_full_budget.py
@@ -215,6 +215,7 @@ def train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -225,6 +226,7 @@ def train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -289,6 +291,10 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  if hasattr(hyperparameters, 'dropout_rate'):
+    dropout_rate = hyperparameters.dropout_rate
+  else:
+    dropout_rate = 0.0
 
   # Create shardings for each argument
   replicated = jax_sharding_utils.get_replicate_sharding()  # No partitioning
@@ -307,6 +313,7 @@ def update_params(
     replicated,  # rng
     replicated,  # grad_clip
     replicated,  # label_smoothing
+    replicated,  # dropout_rate
   )
   out_shardings = (
     replicated,  # new_optimizer_state
@@ -335,6 +342,7 @@ def update_params(
       rng,
       grad_clip,
       label_smoothing,
+      dropout_rate
     )
   )
 

--- a/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_full_budget.py
@@ -339,7 +339,7 @@ def update_params(
       rng,
       grad_clip,
       label_smoothing,
-      dropout_rate
+      dropout_rate,
     )
   )
 

--- a/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_full_budget.py
@@ -291,10 +291,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.dropout_rate
-  else:
-    dropout_rate = 0.0
+  dropout_rate = hyperparameters.dropout_rate
 
   # Create shardings for each argument
   replicated = jax_sharding_utils.get_replicate_sharding()  # No partitioning

--- a/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_target_setting.py
@@ -212,6 +212,7 @@ def train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -222,6 +223,7 @@ def train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -286,6 +288,10 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
+  if hasattr(hyperparameters, 'dropout_rate'):
+    dropout_rate = hyperparameters.dropout_rate
+  else:
+    dropout_rate = 0.0
 
   # Create shardings for each argument
   replicated = jax_sharding_utils.get_replicate_sharding()  # No partitioning
@@ -304,6 +310,7 @@ def update_params(
     replicated,  # rng
     replicated,  # grad_clip
     replicated,  # label_smoothing
+    replicated,  # dropout_rate
   )
   out_shardings = (
     replicated,  # new_optimizer_state
@@ -331,6 +338,7 @@ def update_params(
     rng,
     grad_clip,
     label_smoothing,
+    dropout_rate
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_target_setting.py
@@ -335,7 +335,7 @@ def update_params(
     rng,
     grad_clip,
     label_smoothing,
-    dropout_rate
+    dropout_rate,
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/jax_nadamw_target_setting.py
@@ -288,10 +288,7 @@ def update_params(
     grad_clip = hyperparameters.grad_clip
   else:
     grad_clip = None
-  if hasattr(hyperparameters, 'dropout_rate'):
-    dropout_rate = hyperparameters.dropout_rate
-  else:
-    dropout_rate = 0.0
+  dropout_rate = hyperparameters.dropout_rate
 
   # Create shardings for each argument
   replicated = jax_sharding_utils.get_replicate_sharding()  # No partitioning

--- a/reference_algorithms/qualification_baselines/external_tuning/pytorch_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/pytorch_nadamw_full_budget.py
@@ -264,6 +264,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/qualification_baselines/external_tuning/pytorch_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/pytorch_nadamw_full_budget.py
@@ -264,7 +264,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/qualification_baselines/external_tuning/pytorch_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/pytorch_nadamw_target_setting.py
@@ -264,6 +264,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/qualification_baselines/external_tuning/pytorch_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/external_tuning/pytorch_nadamw_target_setting.py
@@ -264,7 +264,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/qualification_baselines/self_tuning/jax_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/self_tuning/jax_nadamw_full_budget.py
@@ -306,7 +306,7 @@ def update_params(
     grad_clip = None
   dropout_rate = hyperparameters.dropout_rate
 
-    # Create shardings for each argument
+  # Create shardings for each argument
   mesh = jax.sharding.Mesh(jax.devices(), ('batch'))
   replicated = jax_sharding_utils.get_replicate_sharding(
     mesh
@@ -354,7 +354,7 @@ def update_params(
     rng,
     grad_clip,
     label_smoothing,
-    dropout_rate
+    dropout_rate,
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/qualification_baselines/self_tuning/jax_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/self_tuning/jax_nadamw_full_budget.py
@@ -225,6 +225,7 @@ def train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -235,6 +236,7 @@ def train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -302,6 +304,7 @@ def update_params(
     grad_clip = hyperparameters['grad_clip']
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
 
     # Create shardings for each argument
   mesh = jax.sharding.Mesh(jax.devices(), ('batch'))
@@ -323,6 +326,7 @@ def update_params(
     replicated,  # rng
     replicated,  # grad_clip
     replicated,  # label_smoothing
+    replicated,  # dropout_rate
   )
   out_shardings = (
     replicated,  # new_optimizer_state
@@ -350,6 +354,7 @@ def update_params(
     rng,
     grad_clip,
     label_smoothing,
+    dropout_rate
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/qualification_baselines/self_tuning/jax_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/self_tuning/jax_nadamw_target_setting.py
@@ -228,6 +228,7 @@ def train_step(
   rng,
   grad_clip,
   label_smoothing,
+  dropout_rate,
 ):
   def _loss_fn(params):
     """Loss function used for training."""
@@ -238,6 +239,7 @@ def train_step(
       spec.ForwardPassMode.TRAIN,
       rng,
       update_batch_norm=True,
+      dropout_rate=dropout_rate,
     )
     loss_dict = workload.loss_fn(
       label_batch=batch['targets'],
@@ -308,6 +310,7 @@ def update_params(
     grad_clip = hyperparameters['grad_clip']
   else:
     grad_clip = None
+  dropout_rate = hyperparameters.dropout_rate
 
     # Create shardings for each argument
   mesh = jax.sharding.Mesh(jax.devices(), ('batch'))
@@ -329,6 +332,7 @@ def update_params(
     replicated,  # rng
     replicated,  # grad_clip
     replicated,  # label_smoothing
+    replicated,  # dropout_rate
   )
   out_shardings = (
     replicated,  # new_optimizer_state
@@ -356,6 +360,7 @@ def update_params(
     rng,
     grad_clip,
     label_smoothing,
+    dropout_rate
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/qualification_baselines/self_tuning/jax_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/self_tuning/jax_nadamw_target_setting.py
@@ -312,7 +312,7 @@ def update_params(
     grad_clip = None
   dropout_rate = hyperparameters.dropout_rate
 
-    # Create shardings for each argument
+  # Create shardings for each argument
   mesh = jax.sharding.Mesh(jax.devices(), ('batch'))
   replicated = jax_sharding_utils.get_replicate_sharding(
     mesh
@@ -360,7 +360,7 @@ def update_params(
     rng,
     grad_clip,
     label_smoothing,
-    dropout_rate
+    dropout_rate,
   )
   new_optimizer_state, new_params, new_model_state, loss, grad_norm = outputs
 

--- a/reference_algorithms/qualification_baselines/self_tuning/pytorch_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/self_tuning/pytorch_nadamw_full_budget.py
@@ -281,6 +281,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/qualification_baselines/self_tuning/pytorch_nadamw_full_budget.py
+++ b/reference_algorithms/qualification_baselines/self_tuning/pytorch_nadamw_full_budget.py
@@ -281,7 +281,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/reference_algorithms/qualification_baselines/self_tuning/pytorch_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/self_tuning/pytorch_nadamw_target_setting.py
@@ -281,6 +281,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
+    dropout_rate=hyperparameters.dropout_rate
   )
 
   label_smoothing = (

--- a/reference_algorithms/qualification_baselines/self_tuning/pytorch_nadamw_target_setting.py
+++ b/reference_algorithms/qualification_baselines/self_tuning/pytorch_nadamw_target_setting.py
@@ -281,7 +281,7 @@ def update_params(
     mode=spec.ForwardPassMode.TRAIN,
     rng=rng,
     update_batch_norm=True,
-    dropout_rate=hyperparameters.dropout_rate
+    dropout_rate=hyperparameters.dropout_rate,
   )
 
   label_smoothing = (

--- a/tests/modeldiffs/criteo1tb/compare.py
+++ b/tests/modeldiffs/criteo1tb/compare.py
@@ -69,6 +69,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -76,6 +77,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/criteo1tb_embed_init/compare.py
+++ b/tests/modeldiffs/criteo1tb_embed_init/compare.py
@@ -68,6 +68,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -75,6 +76,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/criteo1tb_layernorm/compare.py
+++ b/tests/modeldiffs/criteo1tb_layernorm/compare.py
@@ -80,6 +80,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -87,6 +88,7 @@ if __name__ == '__main__':
     # mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/criteo1tb_resnet/compare.py
+++ b/tests/modeldiffs/criteo1tb_resnet/compare.py
@@ -87,6 +87,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -94,6 +95,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/diff.py
+++ b/tests/modeldiffs/diff.py
@@ -14,9 +14,7 @@ def torch2jax(
   key_transform=None,
   sd_transform=None,
 ):
-  jax_params, model_state = jax_workload.init_model_fn(
-    jax.random.PRNGKey(0)
-  )
+  jax_params, model_state = jax_workload.init_model_fn(jax.random.PRNGKey(0))
   pytorch_model, _ = pytorch_workload.init_model_fn([0])
   if isinstance(jax_params, dict):
     jax_params = FrozenDict(jax_params)

--- a/tests/modeldiffs/diff.py
+++ b/tests/modeldiffs/diff.py
@@ -13,12 +13,11 @@ def torch2jax(
   pytorch_workload,
   key_transform=None,
   sd_transform=None,
-  init_kwargs=dict(dropout_rate=0.0, aux_dropout_rate=0.0),
 ):
   jax_params, model_state = jax_workload.init_model_fn(
-    jax.random.PRNGKey(0), **init_kwargs
+    jax.random.PRNGKey(0)
   )
-  pytorch_model, _ = pytorch_workload.init_model_fn([0], **init_kwargs)
+  pytorch_model, _ = pytorch_workload.init_model_fn([0])
   if isinstance(jax_params, dict):
     jax_params = FrozenDict(jax_params)
   jax_params = jax_utils.unreplicate(jax_params).unfreeze()

--- a/tests/modeldiffs/fastmri/compare.py
+++ b/tests/modeldiffs/fastmri/compare.py
@@ -70,6 +70,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -77,6 +78,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/fastmri_layernorm/compare.py
+++ b/tests/modeldiffs/fastmri_layernorm/compare.py
@@ -77,6 +77,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -84,6 +85,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/fastmri_model_size/compare.py
+++ b/tests/modeldiffs/fastmri_model_size/compare.py
@@ -70,6 +70,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -77,6 +78,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/fastmri_tanh/compare.py
+++ b/tests/modeldiffs/fastmri_tanh/compare.py
@@ -70,6 +70,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -77,6 +78,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/imagenet_resnet/compare.py
+++ b/tests/modeldiffs/imagenet_resnet/compare.py
@@ -90,6 +90,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -97,6 +98,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/imagenet_resnet/gelu_compare.py
+++ b/tests/modeldiffs/imagenet_resnet/gelu_compare.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -41,6 +42,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/imagenet_resnet/silu_compare.py
+++ b/tests/modeldiffs/imagenet_resnet/silu_compare.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -41,6 +42,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/imagenet_vit/compare.py
+++ b/tests/modeldiffs/imagenet_vit/compare.py
@@ -101,6 +101,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -108,6 +109,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/imagenet_vit_glu/compare.py
+++ b/tests/modeldiffs/imagenet_vit_glu/compare.py
@@ -37,6 +37,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -44,6 +45,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/imagenet_vit_map/compare.py
+++ b/tests/modeldiffs/imagenet_vit_map/compare.py
@@ -48,6 +48,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -55,6 +56,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/imagenet_vit_postln/compare.py
+++ b/tests/modeldiffs/imagenet_vit_postln/compare.py
@@ -37,6 +37,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -44,6 +45,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/librispeech_conformer/compare.py
+++ b/tests/modeldiffs/librispeech_conformer/compare.py
@@ -76,6 +76,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -83,6 +84,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/librispeech_conformer_attention_temperature/compare.py
+++ b/tests/modeldiffs/librispeech_conformer_attention_temperature/compare.py
@@ -76,6 +76,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -83,6 +84,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/librispeech_conformer_gelu/compare.py
+++ b/tests/modeldiffs/librispeech_conformer_gelu/compare.py
@@ -76,6 +76,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -83,6 +84,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/librispeech_conformer_layernorm/compare.py
+++ b/tests/modeldiffs/librispeech_conformer_layernorm/compare.py
@@ -76,6 +76,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -83,6 +84,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/librispeech_deepspeech/compare.py
+++ b/tests/modeldiffs/librispeech_deepspeech/compare.py
@@ -103,6 +103,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -110,6 +111,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/librispeech_deepspeech_noresnet/compare.py
+++ b/tests/modeldiffs/librispeech_deepspeech_noresnet/compare.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -46,6 +47,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/librispeech_deepspeech_normaug/compare.py
+++ b/tests/modeldiffs/librispeech_deepspeech_normaug/compare.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -46,6 +47,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/librispeech_deepspeech_tanh/compare.py
+++ b/tests/modeldiffs/librispeech_deepspeech_tanh/compare.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -46,6 +47,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/ogbg/compare.py
+++ b/tests/modeldiffs/ogbg/compare.py
@@ -107,6 +107,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -114,6 +115,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/ogbg_gelu/compare.py
+++ b/tests/modeldiffs/ogbg_gelu/compare.py
@@ -107,6 +107,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -114,6 +115,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/ogbg_model_size/compare.py
+++ b/tests/modeldiffs/ogbg_model_size/compare.py
@@ -107,6 +107,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -114,6 +115,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/ogbg_silu/compare.py
+++ b/tests/modeldiffs/ogbg_silu/compare.py
@@ -107,6 +107,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -114,6 +115,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/wmt/compare.py
+++ b/tests/modeldiffs/wmt/compare.py
@@ -126,6 +126,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -133,6 +134,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/wmt_attention_temp/compare.py
+++ b/tests/modeldiffs/wmt_attention_temp/compare.py
@@ -128,6 +128,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -135,6 +136,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/wmt_glu_tanh/compare.py
+++ b/tests/modeldiffs/wmt_glu_tanh/compare.py
@@ -128,6 +128,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -135,6 +136,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(

--- a/tests/modeldiffs/wmt_post_ln/compare.py
+++ b/tests/modeldiffs/wmt_post_ln/compare.py
@@ -128,6 +128,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=None,
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   jax_model_kwargs = dict(
@@ -135,6 +136,7 @@ if __name__ == '__main__':
     mode=spec.ForwardPassMode.EVAL,
     rng=jax.random.PRNGKey(0),
     update_batch_norm=False,
+    dropout_rate=0.0,
   )
 
   ModelDiffRunner(


### PR DESCRIPTION
The new dropout design in AlgoPerf (see https://github.com/mlcommons/algorithmic-efficiency/issues/753#issuecomment-2974087576 and https://github.com/mlcommons/algorithmic-efficiency/pull/873) requires passing `dropout_rate` to the workload’s forward pass function rather than to `init_model_fn`. Some minor issues from this change were left unresolved, and this PR fixes them.

- *Reference submissions*: we pipe `dropout_rate` through the model fwd pass in both JAX and PyTorch submissions.
- *PyTorch dev workloads*: we adapt MNIST and CIFAR workloads to new dropout design.
- *modeldiff*: we remove `dropout_rate` and `aux_dropout_rate` from `tests/modeldiffs/diff.py` and adapt all tests by pipping `dropout_rate=0.0` through the test call (one-line change).
- *spec.py*: updated spec to reflect new design.
- *DOCS*: updated docs to reflect new design.
