### PR TITLE
fix librispeech ctc_loss incompatibility with jit

### DIFF
--- a/algoperf/workloads/librispeech_conformer/librispeech_jax/workload.py
+++ b/algoperf/workloads/librispeech_conformer/librispeech_jax/workload.py
@@ -325,7 +325,14 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       jax_sharding_utils.get_replicate_sharding(),  # model_state
       jax_sharding_utils.get_replicate_sharding(),  # rng
     ),
-    out_shardings=jax_sharding_utils.get_batch_dim_sharding(),
+    out_shardings={
+      'loss_per_example': jax_sharding_utils.get_batch_dim_sharding(),
+      'decoded': jax_sharding_utils.get_batch_dim_sharding(),
+      'decoded_paddings': jax_sharding_utils.get_batch_dim_sharding(),
+      'targets': jax_sharding_utils.get_batch_dim_sharding(),
+      'target_paddings': jax_sharding_utils.get_batch_dim_sharding(),
+      'n_valid_examples': jax_sharding_utils.get_replicate_sharding(),
+    },
     static_argnums=(0,),
   )
   def _eval_step(
@@ -354,8 +361,7 @@ class LibriSpeechConformerWorkload(workload.BaseLibrispeechWorkload):
       'decoded_paddings': decoded_paddings,
       'targets': targets,
       'target_paddings': target_paddings,
-      'n_valid_examples': jnp.zeros((len(jax.devices()), 1))
-      + loss['n_valid_examples'],
+      'n_valid_examples': loss['n_valid_examples'],
     }
     return metrics_dict
 


### PR DESCRIPTION
fix librispeech ctc_loss scale problem in jax by removing the array of size device_count.
after fix jax and pytorch ctc_loss aligns :
<img width="1800" height="1050" alt="image" src="https://github.com/user-attachments/assets/d7b956ab-9f4b-4491-bddc-896cd6c43b51" />
<img width="1800" height="1050" alt="image" src="https://github.com/user-attachments/assets/8153ddea-df11-4045-ab1a-3b890018c82f" />

